### PR TITLE
oci-image-tool: implement create-runtime-bundle

### DIFF
--- a/cmd/oci-image-tool/create_runtime_bundle.go
+++ b/cmd/oci-image-tool/create_runtime_bundle.go
@@ -24,29 +24,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// supported unpack types
-var unpackTypes = []string{
+// supported bundle types
+var bundleTypes = []string{
 	typeImageLayout,
 	typeImage,
 }
 
-type unpackCmd struct {
+type bundleCmd struct {
 	stdout *log.Logger
 	stderr *log.Logger
-	typ    string // the type to unpack, can be empty string
+	typ    string // the type to bundle, can be empty string
 	ref    string
+	root   string
 }
 
-func newUnpackCmd(stdout, stderr *log.Logger) *cobra.Command {
-	v := &unpackCmd{
+func newBundleCmd(stdout, stderr *log.Logger) *cobra.Command {
+	v := &bundleCmd{
 		stdout: stdout,
 		stderr: stderr,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "unpack [src] [dest]",
-		Short: "Unpack an image or image source layout",
-		Long:  `Unpack the OCI image .tar file or OCI image layout directory present at [src] to the destination directory [dest].`,
+		Use:   "create-runtime-bundle [src] [dest]",
+		Short: "Create an OCI image runtime bundle",
+		Long:  `Creates an OCI image runtime bundle at the destination directory [dest] from an OCI image present at [src].`,
 		Run:   v.Run,
 	}
 
@@ -54,19 +55,25 @@ func newUnpackCmd(stdout, stderr *log.Logger) *cobra.Command {
 		&v.typ, "type", "",
 		fmt.Sprintf(
 			`Type of the file to unpack. If unset, oci-image-tool will try to auto-detect the type. One of "%s"`,
-			strings.Join(unpackTypes, ","),
+			strings.Join(bundleTypes, ","),
 		),
 	)
 
 	cmd.Flags().StringVar(
 		&v.ref, "ref", "v1.0",
-		`The ref pointing to the manifest to be unpacked. This must be present in the "refs" subdirectory of the image.`,
+		`The ref pointing to the manifest of the OCI image. This must be present in the "refs" subdirectory of the image.`,
+	)
+
+	cmd.Flags().StringVar(
+		&v.root, "rootfs", "rootfs",
+		`A directory representing the root filesystem of the container in the OCI runtime bundle.
+It is strongly recommended to keep the default value.`,
 	)
 
 	return cmd
 }
 
-func (v *unpackCmd) Run(cmd *cobra.Command, args []string) {
+func (v *bundleCmd) Run(cmd *cobra.Command, args []string) {
 	if len(args) != 2 {
 		v.stderr.Print("both src and dest must be provided")
 		if err := cmd.Usage(); err != nil {
@@ -87,10 +94,10 @@ func (v *unpackCmd) Run(cmd *cobra.Command, args []string) {
 	var err error
 	switch v.typ {
 	case typeImageLayout:
-		err = image.UnpackLayout(args[0], args[1], v.ref)
+		err = image.CreateRuntimeBundleLayout(args[0], args[1], v.ref, v.root)
 
 	case typeImage:
-		err = image.Unpack(args[0], args[1], v.ref)
+		err = image.CreateRuntimeBundle(args[0], args[1], v.ref, v.root)
 	}
 
 	if err != nil {

--- a/cmd/oci-image-tool/main.go
+++ b/cmd/oci-image-tool/main.go
@@ -32,6 +32,7 @@ func main() {
 
 	cmd.AddCommand(newValidateCmd(stdout, stderr))
 	cmd.AddCommand(newUnpackCmd(stdout, stderr))
+	cmd.AddCommand(newBundleCmd(stdout, stderr))
 
 	if err := cmd.Execute(); err != nil {
 		stderr.Println(err)

--- a/image/config.go
+++ b/image/config.go
@@ -1,0 +1,156 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/opencontainers/image-spec/schema"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+type cfg struct {
+	User         string
+	Memory       int64
+	MemorySwap   int64
+	CPUShares    int64 `json:"CpuShares"`
+	ExposedPorts map[string]struct{}
+	Env          []string
+	Entrypoint   []string
+	Cmd          []string
+	Volumes      map[string]struct{}
+	WorkingDir   string
+}
+
+type config struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Config       cfg    `json:"config"`
+}
+
+func findConfig(w walker, d *descriptor) (*config, error) {
+	var c config
+	cpath := filepath.Join("blobs", d.Digest)
+
+	f := func(path string, info os.FileInfo, r io.Reader) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Clean(path) != cpath {
+			return nil
+		}
+
+		buf, err := ioutil.ReadAll(r)
+		if err != nil {
+			return errors.Wrapf(err, "%s: error reading config", path)
+		}
+
+		if err := schema.MediaTypeImageSerializationConfig.Validate(bytes.NewReader(buf)); err != nil {
+			return errors.Wrapf(err, "%s: config validation failed", path)
+		}
+
+		if err := json.Unmarshal(buf, &c); err != nil {
+			return err
+		}
+
+		return errEOW
+	}
+
+	switch err := w.walk(f); err {
+	case nil:
+		return nil, fmt.Errorf("%s: config not found", cpath)
+	case errEOW:
+		// found, continue below
+	default:
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
+	if c.OS != "linux" {
+		return nil, fmt.Errorf("%s: unsupported OS", c.OS)
+	}
+
+	var s specs.Spec
+	s.Version = "0.5.0"
+	s.Root.Path = rootfs
+	s.Process.Cwd = c.Config.WorkingDir
+	s.Process.Env = append([]string(nil), c.Config.Env...)
+	s.Process.Args = append([]string(nil), c.Config.Entrypoint...)
+	s.Process.Args = append(s.Process.Args, c.Config.Cmd...)
+
+	if uid, err := strconv.Atoi(c.Config.User); err == nil {
+		s.Process.User.UID = uint32(uid)
+	} else if ug := strings.Split(c.Config.User, ":"); len(ug) == 2 {
+		uid, err := strconv.Atoi(ug[0])
+		if err != nil {
+			return nil, errors.New("config.User: unsupported uid format")
+		}
+
+		gid, err := strconv.Atoi(ug[1])
+		if err != nil {
+			return nil, errors.New("config.User: unsupported gid format")
+		}
+
+		s.Process.User.UID = uint32(uid)
+		s.Process.User.GID = uint32(gid)
+	} else {
+		return nil, errors.New("config.User: unsupported format")
+	}
+
+	s.Platform.OS = c.OS
+	s.Platform.Arch = c.Architecture
+
+	mem := uint64(c.Config.Memory)
+	swap := uint64(c.Config.MemorySwap)
+	shares := uint64(c.Config.CPUShares)
+
+	s.Linux.Resources = &specs.Resources{
+		CPU: &specs.CPU{
+			Shares: &shares,
+		},
+
+		Memory: &specs.Memory{
+			Limit:       &mem,
+			Reservation: &mem,
+			Swap:        &swap,
+		},
+	}
+
+	for vol := range c.Config.Volumes {
+		s.Mounts = append(
+			s.Mounts,
+			specs.Mount{
+				Destination: vol,
+				Type:        "bind",
+				Options:     []string{"rbind"},
+			},
+		)
+	}
+
+	return &s, nil
+}


### PR DESCRIPTION
This is a first shot towards a `oci-image-tool create-runtime-bundle` subcommand.

I found that converting towards the runtime bundle we have (obviously) quite some impedance mismatch here and there so I guess I surely missed something.

The most important questions for me are:

- What `ociVersion` to I have to set?
- How to map image `Volumes` to bundle `mounts`?
- Is there anything else obvious I am missing?
- We have redundant declarations of layers, one in the manifest, one in the image JSON, it is not clear to me which layer declaration is the one I should pick for unpacking to the bundle. This also applies to unpack. I opened https://github.com/opencontainers/image-spec/issues/115 for this.

Generally I have the impression that I can only fill up only a small subset of the bundle fields, hence I ask for advice how to proceed here.