### PR TITLE
*: Fix '&lt' -> '<' and '&gt' -> '>' typos

### DIFF
--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -42,7 +42,7 @@ func TestConfig(t *testing.T) {
 			config: `
 {
     "created": "2015-10-31T22:22:56.015925234Z",
-    "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
+    "author": "Alyssa P. Hacker <alyspdev@example.com>",
     "architecture": "amd64",
     "os": "linux",
     "config": {
@@ -102,7 +102,7 @@ func TestConfig(t *testing.T) {
 			config: `
 {
     "created": "2015-10-31T22:22:56.015925234Z",
-    "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
+    "author": "Alyssa P. Hacker <alyspdev@example.com>",
     "architecture": "amd64",
     "os": "linux",
     "config": {

--- a/serialization.md
+++ b/serialization.md
@@ -90,7 +90,7 @@ Here is an example image JSON file:
 ```json,title=Image%20JSON&mediatype=application/vnd.oci.image.serialization.config.v1%2Bjson
 {  
     "created": "2015-10-31T22:22:56.015925234Z",
-    "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
+    "author": "Alyssa P. Hacker <alyspdev@example.com>",
     "architecture": "amd64",
     "os": "linux",
     "config": {


### PR DESCRIPTION
These quasi-entities (which are missing the usual closing semicolon)
have been floating around since c22ca799 (serialization: docker v1
image format media type, 2016-04-04, #6).

Generated with:

    $ sed -i 's/&lt/</;s/&gt/>/' $(git grep -l alyspdev@example.com)