### PR TITLE
README: remove the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,7 @@ A: Existing formats can continue to be a proving ground for technologies, as nee
 
 ## Roadmap
 
-The current roadmap can be found in the [GitHub milestones](https://github.com/opencontainers/image-spec/milestones)
-
-* April v0.0.0
-  * Import Docker v2.2 format
-* April v0.1.0
-  * Spec factored for top to bottom reading with three audiences in mind:
-    * Build system creators
-    * Image registry creators
-    * Container engine creators
-* May v0.2.0
-  * Release version of spec with improvements from two independent experimental implementations from OCI members e.g. Amazon Container Registry and rkt
-* June v1.0.0
-  * Release initial version of spec with two independent non-experimental implementations from OCI members
+The [GitHub milestones](https://github.com/opencontainers/image-spec/milestones) lays out the path to the OCI v1.0.0 release in June 2016.
 
 # Contributing
 


### PR DESCRIPTION
We have the roadmap encoded into GitHub issues. Just point there
instead.