### PR TITLE
serialization: add headers to config JSON example

### DIFF
--- a/serialization.md
+++ b/serialization.md
@@ -91,6 +91,8 @@ Here is an example image JSON file:
 
 ```
 {  
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.serialization.config.v1+json",
     "created": "2015-10-31T22:22:56.015925234Z",
     "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
     "architecture": "amd64",


### PR DESCRIPTION
This adds the schemaVersion, and mediaType headers to the serialization
config example.

Partially fixes #63

Signed-off-by: Sergiusz Urbaniak <sur@coreos.com>