### PR TITLE
*: Remove 'echo -e ...' (use 'echo' and 'printf')

### DIFF
--- a/.tool/check-license
+++ b/.tool/check-license
@@ -7,7 +7,7 @@ set -o pipefail
 ret=0
 
 for file in $(find . -type f -iname '*.go' ! -path './vendor/*'); do
-	(head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)") || (echo -e "${file}:missing license header" && ret=1)
+	(head -n3 "${file}" | grep -Eq "(Copyright|generated|GENERATED)") || (echo "${file}:missing license header" && ret=1)
 done
 
 exit $ret

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ oci-image-tool:
 
 schema-fs:
 	@echo "generating schema fs"
-	@cd schema && echo -e "$$(cat ../.header)\n\n$$(go generate)" > fs.go
+	@cd schema && printf "%s\n\n%s\n" "$$(cat ../.header)" "$$(go generate)" > fs.go
 
 check-license:
 	@echo "checking license headers"


### PR DESCRIPTION
Bash requires `echo -e` to [enable interpretation of backslash
escapes][1], but POSIX [does not standardize any options for
`echo`][2].  From the [POSIX docs][2]:

> It is not possible to use echo portably across all POSIX systems
> unless both -n (as the first argument) and escape sequences are
> omitted.
>
> The printf utility can be used portably to emulate any of the
> traditional behaviors of the echo utility as follows...

`printf` is a better bet.  From the [POSIX docs][3]:

> The printf utility was added to provide functionality that has
> historically been provided by echo.  However, due to irreconcilable
> differences in the various versions of echo extant, the version has
> few special features, leaving those to this new printf utility,
> which is based on one in the Ninth Edition system.

The check-license script has a Bash shabang, so the `echo -e` is
legal.  But the argument doesn't actually use backslash-escaped
characters so there's no point in setting the option.  Unsetting it
closes an extremely low-risk bug where `${file}` contains bytes that
could be interpreted as a backslash-escaped character:

    $ file='a\nb.go'
    $ echo -e "${file}:c"
    a
    b.go:c
    $ echo "${file}:c"
    a\nb.go:c

Spun off from [this discussion][4] (cc @stevvooe).

[1]: https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html#index-echo
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html
[3]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html
[4]: https://github.com/opencontainers/image-spec/pull/111/files#r65660061