### PR TITLE
travis: make the docs in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ language: go
 go:
   - 1.6
 
-sudo: false
+sudo: required
+
+services:
+  - docker
 
 before_script:
   - export PATH=$HOME/gopath/bin:$PATH
 
 before_install:
+  - docker pull vbatts/pandoc
   - go get github.com/vbatts/git-validation
   - go get github.com/alecthomas/gometalinter
   - gometalinter --install --update
@@ -21,3 +25,4 @@ script:
   - make check-license
   - make test
   - make oci-image-tool
+  - make docs


### PR DESCRIPTION
This will likely currently fail, as the pandoc is grumpy with the image references in master, but such is a good test case that it should fail CI if that happens.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>