### PR TITLE
image manifest: add source annotation

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -201,6 +201,7 @@ Unlike the [Manifest List](#manifest-list), which contains information about a s
     * **authors** contact details of the people or organization responsible for the image (freeform string)
     * **homepage** URL to find more information on the image (string, must be a URL with scheme HTTP or HTTPS)
     * **documentation** URL to get documentation on the image (string, must be a URL with scheme HTTP or HTTPS)
+    * **source** URL to get the source code for the binary files in the image (string, must be a URL with scheme HTTP or HTTPS)
 
 
 ## Example Image Manifest


### PR DESCRIPTION
For a number of images, source code needs to be provided due to the
license of the files in the image, so provide an annotation to make it
easy to determine where that source can be found.

Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>