### PR TITLE
Initial import of specs

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -1,0 +1,284 @@
+<!--[metadata]>
++++
+draft = true
++++
+<![end-metadata]-->
+
+# Image Manifest Version 2, Schema 2
+
+This document outlines the format of of the V2 image manifest, schema version 2.
+The original (and provisional) image manifest for V2 (schema 1), was introduced
+in the Docker daemon in the [v1.3.0
+release](https://github.com/docker/docker/commit/9f482a66ab37ec396ac61ed0c00d59122ac07453)
+and is specified in the [schema 1 manifest definition](./manifest-v2-1.md)
+
+This second schema version has two primary goals. The first is to allow
+multi-architecture images, through a "fat manifest" which references image
+manifests for platform-specific versions of an image. The second is to
+move the Docker engine towards content-addressable images, by supporting
+an image model where the image's configuration can be hashed to generate
+an ID for the image.
+
+# Media Types
+
+The following media types are used by the manifest formats described here, and
+the resources they reference:
+
+- `application/vnd.docker.distribution.manifest.v1+json`: schema1 (existing manifest format)
+- `application/vnd.docker.distribution.manifest.v2+json`: New image manifest format (schemaVersion = 2)
+- `application/vnd.docker.distribution.manifest.list.v2+json`: Manifest list, aka "fat manifest"
+- `application/vnd.docker.image.rootfs.diff.tar.gzip`: "Layer", as a gzipped tar
+- `application/vnd.docker.container.image.v1+json`: Container config JSON
+
+## Manifest List
+
+The manifest list is the "fat manifest" which points to specific image manifests
+for one or more platforms. Its use is optional, and relatively few images will
+use one of these manifests. A client will distinguish a manifest list from an
+image manifest based on the Content-Type returned in the HTTP response.
+
+## *Manifest List* Field Descriptions
+
+- **`schemaVersion`** *int*
+	
+  This field specifies the image manifest schema version as an integer. This
+  schema uses the version `2`.
+
+- **`mediaType`** *string*
+
+    The MIME type of the manifest list. This should be set to
+    `application/vnd.docker.distribution.manifest.list.v2+json`.
+
+- **`manifests`** *array*
+
+    The manifests field contains a list of manifests for specific platforms.
+
+    Fields of a object in the manifests list are:
+    
+    - **`mediaType`** *string*
+    
+        The MIME type of the referenced object. This will generally be
+        `application/vnd.docker.image.manifest.v2+json`, but it could also
+        be `application/vnd.docker.image.manifest.v1+json` if the manifest
+        list references a legacy schema-1 manifest.
+    
+    - **`size`** *int*
+    
+        The size in bytes of the object. This field exists so that a client
+        will have an expected size for the content before validating. If the
+        length of the retrieved content does not match the specified length,
+        the content should not be trusted.
+    
+    - **`digest`** *string*
+
+        The digest of the content, as defined by the
+        [Registry V2 HTTP API Specificiation](https://docs.docker.com/registry/spec/api/#digest-parameter).
+
+    - **`platform`** *object*
+
+        The platform object describes the platform which the image in the
+        manifest runs on. A full list of valid operating system and architecture
+        values are listed in the [Go language documentation for `$GOOS` and
+        `$GOARCH`](https://golang.org/doc/install/source#environment)
+
+        - **`architecture`** *string*
+
+            The architecture field specifies the CPU architecture, for example
+            `amd64` or `ppc64le`.
+
+        - **`os`** *string*
+
+            The os field specifies the operating system, for example
+            `linux` or `windows`.
+
+        - **`os.version`** *string*
+
+            The optional os.version field specifies the operating system version,
+            for example `10.0.10586`.
+
+        - **`os.features`** *array*
+
+            The optional os.features field specifies an array of strings,
+            each listing a required OS feature (for example on Windows
+            `win32k`).
+
+        - **`variant`** *string*
+
+            The optional variant field specifies a variant of the CPU, for
+            example `armv6l` to specify a particular CPU variant of the ARM CPU.
+
+        - **`features`** *array*
+
+            The optional features field specifies an array of strings, each
+            listing a required CPU feature (for example `sse4` or `aes`).
+
+## Example Manifest List
+
+*Example showing a simple manifest list pointing to image manifests for two platforms:*
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "size": 7143,
+      "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux",
+      }
+    },
+    {
+      "mediaType": "application/vnd.docker.image.manifest.v2+json",
+      "size": 7682,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux",
+        "features": [
+          "sse4"
+        ]
+      }
+    }
+  ]
+}
+```
+
+# Image Manifest
+
+The image manifest provides a configuration and a set of layers for a container
+image. It's the direct replacement for the schema-1 manifest.
+
+## *Image Manifest* Field Descriptions
+
+- **`schemaVersion`** *int*
+	
+  This field specifies the image manifest schema version as an integer. This
+  schema uses version `2`.
+
+- **`mediaType`** *string*
+
+    The MIME type of the manifest. This should be set to
+    `application/vnd.docker.distribution.manifest.v2+json`.
+
+- **`config`** *object*
+
+    The config field references a configuration object for a container, by
+    digest. This configuration item is a JSON blob that the runtime uses
+    to set up the container. This new schema uses a tweaked version
+    of this configuration to allow image content-addressability on the
+    daemon side.
+
+    Fields of a config object are:
+    
+    - **`mediaType`** *string*
+    
+        The MIME type of the referenced object. This should generally be
+        `application/vnd.docker.container.image.v1+json`.
+    
+    - **`size`** *int*
+    
+        The size in bytes of the object. This field exists so that a client
+        will have an expected size for the content before validating. If the
+        length of the retrieved content does not match the specified length,
+        the content should not be trusted.
+    
+    - **`digest`** *string*
+
+        The digest of the content, as defined by the
+        [Registry V2 HTTP API Specificiation](https://docs.docker.com/registry/spec/api/#digest-parameter).
+
+- **`layers`** *array*
+
+    The layer list is ordered starting from the base image (opposite order of schema1).
+
+    Fields of an item in the layers list are:
+    
+    - **`mediaType`** *string*
+    
+        The MIME type of the referenced object. This should
+        generally be `application/vnd.docker.image.rootfs.diff.tar.gzip`.
+    
+    - **`size`** *int*
+    
+        The size in bytes of the object. This field exists so that a client
+        will have an expected size for the content before validating. If the
+        length of the retrieved content does not match the specified length,
+        the content should not be trusted.
+    
+    - **`digest`** *string*
+
+        The digest of the content, as defined by the
+        [Registry V2 HTTP API Specificiation](https://docs.docker.com/registry/spec/api/#digest-parameter).
+
+## Example Image Manifest
+
+*Example showing an image manifest:*
+```json
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "config": {
+        "mediaType": "application/vnd.docker.container.image.v1+json",
+        "size": 7023,
+        "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+    },
+    "layers": [
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 32654,
+            "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 16724,
+            "digest": "sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b"
+        },
+        {
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 73109,
+            "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736"
+        }
+    ],
+}
+```
+
+# Backward compatibility
+
+The registry will continue to accept uploads of manifests in both the old and
+new formats.
+
+When pushing images, clients which support the new manifest format should first
+construct a manifest in the new format. If uploading this manifest fails,
+presumably because the registry only supports the old format, the client may
+fall back to uploading a manifest in the old format.
+
+When pulling images, clients indicate support for this new version of the
+manifest format by sending the
+`application/vnd.docker.distribution.manifest.v2+json` and
+`application/vnd.docker.distribution.manifest.list.v2+json` media types in an
+`Accept` header when making a request to the `manifests` endpoint. Updated
+clients should check the `Content-Type` header to see whether the manifest
+returned from the endpoint is in the old format, or is an image manifest or
+manifest list in the new format.
+
+If the manifest being requested uses the new format, and the appropriate media
+type is not present in an `Accept` header, the registry will assume that the
+client cannot handle the manifest as-is, and rewrite it on the fly into the old
+format. If the object that would otherwise be returned is a manifest list, the
+registry will look up the appropriate manifest for the amd64 platform and
+linux OS, rewrite that manifest into the old format if necessary, and return
+the result to the client. If no suitable manifest is found in the manifest
+list, the registry will return a 404 error.
+
+One of the challenges in rewriting manifests to the old format is that the old
+format involves an image configuration for each layer in the manifest, but the
+new format only provides one image configuration. To work around this, the
+registry will create synthetic image configurations for all layers except the
+top layer. These image configurations will not result in runnable images on
+their own, but only serve to fill in the parent chain in a compatible way.
+The IDs in these synthetic configurations will be derived from hashes of their
+respective blobs. The registry will create these configurations and their IDs
+using the same scheme as Docker 1.10 when it creates a legacy manifest to push
+to a registry which doesn't support the new format.

--- a/serialization.md
+++ b/serialization.md
@@ -1,0 +1,573 @@
+# Docker Image Specification v1.0.0
+
+An *Image* is an ordered collection of root filesystem changes and the
+corresponding execution parameters for use within a container runtime. This
+specification outlines the format of these filesystem changes and corresponding
+parameters and describes how to create and use them for use with a container
+runtime and execution tool.
+
+## Terminology
+
+This specification uses the following terms:
+
+<dl>
+    <dt>
+        Layer
+    </dt>
+    <dd>
+        Images are composed of <i>layers</i>. <i>Image layer</i> is a general
+        term which may be used to refer to one or both of the following:
+
+        <ol>
+            <li>The metadata for the layer, described in the JSON format.</li>
+            <li>The filesystem changes described by a layer.</li>
+        </ol>
+
+        To refer to the former you may use the term <i>Layer JSON</i> or
+        <i>Layer Metadata</i>. To refer to the latter you may use the term
+        <i>Image Filesystem Changeset</i> or <i>Image Diff</i>.
+    </dd>
+    <dt>
+        Image JSON
+    </dt>
+    <dd>
+        Each layer has an associated JSON structure which describes some
+        basic information about the image such as date created, author, and the
+        ID of its parent image as well as execution/runtime configuration like
+        its entry point, default arguments, CPU/memory shares, networking, and
+        volumes.
+    </dd>
+    <dt>
+        Image Filesystem Changeset
+    </dt>
+    <dd>
+        Each layer has an archive of the files which have been added, changed,
+        or deleted relative to its parent layer. Using a layer-based or union
+        filesystem such as AUFS, or by computing the diff from filesystem
+        snapshots, the filesystem changeset can be used to present a series of
+        image layers as if they were one cohesive filesystem.
+    </dd>
+    <dt>
+        Image ID <a name="id_desc"></a>
+    </dt>
+    <dd>
+        Each layer is given an ID upon its creation. It is 
+        represented as a hexadecimal encoding of 256 bits, e.g.,
+        <code>a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9</code>.
+        Image IDs should be sufficiently random so as to be globally unique.
+        32 bytes read from <code>/dev/urandom</code> is sufficient for all
+        practical purposes. Alternatively, an image ID may be derived as a
+        cryptographic hash of image contents as the result is considered
+        indistinguishable from random. The choice is left up to implementors.
+    </dd>
+    <dt>
+        Image Parent
+    </dt>
+    <dd>
+        Most layer metadata structs contain a <code>parent</code> field which
+        refers to the Image from which another directly descends. An image
+        contains a separate JSON metadata file and set of changes relative to
+        the filesystem of its parent image. <i>Image Ancestor</i> and
+        <i>Image Descendant</i> are also common terms.
+    </dd>
+    <dt>
+        Image Checksum
+    </dt>
+    <dd>
+        Layer metadata structs contain a cryptographic hash of the contents of
+        the layer's filesystem changeset. Though the set of changes exists as a
+        simple Tar archive, two archives with identical filenames and content
+        will have different SHA digests if the last-access or last-modified
+        times of any entries differ. For this reason, image checksums are
+        generated using the TarSum algorithm which produces a cryptographic
+        hash of file contents and selected headers only. Details of this
+        algorithm are described in the separate <a href="https://github.com/docker/docker/blob/master/pkg/tarsum/tarsum_spec.md">TarSum specification</a>.
+    </dd>
+    <dt>
+        Tag
+    </dt>
+    <dd>
+        A tag serves to map a descriptive, user-given name to any single image
+        ID. An image name suffix (the name component after <code>:</code>) is
+        often referred to as a tag as well, though it strictly refers to the
+        full name of an image. Acceptable values for a tag suffix are
+        implementation specific, but they SHOULD be limited to the set of
+        alphanumeric characters <code>[a-zA-z0-9]</code>, punctuation
+        characters <code>[._-]</code>, and MUST NOT contain a <code>:</code>
+        character.
+    </dd>
+    <dt>
+        Repository
+    </dt>
+    <dd>
+        A collection of tags grouped under a common prefix (the name component
+        before <code>:</code>). For example, in an image tagged with the name
+        <code>my-app:3.1.4</code>, <code>my-app</code> is the <i>Repository</i>
+        component of the name. Acceptable values for repository name are
+        implementation specific, but they SHOULD be limited to the set of
+        alphanumeric characters <code>[a-zA-z0-9]</code>, and punctuation
+        characters <code>[._-]</code>, however it MAY contain additional
+        <code>/</code> and <code>:</code> characters for organizational
+        purposes, with the last <code>:</code> character being interpreted
+        dividing the repository component of the name from the tag suffix
+        component.
+    </dd>
+</dl>
+
+## Image JSON Description
+
+Here is an example image JSON file:
+
+```
+{  
+    "id": "a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9",
+    "parent": "c6e3cedcda2e3982a1a6760e178355e8e65f7b80e4e5248743fa3549d284e024",
+    "checksum": "tarsum.v1+sha256:e58fcf7418d2390dec8e8fb69d88c06ec07039d651fedc3aa72af9972e7d046b",
+    "created": "2014-10-13T21:19:18.674353812Z",
+    "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
+    "architecture": "amd64",
+    "os": "linux",
+    "Size": 271828,
+    "config": {
+        "User": "alice",
+        "Memory": 2048,
+        "MemorySwap": 4096,
+        "CpuShares": 8,
+        "ExposedPorts": {  
+            "8080/tcp": {}
+        },
+        "Env": [  
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "FOO=docker_is_a_really",
+            "BAR=great_tool_you_know"
+        ],
+        "Entrypoint": [
+            "/bin/my-app-binary"
+        ],
+        "Cmd": [
+            "--foreground",
+            "--config",
+            "/etc/my-app.d/default.cfg"
+        ],
+        "Volumes": {
+            "/var/job-result-data": {},
+            "/var/log/my-app-logs": {},
+        },
+        "WorkingDir": "/home/alice",
+    }
+}
+```
+
+### Image JSON Field Descriptions
+
+<dl>
+    <dt>
+        id <code>string</code>
+    </dt>
+    <dd>
+        Randomly generated, 256-bit, hexadecimal encoded. Uniquely identifies
+        the image.
+    </dd>
+    <dt>
+        parent <code>string</code>
+    </dt>
+    <dd>
+        ID of the parent image. If there is no parent image then this field
+        should be omitted. A collection of images may share many of the same
+        ancestor layers. This organizational structure is strictly a tree with
+        any one layer having either no parent or a single parent and zero or
+        more descendant layers. Cycles are not allowed and implementations
+        should be careful to avoid creating them or iterating through a cycle
+        indefinitely.
+    </dd>
+    <dt>
+        created <code>string</code>
+    </dt>
+    <dd>
+        ISO-8601 formatted combined date and time at which the image was
+        created.
+    </dd>
+    <dt>
+        author <code>string</code>
+    </dt>
+    <dd>
+        Gives the name and/or email address of the person or entity which
+        created and is responsible for maintaining the image.
+    </dd>
+    <dt>
+        architecture <code>string</code>
+    </dt>
+    <dd>
+        The CPU architecture which the binaries in this image are built to run
+        on. Possible values include:
+        <ul>
+            <li>386</li>
+            <li>amd64</li>
+            <li>arm</li>
+        </ul>
+        More values may be supported in the future and any of these may or may
+        not be supported by a given container runtime implementation.
+    </dd>
+    <dt>
+        os <code>string</code>
+    </dt>
+    <dd>
+        The name of the operating system which the image is built to run on.
+        Possible values include:
+        <ul>
+            <li>darwin</li>
+            <li>freebsd</li>
+            <li>linux</li>
+        </ul>
+        More values may be supported in the future and any of these may or may
+        not be supported by a given container runtime implementation.
+    </dd>
+    <dt>
+        checksum <code>string</code>
+    </dt>
+    <dd>
+        Image Checksum of the filesystem changeset associated with the image
+        layer.
+    </dd>
+    <dt>
+        Size <code>integer</code>
+    </dt>
+    <dd>
+        The size in bytes of the filesystem changeset associated with the image
+        layer.
+    </dd>
+    <dt>
+        config <code>struct</code>
+    </dt>
+    <dd>
+        The execution parameters which should be used as a base when running a
+        container using the image. This field can be <code>null</code>, in
+        which case any execution parameters should be specified at creation of
+        the container.
+
+        <h4>Container RunConfig Field Descriptions</h4>
+
+        <dl>
+            <dt>
+                User <code>string</code>
+            </dt>
+            <dd>
+                <p>The username or UID which the process in the container should
+                run as. This acts as a default value to use when the value is
+                not specified when creating a container.</p>
+
+                <p>All of the following are valid:</p>
+
+                <ul>
+                    <li><code>user</code></li>
+                    <li><code>uid</code></li>
+                    <li><code>user:group</code></li>
+                    <li><code>uid:gid</code></li>
+                    <li><code>uid:group</code></li>
+                    <li><code>user:gid</code></li>
+                </ul>
+
+                <p>If <code>group</code>/<code>gid</code> is not specified, the
+                default group and supplementary groups of the given
+                <code>user</code>/<code>uid</code> in <code>/etc/passwd</code>
+                from the container are applied.</p>
+            </dd>
+            <dt>
+                Memory <code>integer</code>
+            </dt>
+            <dd>
+                Memory limit (in bytes). This acts as a default value to use
+                when the value is not specified when creating a container.
+            </dd>
+            <dt>
+                MemorySwap <code>integer</code>
+            </dt>
+            <dd>
+                Total memory usage (memory + swap); set to <code>-1</code> to
+                disable swap. This acts as a default value to use when the
+                value is not specified when creating a container.
+            </dd>
+            <dt>
+                CpuShares <code>integer</code>
+            </dt>
+            <dd>
+                CPU shares (relative weight vs. other containers). This acts as
+                a default value to use when the value is not specified when
+                creating a container.
+            </dd>
+            <dt>
+                ExposedPorts <code>struct</code>
+            </dt>
+            <dd>
+                A set of ports to expose from a container running this image.
+                This JSON structure value is unusual because it is a direct
+                JSON serialization of the Go type
+                <code>map[string]struct{}</code> and is represented in JSON as
+                an object mapping its keys to an empty object. Here is an
+                example:
+
+<pre>{
+    "8080": {},
+    "53/udp": {},
+    "2356/tcp": {}
+}</pre>
+
+                Its keys can be in the format of:
+                <ul>
+                    <li>
+                        <code>"port/tcp"</code>
+                    </li>
+                    <li>
+                        <code>"port/udp"</code>
+                    </li>
+                    <li>
+                        <code>"port"</code>
+                    </li>
+                </ul>
+                with the default protocol being <code>"tcp"</code> if not
+                specified.
+
+                These values act as defaults and are merged with any specified
+                when creating a container.
+            </dd>
+            <dt>
+                Env <code>array of strings</code>
+            </dt>
+            <dd>
+                Entries are in the format of <code>VARNAME="var value"</code>.
+                These values act as defaults and are merged with any specified
+                when creating a container.
+            </dd>
+            <dt>
+                Entrypoint <code>array of strings</code>
+            </dt>
+            <dd>
+                A list of arguments to use as the command to execute when the
+                container starts. This value acts as a  default and is replaced
+                by an entrypoint specified when creating a container.
+            </dd>
+            <dt>
+                Cmd <code>array of strings</code>
+            </dt>
+            <dd>
+                Default arguments to the entry point of the container. These
+                values act as defaults and are replaced with any specified when
+                creating a container. If an <code>Entrypoint</code> value is
+                not specified, then the first entry of the <code>Cmd</code>
+                array should be interpreted as the executable to run.
+            </dd>
+            <dt>
+                Volumes <code>struct</code>
+            </dt>
+            <dd>
+                A set of directories which should be created as data volumes in
+                a container running this image. This JSON structure value is
+                unusual because it is a direct JSON serialization of the Go
+                type <code>map[string]struct{}</code> and is represented in
+                JSON as an object mapping its keys to an empty object. Here is
+                an example:
+<pre>{
+    "/var/my-app-data/": {},
+    "/etc/some-config.d/": {},
+}</pre>
+            </dd>
+            <dt>
+                WorkingDir <code>string</code>
+            </dt>
+            <dd>
+                Sets the current working directory of the entry point process
+                in the container. This value acts as a default and is replaced
+                by a working directory specified when creating a container.
+            </dd>
+        </dl>
+    </dd>
+</dl>
+
+Any extra fields in the Image JSON struct are considered implementation
+specific and should be ignored by any implementations which are unable to
+interpret them.
+
+## Creating an Image Filesystem Changeset
+
+An example of creating an Image Filesystem Changeset follows.
+
+An image root filesystem is first created as an empty directory named with the
+ID of the image being created. Here is the initial empty directory structure
+for the changeset for an image with ID `c3167915dc9d` ([real IDs are much
+longer](#id_desc), but this example use a truncated one here for brevity.
+Implementations need not name the rootfs directory in this way but it may be
+convenient for keeping record of a large number of image layers.):
+
+```
+c3167915dc9d/
+```
+
+Files and directories are then created:
+
+```
+c3167915dc9d/
+    etc/
+        my-app-config
+    bin/
+        my-app-binary
+        my-app-tools
+```
+
+The `c3167915dc9d` directory is then committed as a plain Tar archive with
+entries for the following files:
+
+```
+etc/my-app-config
+bin/my-app-binary
+bin/my-app-tools
+```
+
+The TarSum checksum for the archive file is then computed and placed in the
+JSON metadata along with the execution parameters.
+
+To make changes to the filesystem of this container image, create a new
+directory named with a new ID, such as `f60c56784b83`, and initialize it with
+a snapshot of the parent image's root filesystem, so that the directory is
+identical to that of `c3167915dc9d`. NOTE: a copy-on-write or union filesystem
+can make this very efficient:
+
+```
+f60c56784b83/
+    etc/
+        my-app-config
+    bin/
+        my-app-binary
+        my-app-tools
+```
+
+This example change is going add a configuration directory at `/etc/my-app.d`
+which contains a default config file. There's also a change to the
+`my-app-tools` binary to handle the config layout change. The `f60c56784b83`
+directory then looks like this:
+
+```
+f60c56784b83/
+    etc/
+        my-app.d/
+            default.cfg
+    bin/
+        my-app-binary
+        my-app-tools
+```
+
+This reflects the removal of `/etc/my-app-config` and creation of a file and
+directory at `/etc/my-app.d/default.cfg`. `/bin/my-app-tools` has also been
+replaced with an updated version. Before committing this directory to a
+changeset, because it has a parent image, it is first compared with the
+directory tree of the parent snapshot, `f60c56784b83`, looking for files and
+directories that have been added, modified, or removed. The following changeset
+is found:
+
+```
+Added:      /etc/my-app.d/default.cfg
+Modified:   /bin/my-app-tools
+Deleted:    /etc/my-app-config
+```
+
+A Tar Archive is then created which contains *only* this changeset: The added
+and modified files and directories in their entirety, and for each deleted item
+an entry for an empty file at the same location but with the basename of the
+deleted file or directory prefixed with `.wh.`. The filenames prefixed with
+`.wh.` are known as "whiteout" files. NOTE: For this reason, it is not possible
+to create an image root filesystem which contains a file or directory with a
+name beginning with `.wh.`. The resulting Tar archive for `f60c56784b83` has
+the following entries:
+
+```
+/etc/my-app.d/default.cfg
+/bin/my-app-tools
+/etc/.wh.my-app-config
+```
+
+Any given image is likely to be composed of several of these Image Filesystem
+Changeset tar archives.
+
+## Combined Image JSON + Filesystem Changeset Format
+
+There is also a format for a single archive which contains complete information
+about an image, including:
+
+ - repository names/tags
+ - all image layer JSON files
+ - all tar archives of each layer filesystem changesets
+
+For example, here's what the full archive of `library/busybox` is (displayed in
+`tree` format):
+
+```
+.
+├── 5785b62b697b99a5af6cd5d0aabc804d5748abbb6d3d07da5d1d3795f2dcc83e
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
+├── a7b8b41220991bfc754d7ad445ad27b7f272ab8b4a2c175b9512b97471d02a8a
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
+├── a936027c5ca8bf8f517923169a233e391cbb38469a75de8383b5228dc2d26ceb
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
+├── f60c56784b832dd990022afc120b8136ab3da9528094752ae13fe63a2d28dc8c
+│   ├── VERSION
+│   ├── json
+│   └── layer.tar
+└── repositories
+```
+
+There are one or more directories named with the ID for each layer in a full
+image. Each of these directories contains 3 files:
+
+ * `VERSION` - The schema version of the `json` file
+ * `json` - The JSON metadata for an image layer
+ * `layer.tar` - The Tar archive of the filesystem changeset for an image
+   layer.
+
+The content of the `VERSION` files is simply the semantic version of the JSON
+metadata schema:
+
+```
+1.0
+```
+
+And the `repositories` file is another JSON file which describes names/tags:
+
+```
+{  
+    "busybox":{  
+        "latest":"5785b62b697b99a5af6cd5d0aabc804d5748abbb6d3d07da5d1d3795f2dcc83e"
+    }
+}
+```
+
+Every key in this object is the name of a repository, and maps to a collection
+of tag suffixes. Each tag maps to the ID of the image represented by that tag.
+
+## Loading an Image Filesystem Changeset
+
+Unpacking a bundle of image layer JSON files and their corresponding filesystem
+changesets can be done using a series of steps:
+
+1. Follow the parent IDs of image layers to find the root ancestor (an image
+with no parent ID specified).
+2. For every image layer, in order from root ancestor and descending down,
+extract the contents of that layer's filesystem changeset archive into a
+directory which will be used as the root of a container filesystem.
+
+    - Extract all contents of each archive.
+    - Walk the directory tree once more, removing any files with the prefix
+    `.wh.` and the corresponding file or directory named without this prefix.
+
+
+## Implementations
+
+This specification is an admittedly imperfect description of an
+imperfectly-understood problem. The Docker project is, in turn, an attempt to
+implement this specification. Our goal and our execution toward it will evolve
+over time, but our primary concern in this specification and in our
+implementation is compatibility and interoperability.


### PR DESCRIPTION
Per the proposal for this image-spec group, this is bringing in the base for the distributable image format from https://github.com/docker/distribution/blob/bf9f80eaffb0eabc768762bc4ff03ded277ea594/docs/spec/manifest-v2-2.md and https://github.com/docker/docker/blob/99a396902f0ea9d81ef87a683489b2435408f415/image/spec/v1.md