### PR TITLE
README: add language around base and optional layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The high level components of the spec include:
 * Signatures that are based on signing image content address (optional layer)
 * Naming that is federated based on DNS and can be delegated (optional layer)
 
+The optional and base layers of all OCI projects are tracked in the [OCI Scope Table](https://www.opencontainers.org/governance/oci-scope-table).
+
 ## Running an OCI Image
 
 The OCI Image Format partner project is the [OCI Runtime Spec project](https://github.com/opencontainers/runtime-spec). The Runtime Specification outlines how to run a "[filesystem bundle](https://github.com/opencontainers/runtime-spec/blob/master/bundle.md)" that is unpacked on disk. At a high-level an OCI implementation would download an OCI Image then unpack that image into an OCI Runtime filesystem bundle. At this point the OCI Runtime Bundle would be run by an OCI Runtime.


### PR DESCRIPTION
Based on feedback new users might not know what the base and optional
layer language is about. Point to the scope doc that uses this language.
Fixes #120.

Signed-off-by: Brandon Philips <brandon.philips@coreos.com>