### PR TITLE
*: fixup the docs output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ DOC_FILES := \
 	code-of-conduct.md \
 	project.md \
 	media-types.md \
-	inline-png-media-types.md \
 	manifest.md \
 	serialization.md
 
 FIGURE_FILES := \
 	img/media-types.png
-OUTPUT ?= output/
+
+OUTPUT		?= output/
+DOC_FILENAME	?= oci-image-spec
 
 default: help
 
@@ -26,9 +27,9 @@ help:
 fmt:
 	for i in *.json ; do jq --indent 2 -M . "$${i}" > xx && cat xx > "$${i}" && rm xx ; done
 
-docs: $(OUTPUT)/docs.pdf $(OUTPUT)/docs.html
+docs: $(OUTPUT)/$(DOC_FILENAME).pdf $(OUTPUT)/$(DOC_FILENAME).html
 
-$(OUTPUT)/docs.pdf: $(DOC_FILES) $(FIGURE_FILES)
+$(OUTPUT)/$(DOC_FILENAME).pdf: $(DOC_FILES) $(FIGURE_FILES)
 	@mkdir -p $(OUTPUT)/ && \
 	cp -ap img/ $(shell pwd)/$(OUTPUT)/&& \
 	$(DOCKER) run \
@@ -38,10 +39,10 @@ $(OUTPUT)/docs.pdf: $(DOC_FILES) $(FIGURE_FILES)
 	-v $(shell pwd)/$(OUTPUT)/:/$(OUTPUT)/ \
 	-u $(shell id -u) \
 	--workdir /input \
-	vbatts/pandoc -f markdown_github -t latex -o /$(OUTPUT)/docs.pdf $(patsubst %,/input/%,$(DOC_FILES)) && \
+	vbatts/pandoc -f markdown_github -t latex -o /$(OUTPUT)/$(DOC_FILENAME).pdf $(patsubst %,/input/%,$(DOC_FILES)) && \
 	ls -sh $(shell readlink -f $@)
 
-$(OUTPUT)/docs.html: $(DOC_FILES) $(FIGURE_FILES)
+$(OUTPUT)/$(DOC_FILENAME).html: $(DOC_FILES) $(FIGURE_FILES)
 	@mkdir -p $(OUTPUT)/ && \
 	cp -ap img/ $(shell pwd)/$(OUTPUT)/&& \
 	$(DOCKER) run \
@@ -51,7 +52,7 @@ $(OUTPUT)/docs.html: $(DOC_FILES) $(FIGURE_FILES)
 	-v $(shell pwd)/$(OUTPUT)/:/$(OUTPUT)/ \
 	-u $(shell id -u) \
 	--workdir /input \
-	vbatts/pandoc -f markdown_github -t html5 -o /$(OUTPUT)/docs.html $(patsubst %,/input/%,$(DOC_FILES)) && \
+	vbatts/pandoc -f markdown_github -t html5 -o /$(OUTPUT)/$(DOC_FILENAME).html $(patsubst %,/input/%,$(DOC_FILES)) && \
 	ls -sh $(shell readlink -f $@)
 
 code-of-conduct.md:
@@ -80,9 +81,6 @@ test:
 
 img/%.png: %.dot
 	dot -Tpng $^ > $@
-
-inline-png-%.md: img/%.png
-	@printf '<img src="data:image/png;base64,%s" alt="$*"/>\n' "$(shell base64 $^)" > $@
 
 clean:
 	rm -rf *~ $(OUTPUT)

--- a/media-types.md
+++ b/media-types.md
@@ -46,4 +46,6 @@ This section shows where the OCI Image Specification is compatible with formats 
 
 The following figure shows how the above media types reference each other:
 
+![](img/media-types.png)
+
 A reference is defined as the target content digest, as defined by the [Registry V2 HTTP API Specificiation](https://docs.docker.com/registry/spec/api/#digest-parameter). The manifest list being a "fat manifest" references one or more image manifests per target platform. An image manifest references exactly one target configuration and possibly many layers.


### PR DESCRIPTION
This includes:
* better doc filename, and variablized for ease
* inline images do not seem needed now. put the media-types back

Closes #90 

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>