### PR TITLE
schema: add line/col info in case of JSON err

### DIFF
--- a/cmd/oci-image-tool/autodetect.go
+++ b/cmd/oci-image-tool/autodetect.go
@@ -84,7 +84,16 @@ func autodetect(path string) (string, error) {
 	}{}
 
 	if err := json.NewDecoder(f).Decode(&header); err != nil {
-		return "", errors.Wrap(err, "unable to parse JSON")
+		if _, errSeek := f.Seek(0, os.SEEK_SET); errSeek != nil {
+			return "", errors.Wrap(err, "unable to seek")
+		}
+
+		e := errors.Wrap(
+			schema.WrapSyntaxError(f, err),
+			"unable to parse JSON",
+		)
+
+		return "", e
 	}
 
 	switch {

--- a/cmd/oci-image-tool/validate.go
+++ b/cmd/oci-image-tool/validate.go
@@ -91,6 +91,10 @@ func (v *validateCmd) Run(cmd *cobra.Command, args []string) {
 		var errs []error
 		if verr, ok := errors.Cause(err).(schema.ValidationError); ok {
 			errs = verr.Errs
+		} else if serr, ok := errors.Cause(err).(*schema.SyntaxError); ok {
+			v.stderr.Printf("%s:%d:%d: validation failed: %v", arg, serr.Line, serr.Col, err)
+			exitcode = 1
+			continue
 		} else {
 			v.stderr.Printf("%s: validation failed: %v", arg, err)
 			exitcode = 1

--- a/schema/error.go
+++ b/schema/error.go
@@ -1,0 +1,44 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"io"
+
+	"go4.org/errorutil"
+)
+
+// A SyntaxError is a description of a JSON syntax error
+// including line, column and offset in the JSON file.
+type SyntaxError struct {
+	msg       string
+	Line, Col int
+	Offset    int64
+}
+
+func (e *SyntaxError) Error() string { return e.msg }
+
+// WrapSyntaxError checks whether the given error is a *json.SyntaxError
+// and converts it into a *schema.SyntaxError containing line/col information using the given reader.
+// If the given error is not a *json.SyntaxError it is returned unchanged.
+func WrapSyntaxError(r io.Reader, err error) error {
+	if serr, ok := err.(*json.SyntaxError); ok {
+		line, col, _ := errorutil.HighlightBytePosition(r, serr.Offset)
+		return &SyntaxError{serr.Error(), line, col, serr.Offset}
+	}
+
+	return err
+}

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -48,7 +49,9 @@ func (v Validator) Validate(src io.Reader) error {
 
 	result, err := gojsonschema.Validate(sl, ml)
 	if err != nil {
-		return errors.Wrapf(err, "schema %s: unable to validate manifest", v)
+		return errors.Wrapf(
+			WrapSyntaxError(bytes.NewReader(buf), err),
+			"schema %s: unable to validate", v)
 	}
 
 	if result.Valid() {


### PR DESCRIPTION
Previously no line/col information was provided if JSON parsing failed.
This fixes it.

Unfortunately we still cannot determine line/col information in case of
schema validation because the original JSON decoderState is lost.

Signed-off-by: Sergiusz Urbaniak <sur@coreos.com>