### PR TITLE
travis: add initial checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+go:
+  - 1.6
+
+sudo: false
+
+before_install:
+  - go get github.com/vbatts/git-validation
+
+install: true
+
+script:
+  - $HOME/gopath/bin/git-validation -run DCO,short-subject -v -range ${TRAVIS_COMMIT_RANGE}
+  


### PR DESCRIPTION
Starting with git commit validation.

Travis integration will still need to be enabled.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>