### PR TITLE
inline images: media-types.png is inline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DOC_FILES := \
 	code-of-conduct.md \
 	project.md \
 	media-types.md \
+	inline-png-media-types.md \
 	manifest.md \
 	serialization.md
 
@@ -70,10 +71,11 @@ lint:
 test:
 	go test -race ./...
 
-media-types.png: media-types.dot
-
 %.png: %.dot
 	dot -Tpng $^ > $@
+
+inline-png-%.md: %.png
+	@printf '<img src="data:image/png;base64,%s" alt="$*"/>\n' "$(shell base64 $^)" > $@
 
 .PHONY: \
 	validate-examples \

--- a/media-types.md
+++ b/media-types.md
@@ -46,6 +46,4 @@ This section shows where the OCI Image Specification is compatible with formats 
 
 The following figure shows how the above media types reference each other:
 
-![Media Types](media-types.png)
-
 A reference is defined as the target content digest, as defined by the [Registry V2 HTTP API Specificiation](https://docs.docker.com/registry/spec/api/#digest-parameter). The manifest list being a "fat manifest" references one or more image manifests per target platform. An image manifest references exactly one target configuration and possibly many layers.


### PR DESCRIPTION

Due to pandoc pdf and html wanting a uri to reference an image, we'll
need images to be inlined fo rthe document. So with this, the document
will get an base64 blob of images that match the target 'inline-png-%.md'

See also https://github.com/opencontainers/image-spec/issues/70#issuecomment-217656058

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>