### PR TITLE
Add PullApprove support to enforce consistent review 

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,9 @@
+approve_by_comment: true
+approve_regex: ^LGTM
+reject_regex: ^Rejected
+reset_on_push: true
+reviewers:
+  teams:
+  - image-spec-maintainers
+  name: default
+  required: 2


### PR DESCRIPTION
Ensure that OCI projects share the same approval settings, this has been done for the runtime-spec and runc already, so it makes sense to do the same for image-spec:
https://github.com/opencontainers/project-template/issues/4
https://pullapprove.com/opencontainers/image-spec/

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>