### PR TITLE
docs: make target for PDF and HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+oci-validate-examples
+code-of-conduct.md

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The specification and code is licensed under the Apache 2.0 license found in the
 
 ## Code of Conduct
 
-Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct](https://github.com/opencontainers/tob/blob/master/code-of-conduct.md).
+Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct](https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md).
 
 ## Discuss your design
 

--- a/serialization.md
+++ b/serialization.md
@@ -486,17 +486,23 @@ For example, here's what the full archive of `library/busybox` is (displayed in 
 
 ```
 .
-├── 47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb.json
-├── 5f29f704785248ddb9d06b90a11b5ea36c534865e9035e4022bb2e71d4ecbb9a
-│   ├── VERSION
-│   ├── json
-│   └── layer.tar
-├── a65da33792c5187473faa80fa3e1b975acba06712852d1dea860692ccddf3198
-│   ├── VERSION
-│   ├── json
-│   └── layer.tar
-├── manifest.json
-└── repositories
+|-- 5785b62b697b99a5af6cd5d0aabc804d5748abbb6d3d07da5d1d3795f2dcc83e
+|	|-- VERSION
+|	|-- json
+|	|-- layer.tar
+|-- a7b8b41220991bfc754d7ad445ad27b7f272ab8b4a2c175b9512b97471d02a8a
+|	|-- VERSION
+|	|-- json
+|	|-- layer.tar
+|-- a936027c5ca8bf8f517923169a233e391cbb38469a75de8383b5228dc2d26ceb
+|	|-- VERSION
+|	|-- json
+|	|-- layer.tar
+|-- f60c56784b832dd990022afc120b8136ab3da9528094752ae13fe63a2d28dc8c
+|	|-- VERSION
+|	|-- json
+|	|-- layer.tar
+|-- repositories
 ```
 
 There are one or more directories named with the ChainID for each layer in a full image.


### PR DESCRIPTION
This adds a `docs` make target for producing a PDF and HTML.

The output of `tree` in `./serialization.md` does not jive with pandoc.
Not sure what better visual layout of a directory tree we can use.

This also pins the version of code-of-conduct, instead of just master.

Fixes #16

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>