### PR TITLE
Vendor dependencies, add hacking guide

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -9,7 +9,7 @@ if [ ! $(command -v gometalinter) ]; then
 	gometalinter --update --install
 fi
 
-for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool'); do
+for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*'); do
 	gometalinter \
 		--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
 		--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,124 @@
+# Hacking Guide
+
+## Overview
+
+This guide contains instructions for building artifacts contained in this repository.
+
+### Go
+
+This spec includes several Go packages, and a command line tool considered to be a reference implementation of the OCI image specification.
+
+Prerequsites:
+* Go >=1.5
+* make
+
+The following make targets are relevant for any work involving the Go packages.
+
+### Linting
+
+The included Go source code is being examined for any linting violations not included in the standard Go compiler. Linting is done using [gometalinter](https://github.com/alecthomas/gometalinter).
+
+Invocation:
+```
+$ make lint
+```
+
+### Tests
+
+This target executes all Go based tests.
+
+Invocation:
+```
+$ make test
+$ make validate-examples
+```
+
+### OCI image tool
+
+This target builds the `oci-image-tool` binary.
+
+Invocation:
+```
+$ make oci-image-tool
+```
+
+### Virtual schema http/FileSystem
+
+The `oci-image-tool` uses a virtual [http/FileSystem](https://golang.org/pkg/net/http/#FileSystem) to load the JSON schema files for validating OCI images and/or manifests. The virtual file system is generated using the `esc` tool and compiled into the `oci-image-tool` binary so the JSON schema files don't have to be distributed along with the binary.
+
+Whenever changes are being done in any of the `schema/*.json` files, one must refresh the generated virtual file system. Otherwise schema changes will not be visible inside the `oci-image-tool`.
+
+Prerequisites:
+* [esc](https://github.com/mjibson/esc)
+
+Invocation:
+```
+$ make schema-fs
+```
+
+### JSON schema formatting
+
+This target auto-formats all JSON files in the `schema` directory using the `jq` tool.
+
+Prerequisites:
+* [jq](https://stedolan.github.io/jq/)
+
+Invocation:
+```
+$ make fmt
+```
+
+### OCI image specification PDF/HTML documentation files
+
+This target generates a PDF/HTML version of the OCI image specification.
+
+Prerequisites:
+* [Docker](https://www.docker.com/)
+
+Invocation:
+```
+$ make docs
+```
+
+### License header check
+
+This target checks if the source code includes necessary headers.
+
+Invocation:
+```
+$ make check-license
+```
+
+### Update vendored dependencies
+
+This target updates all vendored depencies to their newest available versions. The `glide` tools is being used for the actual management and `glide-vc` tool is being used for stripping down the vendor directory size.
+
+Prerequisites:
+* [glide](https://github.com/Masterminds/glide)
+* [glide-vc](https://github.com/sgotti/glide-vc)
+
+Invocation:
+```
+$ make update-deps
+```
+
+### Clean build artifacts
+
+This target cleans all generated/compiled artifacts.
+
+Invocation:
+```
+$ make clean
+```
+
+### Create PNG images from dot files
+
+This target generates PNG image files from DOT source files in the `img` directory.
+
+Prerequisites:
+* [graphviz](http://www.graphviz.org/)
+
+Invocation:
+```
+$ make img/media-types.png
+```

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,26 @@
+hash: 9eee25c418553e1d79fe7fb956eae4b056402d2c1fe7c8c79f5849da571dd99b
+updated: 2016-06-23T09:00:42.232695928+02:00
+imports:
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/opencontainers/runtime-spec
+  version: 06479209bdc0d4135911688c18157bd39bd99c22
+  subpackages:
+  - specs-go
+- name: github.com/pkg/errors
+  version: 01fa4104b9c248c8945d14d9f128454d5b28d595
+- name: github.com/spf13/cobra
+  version: 6a8bd97bdb1fc0d08a83459940498ea49d3e8c93
+- name: github.com/spf13/pflag
+  version: 367864438f1b1a3c7db4da06a2f55b144e6784e0
+- name: github.com/xeipuuv/gojsonpointer
+  version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
+- name: github.com/xeipuuv/gojsonreference
+  version: e02fc20de94c78484cd5ffb007f8af96be030a45
+- name: github.com/xeipuuv/gojsonschema
+  version: d5336c75940ef31c9ceeb0ae64cf92944bccb4ee
+- name: go4.org
+  version: 15c19124e43b90eba9aa27b4341e38365254a84a
+  subpackages:
+  - errorutil
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,4 @@ import:
   version: ">=0.7.0"
 - package: github.com/spf13/cobra
 - package: github.com/xeipuuv/gojsonschema
+  version: d5336c75940ef31c9ceeb0ae64cf92944bccb4ee

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,10 @@
+package: github.com/opencontainers/image-spec
+import:
+- package: github.com/opencontainers/runtime-spec
+  version: ^1.0.0-rc1
+  subpackages:
+  - specs-go
+- package: github.com/pkg/errors
+  version: ">=0.7.0"
+- package: github.com/spf13/cobra
+- package: github.com/xeipuuv/gojsonschema

--- a/vendor/github.com/inconshreveable/mousetrap/LICENSE
+++ b/vendor/github.com/inconshreveable/mousetrap/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2014 Alan Shreve
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/inconshreveable/mousetrap/trap_others.go
+++ b/vendor/github.com/inconshreveable/mousetrap/trap_others.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package mousetrap
+
+// StartedByExplorer returns true if the program was invoked by the user
+// double-clicking on the executable from explorer.exe
+//
+// It is conservative and returns false if any of the internal calls fail.
+// It does not guarantee that the program was run from a terminal. It only can tell you
+// whether it was launched from explorer.exe
+//
+// On non-Windows platforms, it always returns false.
+func StartedByExplorer() bool {
+	return false
+}

--- a/vendor/github.com/inconshreveable/mousetrap/trap_windows.go
+++ b/vendor/github.com/inconshreveable/mousetrap/trap_windows.go
@@ -1,0 +1,98 @@
+// +build windows
+// +build !go1.4
+
+package mousetrap
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	// defined by the Win32 API
+	th32cs_snapprocess uintptr = 0x2
+)
+
+var (
+	kernel                   = syscall.MustLoadDLL("kernel32.dll")
+	CreateToolhelp32Snapshot = kernel.MustFindProc("CreateToolhelp32Snapshot")
+	Process32First           = kernel.MustFindProc("Process32FirstW")
+	Process32Next            = kernel.MustFindProc("Process32NextW")
+)
+
+// ProcessEntry32 structure defined by the Win32 API
+type processEntry32 struct {
+	dwSize              uint32
+	cntUsage            uint32
+	th32ProcessID       uint32
+	th32DefaultHeapID   int
+	th32ModuleID        uint32
+	cntThreads          uint32
+	th32ParentProcessID uint32
+	pcPriClassBase      int32
+	dwFlags             uint32
+	szExeFile           [syscall.MAX_PATH]uint16
+}
+
+func getProcessEntry(pid int) (pe *processEntry32, err error) {
+	snapshot, _, e1 := CreateToolhelp32Snapshot.Call(th32cs_snapprocess, uintptr(0))
+	if snapshot == uintptr(syscall.InvalidHandle) {
+		err = fmt.Errorf("CreateToolhelp32Snapshot: %v", e1)
+		return
+	}
+	defer syscall.CloseHandle(syscall.Handle(snapshot))
+
+	var processEntry processEntry32
+	processEntry.dwSize = uint32(unsafe.Sizeof(processEntry))
+	ok, _, e1 := Process32First.Call(snapshot, uintptr(unsafe.Pointer(&processEntry)))
+	if ok == 0 {
+		err = fmt.Errorf("Process32First: %v", e1)
+		return
+	}
+
+	for {
+		if processEntry.th32ProcessID == uint32(pid) {
+			pe = &processEntry
+			return
+		}
+
+		ok, _, e1 = Process32Next.Call(snapshot, uintptr(unsafe.Pointer(&processEntry)))
+		if ok == 0 {
+			err = fmt.Errorf("Process32Next: %v", e1)
+			return
+		}
+	}
+}
+
+func getppid() (pid int, err error) {
+	pe, err := getProcessEntry(os.Getpid())
+	if err != nil {
+		return
+	}
+
+	pid = int(pe.th32ParentProcessID)
+	return
+}
+
+// StartedByExplorer returns true if the program was invoked by the user double-clicking
+// on the executable from explorer.exe
+//
+// It is conservative and returns false if any of the internal calls fail.
+// It does not guarantee that the program was run from a terminal. It only can tell you
+// whether it was launched from explorer.exe
+func StartedByExplorer() bool {
+	ppid, err := getppid()
+	if err != nil {
+		return false
+	}
+
+	pe, err := getProcessEntry(ppid)
+	if err != nil {
+		return false
+	}
+
+	name := syscall.UTF16ToString(pe.szExeFile[:])
+	return name == "explorer.exe"
+}

--- a/vendor/github.com/inconshreveable/mousetrap/trap_windows_1.4.go
+++ b/vendor/github.com/inconshreveable/mousetrap/trap_windows_1.4.go
@@ -1,0 +1,46 @@
+// +build windows
+// +build go1.4
+
+package mousetrap
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func getProcessEntry(pid int) (*syscall.ProcessEntry32, error) {
+	snapshot, err := syscall.CreateToolhelp32Snapshot(syscall.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.CloseHandle(snapshot)
+	var procEntry syscall.ProcessEntry32
+	procEntry.Size = uint32(unsafe.Sizeof(procEntry))
+	if err = syscall.Process32First(snapshot, &procEntry); err != nil {
+		return nil, err
+	}
+	for {
+		if procEntry.ProcessID == uint32(pid) {
+			return &procEntry, nil
+		}
+		err = syscall.Process32Next(snapshot, &procEntry)
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// StartedByExplorer returns true if the program was invoked by the user double-clicking
+// on the executable from explorer.exe
+//
+// It is conservative and returns false if any of the internal calls fail.
+// It does not guarantee that the program was run from a terminal. It only can tell you
+// whether it was launched from explorer.exe
+func StartedByExplorer() bool {
+	pe, err := getProcessEntry(os.Getppid())
+	if err != nil {
+		return false
+	}
+	return "explorer.exe" == syscall.UTF16ToString(pe.ExeFile[:])
+}

--- a/vendor/github.com/opencontainers/runtime-spec/LICENSE
+++ b/vendor/github.com/opencontainers/runtime-spec/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 The Linux Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -1,0 +1,471 @@
+package specs
+
+import "os"
+
+// Spec is the base configuration for the container.
+type Spec struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"ociVersion"`
+	// Platform is the host information for OS and Arch.
+	Platform Platform `json:"platform"`
+	// Process is the container's main process.
+	Process Process `json:"process"`
+	// Root is the root information for the container's filesystem.
+	Root Root `json:"root"`
+	// Hostname is the container's host name.
+	Hostname string `json:"hostname,omitempty"`
+	// Mounts profile configuration for adding mounts to the container's filesystem.
+	Mounts []Mount `json:"mounts,omitempty"`
+	// Hooks are the commands run at various lifecycle events of the container.
+	Hooks Hooks `json:"hooks"`
+	// Annotations is an unstructured key value map that may be set by external tools to store and retrieve arbitrary metadata.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Linux is platform specific configuration for Linux based containers.
+	Linux Linux `json:"linux" platform:"linux,omitempty"`
+	// Solaris is platform specific configuration for Solaris containers.
+	Solaris Solaris `json:"solaris" platform:"solaris,omitempty"`
+}
+
+// Process contains information to start a specific application inside the container.
+type Process struct {
+	// Terminal creates an interactive terminal for the container.
+	Terminal bool `json:"terminal,omitempty"`
+	// User specifies user information for the process.
+	User User `json:"user"`
+	// Args specifies the binary and arguments for the application to execute.
+	Args []string `json:"args"`
+	// Env populates the process environment for the process.
+	Env []string `json:"env,omitempty"`
+	// Cwd is the current working directory for the process and must be
+	// relative to the container's root.
+	Cwd string `json:"cwd"`
+	// Capabilities are Linux capabilities that are kept for the container.
+	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
+	// Rlimits specifies rlimit options to apply to the process.
+	Rlimits []Rlimit `json:"rlimits,omitempty"`
+	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
+
+	// ApparmorProfile specified the apparmor profile for the container. (this field is platform dependent)
+	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
+	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
+	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
+}
+
+// User specifies Linux specific user and group information for the container's
+// main process.
+type User struct {
+	// UID is the user id. (this field is platform dependent)
+	UID uint32 `json:"uid" platform:"linux"`
+	// GID is the group id. (this field is platform dependent)
+	GID uint32 `json:"gid" platform:"linux"`
+	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
+	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux"`
+}
+
+// Root contains information about the container's root filesystem on the host.
+type Root struct {
+	// Path is the absolute path to the container's root filesystem.
+	Path string `json:"path"`
+	// Readonly makes the root filesystem for the container readonly before the process is executed.
+	Readonly bool `json:"readonly,omitempty"`
+}
+
+// Platform specifies OS and arch information for the host system that the container
+// is created for.
+type Platform struct {
+	// OS is the operating system.
+	OS string `json:"os"`
+	// Arch is the architecture
+	Arch string `json:"arch"`
+}
+
+// Mount specifies a mount for a container.
+type Mount struct {
+	// Destination is the path where the mount will be placed relative to the container's root.  The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
+	Destination string `json:"destination"`
+	// Type specifies the mount kind.
+	Type string `json:"type"`
+	// Source specifies the source path of the mount.  In the case of bind mounts on
+	// Linux based systems this would be the file on the host.
+	Source string `json:"source"`
+	// Options are fstab style mount options.
+	Options []string `json:"options,omitempty"`
+}
+
+// Hook specifies a command that is run at a particular event in the lifecycle of a container
+type Hook struct {
+	Path    string   `json:"path"`
+	Args    []string `json:"args,omitempty"`
+	Env     []string `json:"env,omitempty"`
+	Timeout *int     `json:"timeout,omitempty"`
+}
+
+// Hooks for container setup and teardown
+type Hooks struct {
+	// Prestart is a list of hooks to be run before the container process is executed.
+	// On Linux, they are run after the container namespaces are created.
+	Prestart []Hook `json:"prestart,omitempty"`
+	// Poststart is a list of hooks to be run after the container process is started.
+	Poststart []Hook `json:"poststart,omitempty"`
+	// Poststop is a list of hooks to be run after the container process exits.
+	Poststop []Hook `json:"poststop,omitempty"`
+}
+
+// Linux contains platform specific configuration for Linux based containers.
+type Linux struct {
+	// UIDMapping specifies user mappings for supporting user namespaces on Linux.
+	UIDMappings []IDMapping `json:"uidMappings,omitempty"`
+	// GIDMapping specifies group mappings for supporting user namespaces on Linux.
+	GIDMappings []IDMapping `json:"gidMappings,omitempty"`
+	// Sysctl are a set of key value pairs that are set for the container on start
+	Sysctl map[string]string `json:"sysctl,omitempty"`
+	// Resources contain cgroup information for handling resource constraints
+	// for the container
+	Resources *Resources `json:"resources,omitempty"`
+	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
+	// The path is expected to be relative to the cgroups mountpoint.
+	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
+	CgroupsPath *string `json:"cgroupsPath,omitempty"`
+	// Namespaces contains the namespaces that are created and/or joined by the container
+	Namespaces []Namespace `json:"namespaces,omitempty"`
+	// Devices are a list of device nodes that are created for the container
+	Devices []Device `json:"devices,omitempty"`
+	// Seccomp specifies the seccomp security settings for the container.
+	Seccomp *Seccomp `json:"seccomp,omitempty"`
+	// RootfsPropagation is the rootfs mount propagation mode for the container.
+	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
+	// MaskedPaths masks over the provided paths inside the container.
+	MaskedPaths []string `json:"maskedPaths,omitempty"`
+	// ReadonlyPaths sets the provided paths as RO inside the container.
+	ReadonlyPaths []string `json:"readonlyPaths,omitempty"`
+	// MountLabel specifies the selinux context for the mounts in the container.
+	MountLabel string `json:"mountLabel,omitempty"`
+}
+
+// Namespace is the configuration for a Linux namespace
+type Namespace struct {
+	// Type is the type of Linux namespace
+	Type NamespaceType `json:"type"`
+	// Path is a path to an existing namespace persisted on disk that can be joined
+	// and is of the same type
+	Path string `json:"path,omitempty"`
+}
+
+// NamespaceType is one of the Linux namespaces
+type NamespaceType string
+
+const (
+	// PIDNamespace for isolating process IDs
+	PIDNamespace NamespaceType = "pid"
+	// NetworkNamespace for isolating network devices, stacks, ports, etc
+	NetworkNamespace = "network"
+	// MountNamespace for isolating mount points
+	MountNamespace = "mount"
+	// IPCNamespace for isolating System V IPC, POSIX message queues
+	IPCNamespace = "ipc"
+	// UTSNamespace for isolating hostname and NIS domain name
+	UTSNamespace = "uts"
+	// UserNamespace for isolating user and group IDs
+	UserNamespace = "user"
+	// CgroupNamespace for isolating cgroup hierarchies
+	CgroupNamespace = "cgroup"
+)
+
+// IDMapping specifies UID/GID mappings
+type IDMapping struct {
+	// HostID is the UID/GID of the host user or group
+	HostID uint32 `json:"hostID"`
+	// ContainerID is the UID/GID of the container's user or group
+	ContainerID uint32 `json:"containerID"`
+	// Size is the length of the range of IDs mapped between the two namespaces
+	Size uint32 `json:"size"`
+}
+
+// Rlimit type and restrictions
+type Rlimit struct {
+	// Type of the rlimit to set
+	Type string `json:"type"`
+	// Hard is the hard limit for the specified type
+	Hard uint64 `json:"hard"`
+	// Soft is the soft limit for the specified type
+	Soft uint64 `json:"soft"`
+}
+
+// HugepageLimit structure corresponds to limiting kernel hugepages
+type HugepageLimit struct {
+	// Pagesize is the hugepage size
+	Pagesize *string `json:"pageSize,omitempty"`
+	// Limit is the limit of "hugepagesize" hugetlb usage
+	Limit *uint64 `json:"limit,omitempty"`
+}
+
+// InterfacePriority for network interfaces
+type InterfacePriority struct {
+	// Name is the name of the network interface
+	Name string `json:"name"`
+	// Priority for the interface
+	Priority uint32 `json:"priority"`
+}
+
+// blockIODevice holds major:minor format supported in blkio cgroup
+type blockIODevice struct {
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+}
+
+// WeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+type WeightDevice struct {
+	blockIODevice
+	// Weight is the bandwidth rate for the device, range is from 10 to 1000
+	Weight *uint16 `json:"weight,omitempty"`
+	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	LeafWeight *uint16 `json:"leafWeight,omitempty"`
+}
+
+// ThrottleDevice struct holds a `major:minor rate_per_second` pair
+type ThrottleDevice struct {
+	blockIODevice
+	// Rate is the IO rate limit per cgroup per device
+	Rate *uint64 `json:"rate,omitempty"`
+}
+
+// BlockIO for Linux cgroup 'blkio' resource management
+type BlockIO struct {
+	// Specifies per cgroup weight, range is from 10 to 1000
+	Weight *uint16 `json:"blkioWeight,omitempty"`
+	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
+	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
+	// Weight per cgroup per device, can override BlkioWeight
+	WeightDevice []WeightDevice `json:"blkioWeightDevice,omitempty"`
+	// IO read rate limit per cgroup per device, bytes per second
+	ThrottleReadBpsDevice []ThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
+	// IO write rate limit per cgroup per device, bytes per second
+	ThrottleWriteBpsDevice []ThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
+	// IO read rate limit per cgroup per device, IO per second
+	ThrottleReadIOPSDevice []ThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
+	// IO write rate limit per cgroup per device, IO per second
+	ThrottleWriteIOPSDevice []ThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
+}
+
+// Memory for Linux cgroup 'memory' resource management
+type Memory struct {
+	// Memory limit (in bytes).
+	Limit *uint64 `json:"limit,omitempty"`
+	// Memory reservation or soft_limit (in bytes).
+	Reservation *uint64 `json:"reservation,omitempty"`
+	// Total memory limit (memory + swap).
+	Swap *uint64 `json:"swap,omitempty"`
+	// Kernel memory limit (in bytes).
+	Kernel *uint64 `json:"kernel,omitempty"`
+	// Kernel memory limit for tcp (in bytes)
+	KernelTCP *uint64 `json:"kernelTCP"`
+	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
+	Swappiness *uint64 `json:"swappiness,omitempty"`
+}
+
+// CPU for Linux cgroup 'cpu' resource management
+type CPU struct {
+	// CPU shares (relative weight (ratio) vs. other cgroups with cpu shares).
+	Shares *uint64 `json:"shares,omitempty"`
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	Quota *uint64 `json:"quota,omitempty"`
+	// CPU period to be used for hardcapping (in usecs).
+	Period *uint64 `json:"period,omitempty"`
+	// How much time realtime scheduling may use (in usecs).
+	RealtimeRuntime *uint64 `json:"realtimeRuntime,omitempty"`
+	// CPU period to be used for realtime scheduling (in usecs).
+	RealtimePeriod *uint64 `json:"realtimePeriod,omitempty"`
+	// CPUs to use within the cpuset. Default is to use any CPU available.
+	Cpus *string `json:"cpus,omitempty"`
+	// List of memory nodes in the cpuset. Default is to use any available memory node.
+	Mems *string `json:"mems,omitempty"`
+}
+
+// Pids for Linux cgroup 'pids' resource management (Linux 4.3)
+type Pids struct {
+	// Maximum number of PIDs. Default is "no limit".
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+// Network identification and priority configuration
+type Network struct {
+	// Set class identifier for container's network packets
+	ClassID *uint32 `json:"classID"`
+	// Set priority of network traffic for container
+	Priorities []InterfacePriority `json:"priorities,omitempty"`
+}
+
+// Resources has container runtime resource constraints
+type Resources struct {
+	// Devices are a list of device rules for the whitelist controller
+	Devices []DeviceCgroup `json:"devices"`
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
+	// Specify an oom_score_adj for the container.
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
+	// Memory restriction configuration
+	Memory *Memory `json:"memory,omitempty"`
+	// CPU resource restriction configuration
+	CPU *CPU `json:"cpu,omitempty"`
+	// Task resource restriction configuration.
+	Pids *Pids `json:"pids,omitempty"`
+	// BlockIO restriction configuration
+	BlockIO *BlockIO `json:"blockIO,omitempty"`
+	// Hugetlb limit (in bytes)
+	HugepageLimits []HugepageLimit `json:"hugepageLimits,omitempty"`
+	// Network restriction configuration
+	Network *Network `json:"network,omitempty"`
+}
+
+// Device represents the mknod information for a Linux special device file
+type Device struct {
+	// Path to the device.
+	Path string `json:"path"`
+	// Device type, block, char, etc.
+	Type string `json:"type"`
+	// Major is the device's major number.
+	Major int64 `json:"major"`
+	// Minor is the device's minor number.
+	Minor int64 `json:"minor"`
+	// FileMode permission bits for the device.
+	FileMode *os.FileMode `json:"fileMode,omitempty"`
+	// UID of the device.
+	UID *uint32 `json:"uid,omitempty"`
+	// Gid of the device.
+	GID *uint32 `json:"gid,omitempty"`
+}
+
+// DeviceCgroup represents a device rule for the whitelist controller
+type DeviceCgroup struct {
+	// Allow or deny
+	Allow bool `json:"allow"`
+	// Device type, block, char, etc.
+	Type *string `json:"type,omitempty"`
+	// Major is the device's major number.
+	Major *int64 `json:"major,omitempty"`
+	// Minor is the device's minor number.
+	Minor *int64 `json:"minor,omitempty"`
+	// Cgroup access permissions format, rwm.
+	Access *string `json:"access,omitempty"`
+}
+
+// Seccomp represents syscall restrictions
+type Seccomp struct {
+	DefaultAction Action    `json:"defaultAction"`
+	Architectures []Arch    `json:"architectures"`
+	Syscalls      []Syscall `json:"syscalls,omitempty"`
+}
+
+// Solaris contains platform specific configuration for Solaris application containers.
+type Solaris struct {
+	// SMF FMRI which should go "online" before we start the container process.
+	Milestone string `json:"milestone,omitempty"`
+	// Maximum set of privileges any process in this container can obtain.
+	LimitPriv string `json:"limitpriv,omitempty"`
+	// The maximum amount of shared memory allowed for this container.
+	MaxShmMemory string `json:"maxShmMemory,omitempty"`
+	// Specification for automatic creation of network resources for this container.
+	Anet []Anet `json:"anet,omitempty"`
+	// Set limit on the amount of CPU time that can be used by container.
+	CappedCPU CappedCPU `json:"cappedCPU,omitempty"`
+	// The physical and swap caps on the memory that can be used by this container.
+	CappedMemory CappedMemory `json:"cappedMemory,omitempty"`
+}
+
+// CappedCPU allows users to set limit on the amount of CPU time that can be used by container.
+type CappedCPU struct {
+	Ncpus string `json:"ncpus,omitempty"`
+}
+
+// CappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
+type CappedMemory struct {
+	Physical string `json:"physical,omitempty"`
+	Swap     string `json:"swap,omitempty"`
+}
+
+// Anet provides the specification for automatic creation of network resources for this container.
+type Anet struct {
+	// Specify a name for the automatically created VNIC datalink.
+	Linkname string `json:"linkname,omitempty"`
+	// Specify the link over which the VNIC will be created.
+	Lowerlink string `json:"lowerLink,omitempty"`
+	// The set of IP addresses that the container can use.
+	Allowedaddr string `json:"allowedAddress,omitempty"`
+	// Specifies whether allowedAddress limitation is to be applied to the VNIC.
+	Configallowedaddr string `json:"configureAllowedAddress,omitempty"`
+	// The value of the optional default router.
+	Defrouter string `json:"defrouter,omitempty"`
+	// Enable one or more types of link protection.
+	Linkprotection string `json:"linkProtection,omitempty"`
+	// Set the VNIC's macAddress
+	Macaddress string `json:"macAddress,omitempty"`
+}
+
+// Arch used for additional architectures
+type Arch string
+
+// Additional architectures permitted to be used for system calls
+// By default only the native architecture of the kernel is permitted
+const (
+	ArchX86         Arch = "SCMP_ARCH_X86"
+	ArchX86_64      Arch = "SCMP_ARCH_X86_64"
+	ArchX32         Arch = "SCMP_ARCH_X32"
+	ArchARM         Arch = "SCMP_ARCH_ARM"
+	ArchAARCH64     Arch = "SCMP_ARCH_AARCH64"
+	ArchMIPS        Arch = "SCMP_ARCH_MIPS"
+	ArchMIPS64      Arch = "SCMP_ARCH_MIPS64"
+	ArchMIPS64N32   Arch = "SCMP_ARCH_MIPS64N32"
+	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
+	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
+	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+	ArchPPC         Arch = "SCMP_ARCH_PPC"
+	ArchPPC64       Arch = "SCMP_ARCH_PPC64"
+	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
+	ArchS390        Arch = "SCMP_ARCH_S390"
+	ArchS390X       Arch = "SCMP_ARCH_S390X"
+)
+
+// Action taken upon Seccomp rule match
+type Action string
+
+// Define actions for Seccomp rules
+const (
+	ActKill  Action = "SCMP_ACT_KILL"
+	ActTrap  Action = "SCMP_ACT_TRAP"
+	ActErrno Action = "SCMP_ACT_ERRNO"
+	ActTrace Action = "SCMP_ACT_TRACE"
+	ActAllow Action = "SCMP_ACT_ALLOW"
+)
+
+// Operator used to match syscall arguments in Seccomp
+type Operator string
+
+// Define operators for syscall arguments in Seccomp
+const (
+	OpNotEqual     Operator = "SCMP_CMP_NE"
+	OpLessThan     Operator = "SCMP_CMP_LT"
+	OpLessEqual    Operator = "SCMP_CMP_LE"
+	OpEqualTo      Operator = "SCMP_CMP_EQ"
+	OpGreaterEqual Operator = "SCMP_CMP_GE"
+	OpGreaterThan  Operator = "SCMP_CMP_GT"
+	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
+)
+
+// Arg used for matching specific syscall arguments in Seccomp
+type Arg struct {
+	Index    uint     `json:"index"`
+	Value    uint64   `json:"value"`
+	ValueTwo uint64   `json:"valueTwo"`
+	Op       Operator `json:"op"`
+}
+
+// Syscall is used to match a syscall in Seccomp
+type Syscall struct {
+	Name   string `json:"name"`
+	Action Action `json:"action"`
+	Args   []Arg  `json:"args,omitempty"`
+}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -1,0 +1,17 @@
+package specs
+
+// State holds information about the runtime state of the container.
+type State struct {
+	// Version is the version of the specification that is supported.
+	Version string `json:"version"`
+	// ID is the container ID
+	ID string `json:"id"`
+	// Status is the runtime state of the container.
+	Status string `json:"status"`
+	// Pid is the process id for the container's main process.
+	Pid int `json:"pid"`
+	// BundlePath is the path to the container's bundle directory.
+	BundlePath string `json:"bundlePath"`
+	// Annotations are the annotations associated with the container.
+	Annotations map[string]string `json:"annotations"`
+}

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -1,0 +1,18 @@
+package specs
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 1
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 0
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+
+	// VersionDev indicates development branch. Releases will be empty string.
+	VersionDev = "-rc1"
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,211 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type Causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type StackTrace interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stacktrace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stacktrace of this error. For example:
+//
+//     if err, ok := err.(StackTrace); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// _error is an error implementation returned by New and Errorf
+// that implements its own fmt.Formatter.
+type _error struct {
+	msg string
+	*stack
+}
+
+func (e _error) Error() string { return e.msg }
+
+func (e _error) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, e.msg)
+			fmt.Fprintf(s, "%+v", e.StackTrace())
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, e.msg)
+	}
+}
+
+// New returns an error with the supplied message.
+func New(message string) error {
+	return _error{
+		message,
+		callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+func Errorf(format string, args ...interface{}) error {
+	return _error{
+		fmt.Sprintf(format, args...),
+		callers(),
+	}
+}
+
+type cause struct {
+	cause error
+	msg   string
+}
+
+func (c cause) Error() string { return fmt.Sprintf("%s: %v", c.msg, c.Cause()) }
+func (c cause) Cause() error  { return c.cause }
+
+// wrapper is an error implementation returned by Wrap and Wrapf
+// that implements its own fmt.Formatter.
+type wrapper struct {
+	cause
+	*stack
+}
+
+func (w wrapper) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			fmt.Fprintf(s, "%+v: %s", w.StackTrace()[0], w.msg)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   message,
+		},
+		stack: callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   fmt.Sprintf(format, args...),
+		},
+		stack: callers(),
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type Causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,165 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/vendor/github.com/spf13/cobra/LICENSE.txt
+++ b/vendor/github.com/spf13/cobra/LICENSE.txt
@@ -1,0 +1,174 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/vendor/github.com/spf13/cobra/bash_completions.go
+++ b/vendor/github.com/spf13/cobra/bash_completions.go
@@ -1,0 +1,630 @@
+package cobra
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	BashCompFilenameExt     = "cobra_annotation_bash_completion_filename_extentions"
+	BashCompCustom          = "cobra_annotation_bash_completion_custom"
+	BashCompOneRequiredFlag = "cobra_annotation_bash_completion_one_required_flag"
+	BashCompSubdirsInDir    = "cobra_annotation_bash_completion_subdirs_in_dir"
+)
+
+func preamble(out io.Writer, name string) error {
+	_, err := fmt.Fprintf(out, "# bash completion for %-36s -*- shell-script -*-\n", name)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(out, `
+__debug()
+{
+    if [[ -n ${BASH_COMP_DEBUG_FILE} ]]; then
+        echo "$*" >> "${BASH_COMP_DEBUG_FILE}"
+    fi
+}
+
+# Homebrew on Macs have version 1.3 of bash-completion which doesn't include
+# _init_completion. This is a very minimal version of that function.
+__my_init_completion()
+{
+    COMPREPLY=()
+    _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+__index_of_word()
+{
+    local w word=$1
+    shift
+    index=0
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+        index=$((index+1))
+    done
+    index=-1
+}
+
+__contains_word()
+{
+    local w word=$1; shift
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+    done
+    return 1
+}
+
+__handle_reply()
+{
+    __debug "${FUNCNAME[0]}"
+    case $cur in
+        -*)
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                compopt -o nospace
+            fi
+            local allflags
+            if [ ${#must_have_one_flag[@]} -ne 0 ]; then
+                allflags=("${must_have_one_flag[@]}")
+            else
+                allflags=("${flags[*]} ${two_word_flags[*]}")
+            fi
+            COMPREPLY=( $(compgen -W "${allflags[*]}" -- "$cur") )
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                [[ "${COMPREPLY[0]}" == *= ]] || compopt +o nospace
+            fi
+
+            # complete after --flag=abc
+            if [[ $cur == *=* ]]; then
+                if [[ $(type -t compopt) = "builtin" ]]; then
+                    compopt +o nospace
+                fi
+
+                local index flag
+                flag="${cur%%=*}"
+                __index_of_word "${flag}" "${flags_with_completion[@]}"
+                if [[ ${index} -ge 0 ]]; then
+                    COMPREPLY=()
+                    PREFIX=""
+                    cur="${cur#*=}"
+                    ${flags_completion[${index}]}
+                    if [ -n "${ZSH_VERSION}" ]; then
+                        # zfs completion needs --flag= prefix
+                        eval "COMPREPLY=( \"\${COMPREPLY[@]/#/${flag}=}\" )"
+                    fi
+                fi
+            fi
+            return 0;
+            ;;
+    esac
+
+    # check if we are handling a flag with special work handling
+    local index
+    __index_of_word "${prev}" "${flags_with_completion[@]}"
+    if [[ ${index} -ge 0 ]]; then
+        ${flags_completion[${index}]}
+        return
+    fi
+
+    # we are parsing a flag and don't have a special handler, no completion
+    if [[ ${cur} != "${words[cword]}" ]]; then
+        return
+    fi
+
+    local completions
+    completions=("${commands[@]}")
+    if [[ ${#must_have_one_noun[@]} -ne 0 ]]; then
+        completions=("${must_have_one_noun[@]}")
+    fi
+    if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
+        completions+=("${must_have_one_flag[@]}")
+    fi
+    COMPREPLY=( $(compgen -W "${completions[*]}" -- "$cur") )
+
+    if [[ ${#COMPREPLY[@]} -eq 0 && ${#noun_aliases[@]} -gt 0 && ${#must_have_one_noun[@]} -ne 0 ]]; then
+        COMPREPLY=( $(compgen -W "${noun_aliases[*]}" -- "$cur") )
+    fi
+
+    if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
+        declare -F __custom_func >/dev/null && __custom_func
+    fi
+
+    __ltrim_colon_completions "$cur"
+}
+
+# The arguments should be in the form "ext1|ext2|extn"
+__handle_filename_extension_flag()
+{
+    local ext="$1"
+    _filedir "@(${ext})"
+}
+
+__handle_subdirs_in_dir_flag()
+{
+    local dir="$1"
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1
+}
+
+__handle_flag()
+{
+    __debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+
+    # if a command required a flag, and we found it, unset must_have_one_flag()
+    local flagname=${words[c]}
+    local flagvalue
+    # if the word contained an =
+    if [[ ${words[c]} == *"="* ]]; then
+        flagvalue=${flagname#*=} # take in as flagvalue after the =
+        flagname=${flagname%%=*} # strip everything after the =
+        flagname="${flagname}=" # but put the = back
+    fi
+    __debug "${FUNCNAME[0]}: looking for ${flagname}"
+    if __contains_word "${flagname}" "${must_have_one_flag[@]}"; then
+        must_have_one_flag=()
+    fi
+
+    # if you set a flag which only applies to this command, don't show subcommands
+    if __contains_word "${flagname}" "${local_nonpersistent_flags[@]}"; then
+      commands=()
+    fi
+
+    # keep flag value with flagname as flaghash
+    if [ -n "${flagvalue}" ] ; then
+        flaghash[${flagname}]=${flagvalue}
+    elif [ -n "${words[ $((c+1)) ]}" ] ; then
+        flaghash[${flagname}]=${words[ $((c+1)) ]}
+    else
+        flaghash[${flagname}]="true" # pad "true" for bool flag
+    fi
+
+    # skip the argument to a two word flag
+    if __contains_word "${words[c]}" "${two_word_flags[@]}"; then
+        c=$((c+1))
+        # if we are looking for a flags value, don't show commands
+        if [[ $c -eq $cword ]]; then
+            commands=()
+        fi
+    fi
+
+    c=$((c+1))
+
+}
+
+__handle_noun()
+{
+    __debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+
+    if __contains_word "${words[c]}" "${must_have_one_noun[@]}"; then
+        must_have_one_noun=()
+    elif __contains_word "${words[c]}" "${noun_aliases[@]}"; then
+        must_have_one_noun=()
+    fi
+
+    nouns+=("${words[c]}")
+    c=$((c+1))
+}
+
+__handle_command()
+{
+    __debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+
+    local next_command
+    if [[ -n ${last_command} ]]; then
+        next_command="_${last_command}_${words[c]//:/__}"
+    else
+        if [[ $c -eq 0 ]]; then
+            next_command="_$(basename "${words[c]//:/__}")"
+        else
+            next_command="_${words[c]//:/__}"
+        fi
+    fi
+    c=$((c+1))
+    __debug "${FUNCNAME[0]}: looking for ${next_command}"
+    declare -F $next_command >/dev/null && $next_command
+}
+
+__handle_word()
+{
+    if [[ $c -ge $cword ]]; then
+        __handle_reply
+        return
+    fi
+    __debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    if [[ "${words[c]}" == -* ]]; then
+        __handle_flag
+    elif __contains_word "${words[c]}" "${commands[@]}"; then
+        __handle_command
+    elif [[ $c -eq 0 ]] && __contains_word "$(basename "${words[c]}")" "${commands[@]}"; then
+        __handle_command
+    else
+        __handle_noun
+    fi
+    __handle_word
+}
+
+`)
+	return err
+}
+
+func postscript(w io.Writer, name string) error {
+	name = strings.Replace(name, ":", "__", -1)
+	_, err := fmt.Fprintf(w, "__start_%s()\n", name)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, `{
+    local cur prev words cword
+    declare -A flaghash 2>/dev/null || :
+    if declare -F _init_completion >/dev/null 2>&1; then
+        _init_completion -s || return
+    else
+        __my_init_completion -n "=" || return
+    fi
+
+    local c=0
+    local flags=()
+    local two_word_flags=()
+    local local_nonpersistent_flags=()
+    local flags_with_completion=()
+    local flags_completion=()
+    local commands=("%s")
+    local must_have_one_flag=()
+    local must_have_one_noun=()
+    local last_command
+    local nouns=()
+
+    __handle_word
+}
+
+`, name)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, `if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_%s %s
+else
+    complete -o default -o nospace -F __start_%s %s
+fi
+
+`, name, name, name, name)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "# ex: ts=4 sw=4 et filetype=sh\n")
+	return err
+}
+
+func writeCommands(cmd *Command, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "    commands=()\n"); err != nil {
+		return err
+	}
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() || c == cmd.helpCommand {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "    commands+=(%q)\n", c.Name()); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
+}
+
+func writeFlagHandler(name string, annotations map[string][]string, w io.Writer) error {
+	for key, value := range annotations {
+		switch key {
+		case BashCompFilenameExt:
+			_, err := fmt.Fprintf(w, "    flags_with_completion+=(%q)\n", name)
+			if err != nil {
+				return err
+			}
+
+			if len(value) > 0 {
+				ext := "__handle_filename_extension_flag " + strings.Join(value, "|")
+				_, err = fmt.Fprintf(w, "    flags_completion+=(%q)\n", ext)
+			} else {
+				ext := "_filedir"
+				_, err = fmt.Fprintf(w, "    flags_completion+=(%q)\n", ext)
+			}
+			if err != nil {
+				return err
+			}
+		case BashCompCustom:
+			_, err := fmt.Fprintf(w, "    flags_with_completion+=(%q)\n", name)
+			if err != nil {
+				return err
+			}
+			if len(value) > 0 {
+				handlers := strings.Join(value, "; ")
+				_, err = fmt.Fprintf(w, "    flags_completion+=(%q)\n", handlers)
+			} else {
+				_, err = fmt.Fprintf(w, "    flags_completion+=(:)\n")
+			}
+			if err != nil {
+				return err
+			}
+		case BashCompSubdirsInDir:
+			_, err := fmt.Fprintf(w, "    flags_with_completion+=(%q)\n", name)
+
+			if len(value) == 1 {
+				ext := "__handle_subdirs_in_dir_flag " + value[0]
+				_, err = fmt.Fprintf(w, "    flags_completion+=(%q)\n", ext)
+			} else {
+				ext := "_filedir -d"
+				_, err = fmt.Fprintf(w, "    flags_completion+=(%q)\n", ext)
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeShortFlag(flag *pflag.Flag, w io.Writer) error {
+	b := (len(flag.NoOptDefVal) > 0)
+	name := flag.Shorthand
+	format := "    "
+	if !b {
+		format += "two_word_"
+	}
+	format += "flags+=(\"-%s\")\n"
+	if _, err := fmt.Fprintf(w, format, name); err != nil {
+		return err
+	}
+	return writeFlagHandler("-"+name, flag.Annotations, w)
+}
+
+func writeFlag(flag *pflag.Flag, w io.Writer) error {
+	b := (len(flag.NoOptDefVal) > 0)
+	name := flag.Name
+	format := "    flags+=(\"--%s"
+	if !b {
+		format += "="
+	}
+	format += "\")\n"
+	if _, err := fmt.Fprintf(w, format, name); err != nil {
+		return err
+	}
+	return writeFlagHandler("--"+name, flag.Annotations, w)
+}
+
+func writeLocalNonPersistentFlag(flag *pflag.Flag, w io.Writer) error {
+	b := (len(flag.NoOptDefVal) > 0)
+	name := flag.Name
+	format := "    local_nonpersistent_flags+=(\"--%s"
+	if !b {
+		format += "="
+	}
+	format += "\")\n"
+	if _, err := fmt.Fprintf(w, format, name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeFlags(cmd *Command, w io.Writer) error {
+	_, err := fmt.Fprintf(w, `    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+`)
+	if err != nil {
+		return err
+	}
+	localNonPersistentFlags := cmd.LocalNonPersistentFlags()
+	var visitErr error
+	cmd.NonInheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if err := writeFlag(flag, w); err != nil {
+			visitErr = err
+			return
+		}
+		if len(flag.Shorthand) > 0 {
+			if err := writeShortFlag(flag, w); err != nil {
+				visitErr = err
+				return
+			}
+		}
+		if localNonPersistentFlags.Lookup(flag.Name) != nil {
+			if err := writeLocalNonPersistentFlag(flag, w); err != nil {
+				visitErr = err
+				return
+			}
+		}
+	})
+	if visitErr != nil {
+		return visitErr
+	}
+	cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		if err := writeFlag(flag, w); err != nil {
+			visitErr = err
+			return
+		}
+		if len(flag.Shorthand) > 0 {
+			if err := writeShortFlag(flag, w); err != nil {
+				visitErr = err
+				return
+			}
+		}
+	})
+	if visitErr != nil {
+		return visitErr
+	}
+
+	_, err = fmt.Fprintf(w, "\n")
+	return err
+}
+
+func writeRequiredFlag(cmd *Command, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "    must_have_one_flag=()\n"); err != nil {
+		return err
+	}
+	flags := cmd.NonInheritedFlags()
+	var visitErr error
+	flags.VisitAll(func(flag *pflag.Flag) {
+		for key := range flag.Annotations {
+			switch key {
+			case BashCompOneRequiredFlag:
+				format := "    must_have_one_flag+=(\"--%s"
+				b := (flag.Value.Type() == "bool")
+				if !b {
+					format += "="
+				}
+				format += "\")\n"
+				if _, err := fmt.Fprintf(w, format, flag.Name); err != nil {
+					visitErr = err
+					return
+				}
+
+				if len(flag.Shorthand) > 0 {
+					if _, err := fmt.Fprintf(w, "    must_have_one_flag+=(\"-%s\")\n", flag.Shorthand); err != nil {
+						visitErr = err
+						return
+					}
+				}
+			}
+		}
+	})
+	return visitErr
+}
+
+func writeRequiredNouns(cmd *Command, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "    must_have_one_noun=()\n"); err != nil {
+		return err
+	}
+	sort.Sort(sort.StringSlice(cmd.ValidArgs))
+	for _, value := range cmd.ValidArgs {
+		if _, err := fmt.Fprintf(w, "    must_have_one_noun+=(%q)\n", value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeArgAliases(cmd *Command, w io.Writer) error {
+	if _, err := fmt.Fprintf(w, "    noun_aliases=()\n"); err != nil {
+		return err
+	}
+	sort.Sort(sort.StringSlice(cmd.ArgAliases))
+	for _, value := range cmd.ArgAliases {
+		if _, err := fmt.Fprintf(w, "    noun_aliases+=(%q)\n", value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func gen(cmd *Command, w io.Writer) error {
+	for _, c := range cmd.Commands() {
+		if !c.IsAvailableCommand() || c == cmd.helpCommand {
+			continue
+		}
+		if err := gen(c, w); err != nil {
+			return err
+		}
+	}
+	commandName := cmd.CommandPath()
+	commandName = strings.Replace(commandName, " ", "_", -1)
+	commandName = strings.Replace(commandName, ":", "__", -1)
+	if _, err := fmt.Fprintf(w, "_%s()\n{\n", commandName); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "    last_command=%q\n", commandName); err != nil {
+		return err
+	}
+	if err := writeCommands(cmd, w); err != nil {
+		return err
+	}
+	if err := writeFlags(cmd, w); err != nil {
+		return err
+	}
+	if err := writeRequiredFlag(cmd, w); err != nil {
+		return err
+	}
+	if err := writeRequiredNouns(cmd, w); err != nil {
+		return err
+	}
+	if err := writeArgAliases(cmd, w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "}\n\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cmd *Command) GenBashCompletion(w io.Writer) error {
+	if err := preamble(w, cmd.Name()); err != nil {
+		return err
+	}
+	if len(cmd.BashCompletionFunction) > 0 {
+		if _, err := fmt.Fprintf(w, "%s\n", cmd.BashCompletionFunction); err != nil {
+			return err
+		}
+	}
+	if err := gen(cmd, w); err != nil {
+		return err
+	}
+	return postscript(w, cmd.Name())
+}
+
+func (cmd *Command) GenBashCompletionFile(filename string) error {
+	outFile, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	return cmd.GenBashCompletion(outFile)
+}
+
+// MarkFlagRequired adds the BashCompOneRequiredFlag annotation to the named flag, if it exists.
+func (cmd *Command) MarkFlagRequired(name string) error {
+	return MarkFlagRequired(cmd.Flags(), name)
+}
+
+// MarkPersistentFlagRequired adds the BashCompOneRequiredFlag annotation to the named persistent flag, if it exists.
+func (cmd *Command) MarkPersistentFlagRequired(name string) error {
+	return MarkFlagRequired(cmd.PersistentFlags(), name)
+}
+
+// MarkFlagRequired adds the BashCompOneRequiredFlag annotation to the named flag in the flag set, if it exists.
+func MarkFlagRequired(flags *pflag.FlagSet, name string) error {
+	return flags.SetAnnotation(name, BashCompOneRequiredFlag, []string{"true"})
+}
+
+// MarkFlagFilename adds the BashCompFilenameExt annotation to the named flag, if it exists.
+// Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
+func (cmd *Command) MarkFlagFilename(name string, extensions ...string) error {
+	return MarkFlagFilename(cmd.Flags(), name, extensions...)
+}
+
+// MarkFlagCustom adds the BashCompCustom annotation to the named flag, if it exists.
+// Generated bash autocompletion will call the bash function f for the flag.
+func (cmd *Command) MarkFlagCustom(name string, f string) error {
+	return MarkFlagCustom(cmd.Flags(), name, f)
+}
+
+// MarkPersistentFlagFilename adds the BashCompFilenameExt annotation to the named persistent flag, if it exists.
+// Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
+func (cmd *Command) MarkPersistentFlagFilename(name string, extensions ...string) error {
+	return MarkFlagFilename(cmd.PersistentFlags(), name, extensions...)
+}
+
+// MarkFlagFilename adds the BashCompFilenameExt annotation to the named flag in the flag set, if it exists.
+// Generated bash autocompletion will select filenames for the flag, limiting to named extensions if provided.
+func MarkFlagFilename(flags *pflag.FlagSet, name string, extensions ...string) error {
+	return flags.SetAnnotation(name, BashCompFilenameExt, extensions)
+}
+
+// MarkFlagCustom adds the BashCompCustom annotation to the named flag in the flag set, if it exists.
+// Generated bash autocompletion will call the bash function f for the flag.
+func MarkFlagCustom(flags *pflag.FlagSet, name string, f string) error {
+	return flags.SetAnnotation(name, BashCompCustom, []string{f})
+}

--- a/vendor/github.com/spf13/cobra/cobra.go
+++ b/vendor/github.com/spf13/cobra/cobra.go
@@ -1,0 +1,175 @@
+// Copyright © 2013 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Commands similar to git, go tools and other modern CLI tools
+// inspired by go, go-Commander, gh and subcommand
+
+package cobra
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/template"
+	"unicode"
+)
+
+var templateFuncs = template.FuncMap{
+	"trim":               strings.TrimSpace,
+	"trimRightSpace":     trimRightSpace,
+	"appendIfNotPresent": appendIfNotPresent,
+	"rpad":               rpad,
+	"gt":                 Gt,
+	"eq":                 Eq,
+}
+
+var initializers []func()
+
+// automatic prefix matching can be a dangerous thing to automatically enable in CLI tools.
+// Set this to true to enable it
+var EnablePrefixMatching = false
+
+//EnableCommandSorting controls sorting of the slice of commands, which is turned on by default.
+//To disable sorting, set it to false.
+var EnableCommandSorting = true
+
+//AddTemplateFunc adds a template function that's available to Usage and Help
+//template generation.
+func AddTemplateFunc(name string, tmplFunc interface{}) {
+	templateFuncs[name] = tmplFunc
+}
+
+//AddTemplateFuncs adds multiple template functions availalble to Usage and
+//Help template generation.
+func AddTemplateFuncs(tmplFuncs template.FuncMap) {
+	for k, v := range tmplFuncs {
+		templateFuncs[k] = v
+	}
+}
+
+//OnInitialize takes a series of func() arguments and appends them to a slice of func().
+func OnInitialize(y ...func()) {
+	for _, x := range y {
+		initializers = append(initializers, x)
+	}
+}
+
+//Gt takes two types and checks whether the first type is greater than the second. In case of types Arrays, Chans,
+//Maps and Slices, Gt will compare their lengths. Ints are compared directly while strings are first parsed as
+//ints and then compared.
+func Gt(a interface{}, b interface{}) bool {
+	var left, right int64
+	av := reflect.ValueOf(a)
+
+	switch av.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		left = int64(av.Len())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		left = av.Int()
+	case reflect.String:
+		left, _ = strconv.ParseInt(av.String(), 10, 64)
+	}
+
+	bv := reflect.ValueOf(b)
+
+	switch bv.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		right = int64(bv.Len())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		right = bv.Int()
+	case reflect.String:
+		right, _ = strconv.ParseInt(bv.String(), 10, 64)
+	}
+
+	return left > right
+}
+
+//Eq takes two types and checks whether they are equal. Supported types are int and string. Unsupported types will panic.
+func Eq(a interface{}, b interface{}) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	switch av.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+		panic("Eq called on unsupported type")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return av.Int() == bv.Int()
+	case reflect.String:
+		return av.String() == bv.String()
+	}
+	return false
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// appendIfNotPresent will append stringToAppend to the end of s, but only if it's not yet present in s
+func appendIfNotPresent(s, stringToAppend string) string {
+	if strings.Contains(s, stringToAppend) {
+		return s
+	}
+	return s + " " + stringToAppend
+}
+
+//rpad adds padding to the right of a string
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+// tmpl executes the given template text on data, writing the result to w.
+func tmpl(w io.Writer, text string, data interface{}) error {
+	t := template.New("top")
+	t.Funcs(templateFuncs)
+	template.Must(t.Parse(text))
+	return t.Execute(w, data)
+}
+
+// ld compares two strings and returns the levenshtein distance between them
+func ld(s, t string, ignoreCase bool) int {
+	if ignoreCase {
+		s = strings.ToLower(s)
+		t = strings.ToLower(t)
+	}
+	d := make([][]int, len(s)+1)
+	for i := range d {
+		d[i] = make([]int, len(t)+1)
+	}
+	for i := range d {
+		d[i][0] = i
+	}
+	for j := range d[0] {
+		d[0][j] = j
+	}
+	for j := 1; j <= len(t); j++ {
+		for i := 1; i <= len(s); i++ {
+			if s[i-1] == t[j-1] {
+				d[i][j] = d[i-1][j-1]
+			} else {
+				min := d[i-1][j]
+				if d[i][j-1] < min {
+					min = d[i][j-1]
+				}
+				if d[i-1][j-1] < min {
+					min = d[i-1][j-1]
+				}
+				d[i][j] = min + 1
+			}
+		}
+
+	}
+	return d[len(s)][len(t)]
+}

--- a/vendor/github.com/spf13/cobra/command.go
+++ b/vendor/github.com/spf13/cobra/command.go
@@ -1,0 +1,1256 @@
+// Copyright © 2013 Steve Francia <spf@spf13.com>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//Package cobra is a commander providing a simple interface to create powerful modern CLI interfaces.
+//In addition to providing an interface, Cobra simultaneously provides a controller to organize your application code.
+package cobra
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+)
+
+// Command is just that, a command for your application.
+// eg.  'go run' ... 'run' is the command. Cobra requires
+// you to define the usage and description as part of your command
+// definition to ensure usability.
+type Command struct {
+	// Name is the command name, usually the executable's name.
+	name string
+	// The one-line usage message.
+	Use string
+	// An array of aliases that can be used instead of the first word in Use.
+	Aliases []string
+	// An array of command names for which this command will be suggested - similar to aliases but only suggests.
+	SuggestFor []string
+	// The short description shown in the 'help' output.
+	Short string
+	// The long message shown in the 'help <this-command>' output.
+	Long string
+	// Examples of how to use the command
+	Example string
+	// List of all valid non-flag arguments that are accepted in bash completions
+	ValidArgs []string
+	// List of aliases for ValidArgs. These are not suggested to the user in the bash
+	// completion, but accepted if entered manually.
+	ArgAliases []string
+	// Custom functions used by the bash autocompletion generator
+	BashCompletionFunction string
+	// Is this command deprecated and should print this string when used?
+	Deprecated string
+	// Is this command hidden and should NOT show up in the list of available commands?
+	Hidden bool
+	// Full set of flags
+	flags *flag.FlagSet
+	// Set of flags childrens of this command will inherit
+	pflags *flag.FlagSet
+	// Flags that are declared specifically by this command (not inherited).
+	lflags *flag.FlagSet
+	// SilenceErrors is an option to quiet errors down stream
+	SilenceErrors bool
+	// Silence Usage is an option to silence usage when an error occurs.
+	SilenceUsage bool
+	// The *Run functions are executed in the following order:
+	//   * PersistentPreRun()
+	//   * PreRun()
+	//   * Run()
+	//   * PostRun()
+	//   * PersistentPostRun()
+	// All functions get the same args, the arguments after the command name
+	// PersistentPreRun: children of this command will inherit and execute
+	PersistentPreRun func(cmd *Command, args []string)
+	// PersistentPreRunE: PersistentPreRun but returns an error
+	PersistentPreRunE func(cmd *Command, args []string) error
+	// PreRun: children of this command will not inherit.
+	PreRun func(cmd *Command, args []string)
+	// PreRunE: PreRun but returns an error
+	PreRunE func(cmd *Command, args []string) error
+	// Run: Typically the actual work function. Most commands will only implement this
+	Run func(cmd *Command, args []string)
+	// RunE: Run but returns an error
+	RunE func(cmd *Command, args []string) error
+	// PostRun: run after the Run command.
+	PostRun func(cmd *Command, args []string)
+	// PostRunE: PostRun but returns an error
+	PostRunE func(cmd *Command, args []string) error
+	// PersistentPostRun: children of this command will inherit and execute after PostRun
+	PersistentPostRun func(cmd *Command, args []string)
+	// PersistentPostRunE: PersistentPostRun but returns an error
+	PersistentPostRunE func(cmd *Command, args []string) error
+	// DisableAutoGenTag remove
+	DisableAutoGenTag bool
+	// Commands is the list of commands supported by this program.
+	commands []*Command
+	// Parent Command for this command
+	parent *Command
+	// max lengths of commands' string lengths for use in padding
+	commandsMaxUseLen         int
+	commandsMaxCommandPathLen int
+	commandsMaxNameLen        int
+	// is commands slice are sorted or not
+	commandsAreSorted bool
+
+	flagErrorBuf *bytes.Buffer
+
+	args          []string                 // actual args parsed from flags
+	output        *io.Writer               // nil means stderr; use Out() method instead
+	usageFunc     func(*Command) error     // Usage can be defined by application
+	usageTemplate string                   // Can be defined by Application
+	helpTemplate  string                   // Can be defined by Application
+	helpFunc      func(*Command, []string) // Help can be defined by application
+	helpCommand   *Command                 // The help command
+	// The global normalization function that we can use on every pFlag set and children commands
+	globNormFunc func(f *flag.FlagSet, name string) flag.NormalizedName
+
+	// Disable the suggestions based on Levenshtein distance that go along with 'unknown command' messages
+	DisableSuggestions bool
+	// If displaying suggestions, allows to set the minimum levenshtein distance to display, must be > 0
+	SuggestionsMinimumDistance int
+
+	// Disable the flag parsing. If this is true all flags will be passed to the command as arguments.
+	DisableFlagParsing bool
+}
+
+// os.Args[1:] by default, if desired, can be overridden
+// particularly useful when testing.
+func (c *Command) SetArgs(a []string) {
+	c.args = a
+}
+
+func (c *Command) getOut(def io.Writer) io.Writer {
+	if c.output != nil {
+		return *c.output
+	}
+
+	if c.HasParent() {
+		return c.parent.Out()
+	}
+	return def
+}
+
+func (c *Command) Out() io.Writer {
+	return c.getOut(os.Stderr)
+}
+
+func (c *Command) getOutOrStdout() io.Writer {
+	return c.getOut(os.Stdout)
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (c *Command) SetOutput(output io.Writer) {
+	c.output = &output
+}
+
+// Usage can be defined by application
+func (c *Command) SetUsageFunc(f func(*Command) error) {
+	c.usageFunc = f
+}
+
+// Can be defined by Application
+func (c *Command) SetUsageTemplate(s string) {
+	c.usageTemplate = s
+}
+
+// Can be defined by Application
+func (c *Command) SetHelpFunc(f func(*Command, []string)) {
+	c.helpFunc = f
+}
+
+func (c *Command) SetHelpCommand(cmd *Command) {
+	c.helpCommand = cmd
+}
+
+// Can be defined by Application
+func (c *Command) SetHelpTemplate(s string) {
+	c.helpTemplate = s
+}
+
+// SetGlobalNormalizationFunc sets a normalization function to all flag sets and also to child commands.
+// The user should not have a cyclic dependency on commands.
+func (c *Command) SetGlobalNormalizationFunc(n func(f *flag.FlagSet, name string) flag.NormalizedName) {
+	c.Flags().SetNormalizeFunc(n)
+	c.PersistentFlags().SetNormalizeFunc(n)
+	c.globNormFunc = n
+
+	for _, command := range c.commands {
+		command.SetGlobalNormalizationFunc(n)
+	}
+}
+
+func (c *Command) UsageFunc() (f func(*Command) error) {
+	if c.usageFunc != nil {
+		return c.usageFunc
+	}
+
+	if c.HasParent() {
+		return c.parent.UsageFunc()
+	}
+	return func(c *Command) error {
+		err := tmpl(c.Out(), c.UsageTemplate(), c)
+		if err != nil {
+			fmt.Print(err)
+		}
+		return err
+	}
+}
+
+// HelpFunc returns either the function set by SetHelpFunc for this command
+// or a parent, or it returns a function which calls c.Help()
+func (c *Command) HelpFunc() func(*Command, []string) {
+	cmd := c
+	for cmd != nil {
+		if cmd.helpFunc != nil {
+			return cmd.helpFunc
+		}
+		cmd = cmd.parent
+	}
+	return func(*Command, []string) {
+		err := c.Help()
+		if err != nil {
+			c.Println(err)
+		}
+	}
+}
+
+var minUsagePadding = 25
+
+func (c *Command) UsagePadding() int {
+	if c.parent == nil || minUsagePadding > c.parent.commandsMaxUseLen {
+		return minUsagePadding
+	}
+	return c.parent.commandsMaxUseLen
+}
+
+var minCommandPathPadding = 11
+
+//
+func (c *Command) CommandPathPadding() int {
+	if c.parent == nil || minCommandPathPadding > c.parent.commandsMaxCommandPathLen {
+		return minCommandPathPadding
+	}
+	return c.parent.commandsMaxCommandPathLen
+}
+
+var minNamePadding = 11
+
+func (c *Command) NamePadding() int {
+	if c.parent == nil || minNamePadding > c.parent.commandsMaxNameLen {
+		return minNamePadding
+	}
+	return c.parent.commandsMaxNameLen
+}
+
+func (c *Command) UsageTemplate() string {
+	if c.usageTemplate != "" {
+		return c.usageTemplate
+	}
+
+	if c.HasParent() {
+		return c.parent.UsageTemplate()
+	}
+	return `Usage:{{if .Runnable}}
+  {{if .HasAvailableFlags}}{{appendIfNotPresent .UseLine "[flags]"}}{{else}}{{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+  {{ .CommandPath}} [command]{{end}}{{if gt .Aliases 0}}
+
+Aliases:
+  {{.NameAndAliases}}
+{{end}}{{if .HasExample}}
+
+Examples:
+{{ .Example }}{{end}}{{ if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimRightSpace}}{{end}}{{ if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimRightSpace}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsHelpCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{ if .HasAvailableSubCommands }}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+}
+
+func (c *Command) HelpTemplate() string {
+	if c.helpTemplate != "" {
+		return c.helpTemplate
+	}
+
+	if c.HasParent() {
+		return c.parent.HelpTemplate()
+	}
+	return `{{with or .Long .Short }}{{. | trim}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+}
+
+// Really only used when casting a command to a commander
+func (c *Command) resetChildrensParents() {
+	for _, x := range c.commands {
+		x.parent = c
+	}
+}
+
+// Test if the named flag is a boolean flag.
+func isBooleanFlag(name string, f *flag.FlagSet) bool {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return false
+	}
+	return flag.Value.Type() == "bool"
+}
+
+// Test if the named flag is a boolean flag.
+func isBooleanShortFlag(name string, f *flag.FlagSet) bool {
+	result := false
+	f.VisitAll(func(f *flag.Flag) {
+		if f.Shorthand == name && f.Value.Type() == "bool" {
+			result = true
+		}
+	})
+	return result
+}
+
+func stripFlags(args []string, c *Command) []string {
+	if len(args) < 1 {
+		return args
+	}
+	c.mergePersistentFlags()
+
+	commands := []string{}
+
+	inQuote := false
+	inFlag := false
+	for _, y := range args {
+		if !inQuote {
+			switch {
+			case strings.HasPrefix(y, "\""):
+				inQuote = true
+			case strings.Contains(y, "=\""):
+				inQuote = true
+			case strings.HasPrefix(y, "--") && !strings.Contains(y, "="):
+				// TODO: this isn't quite right, we should really check ahead for 'true' or 'false'
+				inFlag = !isBooleanFlag(y[2:], c.Flags())
+			case strings.HasPrefix(y, "-") && !strings.Contains(y, "=") && len(y) == 2 && !isBooleanShortFlag(y[1:], c.Flags()):
+				inFlag = true
+			case inFlag:
+				inFlag = false
+			case y == "":
+				// strip empty commands, as the go tests expect this to be ok....
+			case !strings.HasPrefix(y, "-"):
+				commands = append(commands, y)
+				inFlag = false
+			}
+		}
+
+		if strings.HasSuffix(y, "\"") && !strings.HasSuffix(y, "\\\"") {
+			inQuote = false
+		}
+	}
+
+	return commands
+}
+
+// argsMinusFirstX removes only the first x from args.  Otherwise, commands that look like
+// openshift admin policy add-role-to-user admin my-user, lose the admin argument (arg[4]).
+func argsMinusFirstX(args []string, x string) []string {
+	for i, y := range args {
+		if x == y {
+			ret := []string{}
+			ret = append(ret, args[:i]...)
+			ret = append(ret, args[i+1:]...)
+			return ret
+		}
+	}
+	return args
+}
+
+// find the target command given the args and command tree
+// Meant to be run on the highest node. Only searches down.
+func (c *Command) Find(args []string) (*Command, []string, error) {
+	if c == nil {
+		return nil, nil, fmt.Errorf("Called find() on a nil Command")
+	}
+
+	var innerfind func(*Command, []string) (*Command, []string)
+
+	innerfind = func(c *Command, innerArgs []string) (*Command, []string) {
+		argsWOflags := stripFlags(innerArgs, c)
+		if len(argsWOflags) == 0 {
+			return c, innerArgs
+		}
+		nextSubCmd := argsWOflags[0]
+		matches := make([]*Command, 0)
+		for _, cmd := range c.commands {
+			if cmd.Name() == nextSubCmd || cmd.HasAlias(nextSubCmd) { // exact name or alias match
+				return innerfind(cmd, argsMinusFirstX(innerArgs, nextSubCmd))
+			}
+			if EnablePrefixMatching {
+				if strings.HasPrefix(cmd.Name(), nextSubCmd) { // prefix match
+					matches = append(matches, cmd)
+				}
+				for _, x := range cmd.Aliases {
+					if strings.HasPrefix(x, nextSubCmd) {
+						matches = append(matches, cmd)
+					}
+				}
+			}
+		}
+
+		// only accept a single prefix match - multiple matches would be ambiguous
+		if len(matches) == 1 {
+			return innerfind(matches[0], argsMinusFirstX(innerArgs, argsWOflags[0]))
+		}
+
+		return c, innerArgs
+	}
+
+	commandFound, a := innerfind(c, args)
+	argsWOflags := stripFlags(a, commandFound)
+
+	// no subcommand, always take args
+	if !commandFound.HasSubCommands() {
+		return commandFound, a, nil
+	}
+
+	// root command with subcommands, do subcommand checking
+	if commandFound == c && len(argsWOflags) > 0 {
+		suggestionsString := ""
+		if !c.DisableSuggestions {
+			if c.SuggestionsMinimumDistance <= 0 {
+				c.SuggestionsMinimumDistance = 2
+			}
+			if suggestions := c.SuggestionsFor(argsWOflags[0]); len(suggestions) > 0 {
+				suggestionsString += "\n\nDid you mean this?\n"
+				for _, s := range suggestions {
+					suggestionsString += fmt.Sprintf("\t%v\n", s)
+				}
+			}
+		}
+		return commandFound, a, fmt.Errorf("unknown command %q for %q%s", argsWOflags[0], commandFound.CommandPath(), suggestionsString)
+	}
+
+	return commandFound, a, nil
+}
+
+func (c *Command) SuggestionsFor(typedName string) []string {
+	suggestions := []string{}
+	for _, cmd := range c.commands {
+		if cmd.IsAvailableCommand() {
+			levenshteinDistance := ld(typedName, cmd.Name(), true)
+			suggestByLevenshtein := levenshteinDistance <= c.SuggestionsMinimumDistance
+			suggestByPrefix := strings.HasPrefix(strings.ToLower(cmd.Name()), strings.ToLower(typedName))
+			if suggestByLevenshtein || suggestByPrefix {
+				suggestions = append(suggestions, cmd.Name())
+			}
+			for _, explicitSuggestion := range cmd.SuggestFor {
+				if strings.EqualFold(typedName, explicitSuggestion) {
+					suggestions = append(suggestions, cmd.Name())
+				}
+			}
+		}
+	}
+	return suggestions
+}
+
+func (c *Command) VisitParents(fn func(*Command)) {
+	var traverse func(*Command) *Command
+
+	traverse = func(x *Command) *Command {
+		if x != c {
+			fn(x)
+		}
+		if x.HasParent() {
+			return traverse(x.parent)
+		}
+		return x
+	}
+	traverse(c)
+}
+
+func (c *Command) Root() *Command {
+	var findRoot func(*Command) *Command
+
+	findRoot = func(x *Command) *Command {
+		if x.HasParent() {
+			return findRoot(x.parent)
+		}
+		return x
+	}
+
+	return findRoot(c)
+}
+
+// ArgsLenAtDash will return the length of f.Args at the moment when a -- was
+// found during arg parsing. This allows your program to know which args were
+// before the -- and which came after. (Description from
+// https://godoc.org/github.com/spf13/pflag#FlagSet.ArgsLenAtDash).
+func (c *Command) ArgsLenAtDash() int {
+	return c.Flags().ArgsLenAtDash()
+}
+
+func (c *Command) execute(a []string) (err error) {
+	if c == nil {
+		return fmt.Errorf("Called Execute() on a nil Command")
+	}
+
+	if len(c.Deprecated) > 0 {
+		c.Printf("Command %q is deprecated, %s\n", c.Name(), c.Deprecated)
+	}
+
+	// initialize help flag as the last point possible to allow for user
+	// overriding
+	c.initHelpFlag()
+
+	err = c.ParseFlags(a)
+	if err != nil {
+		return err
+	}
+	// If help is called, regardless of other flags, return we want help
+	// Also say we need help if the command isn't runnable.
+	helpVal, err := c.Flags().GetBool("help")
+	if err != nil {
+		// should be impossible to get here as we always declare a help
+		// flag in initHelpFlag()
+		c.Println("\"help\" flag declared as non-bool. Please correct your code")
+		return err
+	}
+	if helpVal || !c.Runnable() {
+		return flag.ErrHelp
+	}
+
+	c.preRun()
+
+	argWoFlags := c.Flags().Args()
+	if c.DisableFlagParsing {
+		argWoFlags = a
+	}
+
+	for p := c; p != nil; p = p.Parent() {
+		if p.PersistentPreRunE != nil {
+			if err := p.PersistentPreRunE(c, argWoFlags); err != nil {
+				return err
+			}
+			break
+		} else if p.PersistentPreRun != nil {
+			p.PersistentPreRun(c, argWoFlags)
+			break
+		}
+	}
+	if c.PreRunE != nil {
+		if err := c.PreRunE(c, argWoFlags); err != nil {
+			return err
+		}
+	} else if c.PreRun != nil {
+		c.PreRun(c, argWoFlags)
+	}
+
+	if c.RunE != nil {
+		if err := c.RunE(c, argWoFlags); err != nil {
+			return err
+		}
+	} else {
+		c.Run(c, argWoFlags)
+	}
+	if c.PostRunE != nil {
+		if err := c.PostRunE(c, argWoFlags); err != nil {
+			return err
+		}
+	} else if c.PostRun != nil {
+		c.PostRun(c, argWoFlags)
+	}
+	for p := c; p != nil; p = p.Parent() {
+		if p.PersistentPostRunE != nil {
+			if err := p.PersistentPostRunE(c, argWoFlags); err != nil {
+				return err
+			}
+			break
+		} else if p.PersistentPostRun != nil {
+			p.PersistentPostRun(c, argWoFlags)
+			break
+		}
+	}
+
+	return nil
+}
+
+func (c *Command) preRun() {
+	for _, x := range initializers {
+		x()
+	}
+}
+
+func (c *Command) errorMsgFromParse() string {
+	s := c.flagErrorBuf.String()
+
+	x := strings.Split(s, "\n")
+
+	if len(x) > 0 {
+		return x[0]
+	}
+	return ""
+}
+
+// Call execute to use the args (os.Args[1:] by default)
+// and run through the command tree finding appropriate matches
+// for commands and then corresponding flags.
+func (c *Command) Execute() error {
+	_, err := c.ExecuteC()
+	return err
+}
+
+func (c *Command) ExecuteC() (cmd *Command, err error) {
+
+	// Regardless of what command execute is called on, run on Root only
+	if c.HasParent() {
+		return c.Root().ExecuteC()
+	}
+
+	// windows hook
+	if preExecHookFn != nil {
+		preExecHookFn(c)
+	}
+
+	// initialize help as the last point possible to allow for user
+	// overriding
+	c.initHelpCmd()
+
+	var args []string
+
+	// Workaround FAIL with "go test -v" or "cobra.test -test.v", see #155
+	if c.args == nil && filepath.Base(os.Args[0]) != "cobra.test" {
+		args = os.Args[1:]
+	} else {
+		args = c.args
+	}
+
+	cmd, flags, err := c.Find(args)
+	if err != nil {
+		// If found parse to a subcommand and then failed, talk about the subcommand
+		if cmd != nil {
+			c = cmd
+		}
+		if !c.SilenceErrors {
+			c.Println("Error:", err.Error())
+			c.Printf("Run '%v --help' for usage.\n", c.CommandPath())
+		}
+		return c, err
+	}
+	err = cmd.execute(flags)
+	if err != nil {
+		// Always show help if requested, even if SilenceErrors is in
+		// effect
+		if err == flag.ErrHelp {
+			cmd.HelpFunc()(cmd, args)
+			return cmd, nil
+		}
+
+		// If root command has SilentErrors flagged,
+		// all subcommands should respect it
+		if !cmd.SilenceErrors && !c.SilenceErrors {
+			c.Println("Error:", err.Error())
+		}
+
+		// If root command has SilentUsage flagged,
+		// all subcommands should respect it
+		if !cmd.SilenceUsage && !c.SilenceUsage {
+			c.Println(cmd.UsageString())
+		}
+		return cmd, err
+	}
+	return cmd, nil
+}
+
+func (c *Command) initHelpFlag() {
+	if c.Flags().Lookup("help") == nil {
+		c.Flags().BoolP("help", "h", false, "help for "+c.Name())
+	}
+}
+
+func (c *Command) initHelpCmd() {
+	if c.helpCommand == nil {
+		if !c.HasSubCommands() {
+			return
+		}
+
+		c.helpCommand = &Command{
+			Use:   "help [command]",
+			Short: "Help about any command",
+			Long: `Help provides help for any command in the application.
+    Simply type ` + c.Name() + ` help [path to command] for full details.`,
+			PersistentPreRun:  func(cmd *Command, args []string) {},
+			PersistentPostRun: func(cmd *Command, args []string) {},
+
+			Run: func(c *Command, args []string) {
+				cmd, _, e := c.Root().Find(args)
+				if cmd == nil || e != nil {
+					c.Printf("Unknown help topic %#q.", args)
+					c.Root().Usage()
+				} else {
+					helpFunc := cmd.HelpFunc()
+					helpFunc(cmd, args)
+				}
+			},
+		}
+	}
+	c.AddCommand(c.helpCommand)
+}
+
+// Used for testing
+func (c *Command) ResetCommands() {
+	c.commands = nil
+	c.helpCommand = nil
+}
+
+// Sorts commands by their names
+type commandSorterByName []*Command
+
+func (c commandSorterByName) Len() int           { return len(c) }
+func (c commandSorterByName) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c commandSorterByName) Less(i, j int) bool { return c[i].Name() < c[j].Name() }
+
+// Commands returns a sorted slice of child commands.
+func (c *Command) Commands() []*Command {
+	// do not sort commands if it already sorted or sorting was disabled
+	if EnableCommandSorting && !c.commandsAreSorted{
+		sort.Sort(commandSorterByName(c.commands))
+		c.commandsAreSorted = true
+	}
+	return c.commands
+}
+
+// AddCommand adds one or more commands to this parent command.
+func (c *Command) AddCommand(cmds ...*Command) {
+	for i, x := range cmds {
+		if cmds[i] == c {
+			panic("Command can't be a child of itself")
+		}
+		cmds[i].parent = c
+		// update max lengths
+		usageLen := len(x.Use)
+		if usageLen > c.commandsMaxUseLen {
+			c.commandsMaxUseLen = usageLen
+		}
+		commandPathLen := len(x.CommandPath())
+		if commandPathLen > c.commandsMaxCommandPathLen {
+			c.commandsMaxCommandPathLen = commandPathLen
+		}
+		nameLen := len(x.Name())
+		if nameLen > c.commandsMaxNameLen {
+			c.commandsMaxNameLen = nameLen
+		}
+		// If global normalization function exists, update all children
+		if c.globNormFunc != nil {
+			x.SetGlobalNormalizationFunc(c.globNormFunc)
+		}
+		c.commands = append(c.commands, x)
+		c.commandsAreSorted = false
+	}
+}
+
+// RemoveCommand removes one or more commands from a parent command.
+func (c *Command) RemoveCommand(cmds ...*Command) {
+	commands := []*Command{}
+main:
+	for _, command := range c.commands {
+		for _, cmd := range cmds {
+			if command == cmd {
+				command.parent = nil
+				continue main
+			}
+		}
+		commands = append(commands, command)
+	}
+	c.commands = commands
+	// recompute all lengths
+	c.commandsMaxUseLen = 0
+	c.commandsMaxCommandPathLen = 0
+	c.commandsMaxNameLen = 0
+	for _, command := range c.commands {
+		usageLen := len(command.Use)
+		if usageLen > c.commandsMaxUseLen {
+			c.commandsMaxUseLen = usageLen
+		}
+		commandPathLen := len(command.CommandPath())
+		if commandPathLen > c.commandsMaxCommandPathLen {
+			c.commandsMaxCommandPathLen = commandPathLen
+		}
+		nameLen := len(command.Name())
+		if nameLen > c.commandsMaxNameLen {
+			c.commandsMaxNameLen = nameLen
+		}
+	}
+}
+
+// Print is a convenience method to Print to the defined output
+func (c *Command) Print(i ...interface{}) {
+	fmt.Fprint(c.Out(), i...)
+}
+
+// Println is a convenience method to Println to the defined output
+func (c *Command) Println(i ...interface{}) {
+	str := fmt.Sprintln(i...)
+	c.Print(str)
+}
+
+// Printf is a convenience method to Printf to the defined output
+func (c *Command) Printf(format string, i ...interface{}) {
+	str := fmt.Sprintf(format, i...)
+	c.Print(str)
+}
+
+// Output the usage for the command
+// Used when a user provides invalid input
+// Can be defined by user by overriding UsageFunc
+func (c *Command) Usage() error {
+	c.mergePersistentFlags()
+	err := c.UsageFunc()(c)
+	return err
+}
+
+// Output the help for the command
+// Used when a user calls help [command]
+// by the default HelpFunc in the commander
+func (c *Command) Help() error {
+	c.mergePersistentFlags()
+	err := tmpl(c.getOutOrStdout(), c.HelpTemplate(), c)
+	return err
+}
+
+func (c *Command) UsageString() string {
+	tmpOutput := c.output
+	bb := new(bytes.Buffer)
+	c.SetOutput(bb)
+	c.Usage()
+	c.output = tmpOutput
+	return bb.String()
+}
+
+// CommandPath returns the full path to this command.
+func (c *Command) CommandPath() string {
+	str := c.Name()
+	x := c
+	for x.HasParent() {
+		str = x.parent.Name() + " " + str
+		x = x.parent
+	}
+	return str
+}
+
+//The full usage for a given command (including parents)
+func (c *Command) UseLine() string {
+	str := ""
+	if c.HasParent() {
+		str = c.parent.CommandPath() + " "
+	}
+	return str + c.Use
+}
+
+// For use in determining which flags have been assigned to which commands
+// and which persist
+func (c *Command) DebugFlags() {
+	c.Println("DebugFlags called on", c.Name())
+	var debugflags func(*Command)
+
+	debugflags = func(x *Command) {
+		if x.HasFlags() || x.HasPersistentFlags() {
+			c.Println(x.Name())
+		}
+		if x.HasFlags() {
+			x.flags.VisitAll(func(f *flag.Flag) {
+				if x.HasPersistentFlags() {
+					if x.persistentFlag(f.Name) == nil {
+						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+					} else {
+						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [LP]")
+					}
+				} else {
+					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [L]")
+				}
+			})
+		}
+		if x.HasPersistentFlags() {
+			x.pflags.VisitAll(func(f *flag.Flag) {
+				if x.HasFlags() {
+					if x.flags.Lookup(f.Name) == nil {
+						c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+					}
+				} else {
+					c.Println("  -"+f.Shorthand+",", "--"+f.Name, "["+f.DefValue+"]", "", f.Value, "  [P]")
+				}
+			})
+		}
+		c.Println(x.flagErrorBuf)
+		if x.HasSubCommands() {
+			for _, y := range x.commands {
+				debugflags(y)
+			}
+		}
+	}
+
+	debugflags(c)
+}
+
+// Name returns the command's name: the first word in the use line.
+func (c *Command) Name() string {
+	if c.name != "" {
+		return c.name
+	}
+	name := c.Use
+	i := strings.Index(name, " ")
+	if i >= 0 {
+		name = name[:i]
+	}
+	return name
+}
+
+// HasAlias determines if a given string is an alias of the command.
+func (c *Command) HasAlias(s string) bool {
+	for _, a := range c.Aliases {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Command) NameAndAliases() string {
+	return strings.Join(append([]string{c.Name()}, c.Aliases...), ", ")
+}
+
+func (c *Command) HasExample() bool {
+	return len(c.Example) > 0
+}
+
+// Runnable determines if the command is itself runnable
+func (c *Command) Runnable() bool {
+	return c.Run != nil || c.RunE != nil
+}
+
+// HasSubCommands determines if the command has children commands
+func (c *Command) HasSubCommands() bool {
+	return len(c.commands) > 0
+}
+
+// IsAvailableCommand determines if a command is available as a non-help command
+// (this includes all non deprecated/hidden commands)
+func (c *Command) IsAvailableCommand() bool {
+	if len(c.Deprecated) != 0 || c.Hidden {
+		return false
+	}
+
+	if c.HasParent() && c.Parent().helpCommand == c {
+		return false
+	}
+
+	if c.Runnable() || c.HasAvailableSubCommands() {
+		return true
+	}
+
+	return false
+}
+
+// IsHelpCommand determines if a command is a 'help' command; a help command is
+// determined by the fact that it is NOT runnable/hidden/deprecated, and has no
+// sub commands that are runnable/hidden/deprecated
+func (c *Command) IsHelpCommand() bool {
+
+	// if a command is runnable, deprecated, or hidden it is not a 'help' command
+	if c.Runnable() || len(c.Deprecated) != 0 || c.Hidden {
+		return false
+	}
+
+	// if any non-help sub commands are found, the command is not a 'help' command
+	for _, sub := range c.commands {
+		if !sub.IsHelpCommand() {
+			return false
+		}
+	}
+
+	// the command either has no sub commands, or no non-help sub commands
+	return true
+}
+
+// HasHelpSubCommands determines if a command has any avilable 'help' sub commands
+// that need to be shown in the usage/help default template under 'additional help
+// topics'
+func (c *Command) HasHelpSubCommands() bool {
+
+	// return true on the first found available 'help' sub command
+	for _, sub := range c.commands {
+		if sub.IsHelpCommand() {
+			return true
+		}
+	}
+
+	// the command either has no sub commands, or no available 'help' sub commands
+	return false
+}
+
+// HasAvailableSubCommands determines if a command has available sub commands that
+// need to be shown in the usage/help default template under 'available commands'
+func (c *Command) HasAvailableSubCommands() bool {
+
+	// return true on the first found available (non deprecated/help/hidden)
+	// sub command
+	for _, sub := range c.commands {
+		if sub.IsAvailableCommand() {
+			return true
+		}
+	}
+
+	// the command either has no sub comamnds, or no available (non deprecated/help/hidden)
+	// sub commands
+	return false
+}
+
+// Determine if the command is a child command
+func (c *Command) HasParent() bool {
+	return c.parent != nil
+}
+
+// GlobalNormalizationFunc returns the global normalization function or nil if doesn't exists
+func (c *Command) GlobalNormalizationFunc() func(f *flag.FlagSet, name string) flag.NormalizedName {
+	return c.globNormFunc
+}
+
+// Get the complete FlagSet that applies to this command (local and persistent declared here and by all parents)
+func (c *Command) Flags() *flag.FlagSet {
+	if c.flags == nil {
+		c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.flags.SetOutput(c.flagErrorBuf)
+	}
+	return c.flags
+}
+
+// LocalNonPersistentFlags are flags specific to this command which will NOT persist to subcommands
+func (c *Command) LocalNonPersistentFlags() *flag.FlagSet {
+	persistentFlags := c.PersistentFlags()
+
+	out := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.LocalFlags().VisitAll(func(f *flag.Flag) {
+		if persistentFlags.Lookup(f.Name) == nil {
+			out.AddFlag(f)
+		}
+	})
+	return out
+}
+
+// Get the local FlagSet specifically set in the current command
+func (c *Command) LocalFlags() *flag.FlagSet {
+	c.mergePersistentFlags()
+
+	local := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.lflags.VisitAll(func(f *flag.Flag) {
+		local.AddFlag(f)
+	})
+	if !c.HasParent() {
+		flag.CommandLine.VisitAll(func(f *flag.Flag) {
+			if local.Lookup(f.Name) == nil {
+				local.AddFlag(f)
+			}
+		})
+	}
+	return local
+}
+
+// All Flags which were inherited from parents commands
+func (c *Command) InheritedFlags() *flag.FlagSet {
+	c.mergePersistentFlags()
+
+	inherited := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	local := c.LocalFlags()
+
+	var rmerge func(x *Command)
+
+	rmerge = func(x *Command) {
+		if x.HasPersistentFlags() {
+			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
+				if inherited.Lookup(f.Name) == nil && local.Lookup(f.Name) == nil {
+					inherited.AddFlag(f)
+				}
+			})
+		}
+		if x.HasParent() {
+			rmerge(x.parent)
+		}
+	}
+
+	if c.HasParent() {
+		rmerge(c.parent)
+	}
+
+	return inherited
+}
+
+// All Flags which were not inherited from parent commands
+func (c *Command) NonInheritedFlags() *flag.FlagSet {
+	return c.LocalFlags()
+}
+
+// Get the Persistent FlagSet specifically set in the current command
+func (c *Command) PersistentFlags() *flag.FlagSet {
+	if c.pflags == nil {
+		c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.pflags.SetOutput(c.flagErrorBuf)
+	}
+	return c.pflags
+}
+
+// For use in testing
+func (c *Command) ResetFlags() {
+	c.flagErrorBuf = new(bytes.Buffer)
+	c.flagErrorBuf.Reset()
+	c.flags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.flags.SetOutput(c.flagErrorBuf)
+	c.pflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	c.pflags.SetOutput(c.flagErrorBuf)
+}
+
+// Does the command contain any flags (local plus persistent from the entire structure)
+func (c *Command) HasFlags() bool {
+	return c.Flags().HasFlags()
+}
+
+// Does the command contain persistent flags
+func (c *Command) HasPersistentFlags() bool {
+	return c.PersistentFlags().HasFlags()
+}
+
+// Does the command has flags specifically declared locally
+func (c *Command) HasLocalFlags() bool {
+	return c.LocalFlags().HasFlags()
+}
+
+// Does the command have flags inherited from its parent command
+func (c *Command) HasInheritedFlags() bool {
+	return c.InheritedFlags().HasFlags()
+}
+
+// Does the command contain any flags (local plus persistent from the entire
+// structure) which are not hidden or deprecated
+func (c *Command) HasAvailableFlags() bool {
+	return c.Flags().HasAvailableFlags()
+}
+
+// Does the command contain persistent flags which are not hidden or deprecated
+func (c *Command) HasAvailablePersistentFlags() bool {
+	return c.PersistentFlags().HasAvailableFlags()
+}
+
+// Does the command has flags specifically declared locally which are not hidden
+// or deprecated
+func (c *Command) HasAvailableLocalFlags() bool {
+	return c.LocalFlags().HasAvailableFlags()
+}
+
+// Does the command have flags inherited from its parent command which are
+// not hidden or deprecated
+func (c *Command) HasAvailableInheritedFlags() bool {
+	return c.InheritedFlags().HasAvailableFlags()
+}
+
+// Flag climbs up the command tree looking for matching flag
+func (c *Command) Flag(name string) (flag *flag.Flag) {
+	flag = c.Flags().Lookup(name)
+
+	if flag == nil {
+		flag = c.persistentFlag(name)
+	}
+
+	return
+}
+
+// recursively find matching persistent flag
+func (c *Command) persistentFlag(name string) (flag *flag.Flag) {
+	if c.HasPersistentFlags() {
+		flag = c.PersistentFlags().Lookup(name)
+	}
+
+	if flag == nil && c.HasParent() {
+		flag = c.parent.persistentFlag(name)
+	}
+	return
+}
+
+// ParseFlags parses persistent flag tree & local flags
+func (c *Command) ParseFlags(args []string) (err error) {
+	if c.DisableFlagParsing {
+		return nil
+	}
+	c.mergePersistentFlags()
+	err = c.Flags().Parse(args)
+	return
+}
+
+// Parent returns a commands parent command
+func (c *Command) Parent() *Command {
+	return c.parent
+}
+
+func (c *Command) mergePersistentFlags() {
+	var rmerge func(x *Command)
+
+	// Save the set of local flags
+	if c.lflags == nil {
+		c.lflags = flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+		if c.flagErrorBuf == nil {
+			c.flagErrorBuf = new(bytes.Buffer)
+		}
+		c.lflags.SetOutput(c.flagErrorBuf)
+		addtolocal := func(f *flag.Flag) {
+			c.lflags.AddFlag(f)
+		}
+		c.Flags().VisitAll(addtolocal)
+		c.PersistentFlags().VisitAll(addtolocal)
+	}
+	rmerge = func(x *Command) {
+		if !x.HasParent() {
+			flag.CommandLine.VisitAll(func(f *flag.Flag) {
+				if x.PersistentFlags().Lookup(f.Name) == nil {
+					x.PersistentFlags().AddFlag(f)
+				}
+			})
+		}
+		if x.HasPersistentFlags() {
+			x.PersistentFlags().VisitAll(func(f *flag.Flag) {
+				if c.Flags().Lookup(f.Name) == nil {
+					c.Flags().AddFlag(f)
+				}
+			})
+		}
+		if x.HasParent() {
+			rmerge(x.parent)
+		}
+	}
+
+	rmerge(c)
+}

--- a/vendor/github.com/spf13/cobra/command_notwin.go
+++ b/vendor/github.com/spf13/cobra/command_notwin.go
@@ -1,0 +1,5 @@
+// +build !windows
+
+package cobra
+
+var preExecHookFn func(*Command)

--- a/vendor/github.com/spf13/cobra/command_win.go
+++ b/vendor/github.com/spf13/cobra/command_win.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package cobra
+
+import (
+	"os"
+	"time"
+
+	"github.com/inconshreveable/mousetrap"
+)
+
+var preExecHookFn = preExecHook
+
+// enables an information splash screen on Windows if the CLI is started from explorer.exe.
+var MousetrapHelpText string = `This is a command line tool
+
+You need to open cmd.exe and run it from there.
+`
+
+func preExecHook(c *Command) {
+	if mousetrap.StartedByExplorer() {
+		c.Print(MousetrapHelpText)
+		time.Sleep(5 * time.Second)
+		os.Exit(1)
+	}
+}

--- a/vendor/github.com/spf13/pflag/LICENSE
+++ b/vendor/github.com/spf13/pflag/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/spf13/pflag/bool.go
+++ b/vendor/github.com/spf13/pflag/bool.go
@@ -1,0 +1,97 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// optional interface to indicate boolean flags that can be
+// supplied without "=value" text
+type boolFlag interface {
+	Value
+	IsBoolFlag() bool
+}
+
+// -- bool Value
+type boolValue bool
+
+func newBoolValue(val bool, p *bool) *boolValue {
+	*p = val
+	return (*boolValue)(p)
+}
+
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b = boolValue(v)
+	return err
+}
+
+func (b *boolValue) Type() string {
+	return "bool"
+}
+
+func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+
+func (b *boolValue) IsBoolFlag() bool { return true }
+
+func boolConv(sval string) (interface{}, error) {
+	return strconv.ParseBool(sval)
+}
+
+// GetBool return the bool value of a flag with the given name
+func (f *FlagSet) GetBool(name string) (bool, error) {
+	val, err := f.getFlagType(name, "bool", boolConv)
+	if err != nil {
+		return false, err
+	}
+	return val.(bool), nil
+}
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
+	f.BoolVarP(p, name, "", value, usage)
+}
+
+// BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
+	flag := f.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag.NoOptDefVal = "true"
+}
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func BoolVar(p *bool, name string, value bool, usage string) {
+	BoolVarP(p, name, "", value, usage)
+}
+
+// BoolVarP is like BoolVar, but accepts a shorthand letter that can be used after a single dash.
+func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
+	flag := CommandLine.VarPF(newBoolValue(value, p), name, shorthand, usage)
+	flag.NoOptDefVal = "true"
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
+	return f.BoolP(name, "", value, usage)
+}
+
+// BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func Bool(name string, value bool, usage string) *bool {
+	return BoolP(name, "", value, usage)
+}
+
+// BoolP is like Bool, but accepts a shorthand letter that can be used after a single dash.
+func BoolP(name, shorthand string, value bool, usage string) *bool {
+	b := CommandLine.BoolP(name, shorthand, value, usage)
+	return b
+}

--- a/vendor/github.com/spf13/pflag/count.go
+++ b/vendor/github.com/spf13/pflag/count.go
@@ -1,0 +1,97 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- count Value
+type countValue int
+
+func newCountValue(val int, p *int) *countValue {
+	*p = val
+	return (*countValue)(p)
+}
+
+func (i *countValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	// -1 means that no specific value was passed, so increment
+	if v == -1 {
+		*i = countValue(*i + 1)
+	} else {
+		*i = countValue(v)
+	}
+	return err
+}
+
+func (i *countValue) Type() string {
+	return "count"
+}
+
+func (i *countValue) String() string { return fmt.Sprintf("%v", *i) }
+
+func countConv(sval string) (interface{}, error) {
+	i, err := strconv.Atoi(sval)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// GetCount return the int value of a flag with the given name
+func (f *FlagSet) GetCount(name string) (int, error) {
+	val, err := f.getFlagType(name, "count", countConv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(int), nil
+}
+
+// CountVar defines a count flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+// A count flag will add 1 to its value evey time it is found on the command line
+func (f *FlagSet) CountVar(p *int, name string, usage string) {
+	f.CountVarP(p, name, "", usage)
+}
+
+// CountVarP is like CountVar only take a shorthand for the flag name.
+func (f *FlagSet) CountVarP(p *int, name, shorthand string, usage string) {
+	flag := f.VarPF(newCountValue(0, p), name, shorthand, usage)
+	flag.NoOptDefVal = "-1"
+}
+
+// CountVar like CountVar only the flag is placed on the CommandLine instead of a given flag set
+func CountVar(p *int, name string, usage string) {
+	CommandLine.CountVar(p, name, usage)
+}
+
+// CountVarP is like CountVar only take a shorthand for the flag name.
+func CountVarP(p *int, name, shorthand string, usage string) {
+	CommandLine.CountVarP(p, name, shorthand, usage)
+}
+
+// Count defines a count flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+// A count flag will add 1 to its value evey time it is found on the command line
+func (f *FlagSet) Count(name string, usage string) *int {
+	p := new(int)
+	f.CountVarP(p, name, "", usage)
+	return p
+}
+
+// CountP is like Count only takes a shorthand for the flag name.
+func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
+	p := new(int)
+	f.CountVarP(p, name, shorthand, usage)
+	return p
+}
+
+// Count like Count only the flag is placed on the CommandLine isntead of a given flag set
+func Count(name string, usage string) *int {
+	return CommandLine.CountP(name, "", usage)
+}
+
+// CountP is like Count only takes a shorthand for the flag name.
+func CountP(name, shorthand string, usage string) *int {
+	return CommandLine.CountP(name, shorthand, usage)
+}

--- a/vendor/github.com/spf13/pflag/duration.go
+++ b/vendor/github.com/spf13/pflag/duration.go
@@ -1,0 +1,86 @@
+package pflag
+
+import (
+	"time"
+)
+
+// -- time.Duration Value
+type durationValue time.Duration
+
+func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+	*p = val
+	return (*durationValue)(p)
+}
+
+func (d *durationValue) Set(s string) error {
+	v, err := time.ParseDuration(s)
+	*d = durationValue(v)
+	return err
+}
+
+func (d *durationValue) Type() string {
+	return "duration"
+}
+
+func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+
+func durationConv(sval string) (interface{}, error) {
+	return time.ParseDuration(sval)
+}
+
+// GetDuration return the duration value of a flag with the given name
+func (f *FlagSet) GetDuration(name string) (time.Duration, error) {
+	val, err := f.getFlagType(name, "duration", durationConv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(time.Duration), nil
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	f.VarP(newDurationValue(value, p), name, "", usage)
+}
+
+// DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
+	f.VarP(newDurationValue(value, p), name, shorthand, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	CommandLine.VarP(newDurationValue(value, p), name, "", usage)
+}
+
+// DurationVarP is like DurationVar, but accepts a shorthand letter that can be used after a single dash.
+func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
+	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func (f *FlagSet) Duration(name string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVarP(p, name, "", value, usage)
+	return p
+}
+
+// DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func Duration(name string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.DurationP(name, "", value, usage)
+}
+
+// DurationP is like Duration, but accepts a shorthand letter that can be used after a single dash.
+func DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.DurationP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/flag.go
+++ b/vendor/github.com/spf13/pflag/flag.go
@@ -1,0 +1,934 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package pflag is a drop-in replacement for Go's flag package, implementing
+POSIX/GNU-style --flags.
+
+pflag is compatible with the GNU extensions to the POSIX recommendations
+for command-line options. See
+http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Usage:
+
+pflag is a drop-in replacement of Go's native flag package. If you import
+pflag under the name "flag" then all code should continue to function
+with no changes.
+
+	import flag "github.com/ogier/pflag"
+
+	There is one exception to this: if you directly instantiate the Flag struct
+there is one more field "Shorthand" that you will need to set.
+Most code never instantiates this struct directly, and instead uses
+functions such as String(), BoolVar(), and Var(), and is therefore
+unaffected.
+
+Define flags using flag.String(), Bool(), Int(), etc.
+
+This declares an integer flag, -flagname, stored in the pointer ip, with type *int.
+	var ip = flag.Int("flagname", 1234, "help message for flagname")
+If you like, you can bind the flag to a variable using the Var() functions.
+	var flagvar int
+	func init() {
+		flag.IntVar(&flagvar, "flagname", 1234, "help message for flagname")
+	}
+Or you can create custom flags that satisfy the Value interface (with
+pointer receivers) and couple them to flag parsing by
+	flag.Var(&flagVal, "name", "help message for flagname")
+For such flags, the default value is just the initial value of the variable.
+
+After all flags are defined, call
+	flag.Parse()
+to parse the command line into the defined flags.
+
+Flags may then be used directly. If you're using the flags themselves,
+they are all pointers; if you bind to variables, they're values.
+	fmt.Println("ip has value ", *ip)
+	fmt.Println("flagvar has value ", flagvar)
+
+After parsing, the arguments after the flag are available as the
+slice flag.Args() or individually as flag.Arg(i).
+The arguments are indexed from 0 through flag.NArg()-1.
+
+The pflag package also defines some new functions that are not in flag,
+that give one-letter shorthands for flags. You can use these by appending
+'P' to the name of any function that defines a flag.
+	var ip = flag.IntP("flagname", "f", 1234, "help message")
+	var flagvar bool
+	func init() {
+		flag.BoolVarP("boolname", "b", true, "help message")
+	}
+	flag.VarP(&flagVar, "varname", "v", 1234, "help message")
+Shorthand letters can be used with single dashes on the command line.
+Boolean shorthand flags can be combined with other shorthand flags.
+
+Command line flag syntax:
+	--flag    // boolean flags only
+	--flag=x
+
+Unlike the flag package, a single dash before an option means something
+different than a double dash. Single dashes signify a series of shorthand
+letters for flags. All but the last shorthand letter must be boolean flags.
+	// boolean flags
+	-f
+	-abc
+	// non-boolean flags
+	-n 1234
+	-Ifile
+	// mixed
+	-abcs "hello"
+	-abcn1234
+
+Flag parsing stops after the terminator "--". Unlike the flag package,
+flags can be interspersed with arguments anywhere on the command line
+before this terminator.
+
+Integer flags accept 1234, 0664, 0x1234 and may be negative.
+Boolean flags (in their long form) accept 1, 0, t, f, true, false,
+TRUE, FALSE, True, False.
+Duration flags accept any input valid for time.ParseDuration.
+
+The default set of command-line flags is controlled by
+top-level functions.  The FlagSet type allows one to define
+independent sets of flags, such as to implement subcommands
+in a command-line interface. The methods of FlagSet are
+analogous to the top-level functions for the command-line
+flag set.
+*/
+package pflag
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
+var ErrHelp = errors.New("pflag: help requested")
+
+// ErrorHandling defines how to handle flag parsing errors.
+type ErrorHandling int
+
+const (
+	// ContinueOnError will return an err from Parse() if an error is found
+	ContinueOnError ErrorHandling = iota
+	// ExitOnError will call os.Exit(2) if an error is found when parsing
+	ExitOnError
+	// PanicOnError will panic() if an error is found when parsing flags
+	PanicOnError
+)
+
+// NormalizedName is a flag name that has been normalized according to rules
+// for the FlagSet (e.g. making '-' and '_' equivalent).
+type NormalizedName string
+
+// A FlagSet represents a set of defined flags.
+type FlagSet struct {
+	// Usage is the function called when an error occurs while parsing flags.
+	// The field is a function (not a method) that may be changed to point to
+	// a custom error handler.
+	Usage func()
+
+	name              string
+	parsed            bool
+	actual            map[NormalizedName]*Flag
+	formal            map[NormalizedName]*Flag
+	shorthands        map[byte]*Flag
+	args              []string // arguments after flags
+	argsLenAtDash     int      // len(args) when a '--' was located when parsing, or -1 if no --
+	exitOnError       bool     // does the program exit if there's an error?
+	errorHandling     ErrorHandling
+	output            io.Writer // nil means stderr; use out() accessor
+	interspersed      bool      // allow interspersed option/non-option args
+	normalizeNameFunc func(f *FlagSet, name string) NormalizedName
+}
+
+// A Flag represents the state of a flag.
+type Flag struct {
+	Name                string              // name as it appears on command line
+	Shorthand           string              // one-letter abbreviated flag
+	Usage               string              // help message
+	Value               Value               // value as set
+	DefValue            string              // default value (as text); for usage message
+	Changed             bool                // If the user set the value (or if left to default)
+	NoOptDefVal         string              //default value (as text); if the flag is on the command line without any options
+	Deprecated          string              // If this flag is deprecated, this string is the new or now thing to use
+	Hidden              bool                // used by cobra.Command to allow flags to be hidden from help/usage text
+	ShorthandDeprecated string              // If the shorthand of this flag is deprecated, this string is the new or now thing to use
+	Annotations         map[string][]string // used by cobra.Command bash autocomple code
+}
+
+// Value is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+type Value interface {
+	String() string
+	Set(string) error
+	Type() string
+}
+
+// sortFlags returns the flags as a slice in lexicographical sorted order.
+func sortFlags(flags map[NormalizedName]*Flag) []*Flag {
+	list := make(sort.StringSlice, len(flags))
+	i := 0
+	for k := range flags {
+		list[i] = string(k)
+		i++
+	}
+	list.Sort()
+	result := make([]*Flag, len(list))
+	for i, name := range list {
+		result[i] = flags[NormalizedName(name)]
+	}
+	return result
+}
+
+// SetNormalizeFunc allows you to add a function which can translate flag names.
+// Flags added to the FlagSet will be translated and then when anything tries to
+// look up the flag that will also be translated. So it would be possible to create
+// a flag named "getURL" and have it translated to "geturl".  A user could then pass
+// "--getUrl" which may also be translated to "geturl" and everything will work.
+func (f *FlagSet) SetNormalizeFunc(n func(f *FlagSet, name string) NormalizedName) {
+	f.normalizeNameFunc = n
+	for k, v := range f.formal {
+		delete(f.formal, k)
+		nname := f.normalizeFlagName(string(k))
+		f.formal[nname] = v
+		v.Name = string(nname)
+	}
+}
+
+// GetNormalizeFunc returns the previously set NormalizeFunc of a function which
+// does no translation, if not set previously.
+func (f *FlagSet) GetNormalizeFunc() func(f *FlagSet, name string) NormalizedName {
+	if f.normalizeNameFunc != nil {
+		return f.normalizeNameFunc
+	}
+	return func(f *FlagSet, name string) NormalizedName { return NormalizedName(name) }
+}
+
+func (f *FlagSet) normalizeFlagName(name string) NormalizedName {
+	n := f.GetNormalizeFunc()
+	return n(f, name)
+}
+
+func (f *FlagSet) out() io.Writer {
+	if f.output == nil {
+		return os.Stderr
+	}
+	return f.output
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (f *FlagSet) SetOutput(output io.Writer) {
+	f.output = output
+}
+
+// VisitAll visits the flags in lexicographical order, calling fn for each.
+// It visits all flags, even those not set.
+func (f *FlagSet) VisitAll(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.formal) {
+		fn(flag)
+	}
+}
+
+// HasFlags returns a bool to indicate if the FlagSet has any flags definied.
+func (f *FlagSet) HasFlags() bool {
+	return len(f.formal) > 0
+}
+
+// HasAvailableFlags returns a bool to indicate if the FlagSet has any flags
+// definied that are not hidden or deprecated.
+func (f *FlagSet) HasAvailableFlags() bool {
+	for _, flag := range f.formal {
+		if !flag.Hidden && len(flag.Deprecated) == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// VisitAll visits the command-line flags in lexicographical order, calling
+// fn for each.  It visits all flags, even those not set.
+func VisitAll(fn func(*Flag)) {
+	CommandLine.VisitAll(fn)
+}
+
+// Visit visits the flags in lexicographical order, calling fn for each.
+// It visits only those flags that have been set.
+func (f *FlagSet) Visit(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.actual) {
+		fn(flag)
+	}
+}
+
+// Visit visits the command-line flags in lexicographical order, calling fn
+// for each.  It visits only those flags that have been set.
+func Visit(fn func(*Flag)) {
+	CommandLine.Visit(fn)
+}
+
+// Lookup returns the Flag structure of the named flag, returning nil if none exists.
+func (f *FlagSet) Lookup(name string) *Flag {
+	return f.lookup(f.normalizeFlagName(name))
+}
+
+// lookup returns the Flag structure of the named flag, returning nil if none exists.
+func (f *FlagSet) lookup(name NormalizedName) *Flag {
+	return f.formal[name]
+}
+
+// func to return a given type for a given flag name
+func (f *FlagSet) getFlagType(name string, ftype string, convFunc func(sval string) (interface{}, error)) (interface{}, error) {
+	flag := f.Lookup(name)
+	if flag == nil {
+		err := fmt.Errorf("flag accessed but not defined: %s", name)
+		return nil, err
+	}
+
+	if flag.Value.Type() != ftype {
+		err := fmt.Errorf("trying to get %s value of flag of type %s", ftype, flag.Value.Type())
+		return nil, err
+	}
+
+	sval := flag.Value.String()
+	result, err := convFunc(sval)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ArgsLenAtDash will return the length of f.Args at the moment when a -- was
+// found during arg parsing. This allows your program to know which args were
+// before the -- and which came after.
+func (f *FlagSet) ArgsLenAtDash() int {
+	return f.argsLenAtDash
+}
+
+// MarkDeprecated indicated that a flag is deprecated in your program. It will
+// continue to function but will not show up in help or usage messages. Using
+// this flag will also print the given usageMessage.
+func (f *FlagSet) MarkDeprecated(name string, usageMessage string) error {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %q does not exist", name)
+	}
+	if len(usageMessage) == 0 {
+		return fmt.Errorf("deprecated message for flag %q must be set", name)
+	}
+	flag.Deprecated = usageMessage
+	return nil
+}
+
+// MarkShorthandDeprecated will mark the shorthand of a flag deprecated in your
+// program. It will continue to function but will not show up in help or usage
+// messages. Using this flag will also print the given usageMessage.
+func (f *FlagSet) MarkShorthandDeprecated(name string, usageMessage string) error {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %q does not exist", name)
+	}
+	if len(usageMessage) == 0 {
+		return fmt.Errorf("deprecated message for flag %q must be set", name)
+	}
+	flag.ShorthandDeprecated = usageMessage
+	return nil
+}
+
+// MarkHidden sets a flag to 'hidden' in your program. It will continue to
+// function but will not show up in help or usage messages.
+func (f *FlagSet) MarkHidden(name string) error {
+	flag := f.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("flag %q does not exist", name)
+	}
+	flag.Hidden = true
+	return nil
+}
+
+// Lookup returns the Flag structure of the named command-line flag,
+// returning nil if none exists.
+func Lookup(name string) *Flag {
+	return CommandLine.Lookup(name)
+}
+
+// Set sets the value of the named flag.
+func (f *FlagSet) Set(name, value string) error {
+	normalName := f.normalizeFlagName(name)
+	flag, ok := f.formal[normalName]
+	if !ok {
+		return fmt.Errorf("no such flag -%v", name)
+	}
+	err := flag.Value.Set(value)
+	if err != nil {
+		return err
+	}
+	if f.actual == nil {
+		f.actual = make(map[NormalizedName]*Flag)
+	}
+	f.actual[normalName] = flag
+	flag.Changed = true
+	if len(flag.Deprecated) > 0 {
+		fmt.Fprintf(os.Stderr, "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
+	}
+	return nil
+}
+
+// SetAnnotation allows one to set arbitrary annotations on a flag in the FlagSet.
+// This is sometimes used by spf13/cobra programs which want to generate additional
+// bash completion information.
+func (f *FlagSet) SetAnnotation(name, key string, values []string) error {
+	normalName := f.normalizeFlagName(name)
+	flag, ok := f.formal[normalName]
+	if !ok {
+		return fmt.Errorf("no such flag -%v", name)
+	}
+	if flag.Annotations == nil {
+		flag.Annotations = map[string][]string{}
+	}
+	flag.Annotations[key] = values
+	return nil
+}
+
+// Changed returns true if the flag was explicitly set during Parse() and false
+// otherwise
+func (f *FlagSet) Changed(name string) bool {
+	flag := f.Lookup(name)
+	// If a flag doesn't exist, it wasn't changed....
+	if flag == nil {
+		return false
+	}
+	return flag.Changed
+}
+
+// Set sets the value of the named command-line flag.
+func Set(name, value string) error {
+	return CommandLine.Set(name, value)
+}
+
+// PrintDefaults prints, to standard error unless configured
+// otherwise, the default values of all defined flags in the set.
+func (f *FlagSet) PrintDefaults() {
+	usages := f.FlagUsages()
+	fmt.Fprintf(f.out(), "%s", usages)
+}
+
+// isZeroValue guesses whether the string represents the zero
+// value for a flag. It is not accurate but in practice works OK.
+func isZeroValue(value string) bool {
+	switch value {
+	case "false":
+		return true
+	case "<nil>":
+		return true
+	case "":
+		return true
+	case "0":
+		return true
+	}
+	return false
+}
+
+// UnquoteUsage extracts a back-quoted name from the usage
+// string for a flag and returns it and the un-quoted usage.
+// Given "a `name` to show" it returns ("name", "a name to show").
+// If there are no back quotes, the name is an educated guess of the
+// type of the flag's value, or the empty string if the flag is boolean.
+func UnquoteUsage(flag *Flag) (name string, usage string) {
+	// Look for a back-quoted name, but avoid the strings package.
+	usage = flag.Usage
+	for i := 0; i < len(usage); i++ {
+		if usage[i] == '`' {
+			for j := i + 1; j < len(usage); j++ {
+				if usage[j] == '`' {
+					name = usage[i+1 : j]
+					usage = usage[:i] + name + usage[j+1:]
+					return name, usage
+				}
+			}
+			break // Only one back quote; use type name.
+		}
+	}
+	// No explicit name, so use type if we can find one.
+	name = "value"
+	switch flag.Value.(type) {
+	case boolFlag:
+		name = ""
+	case *durationValue:
+		name = "duration"
+	case *float64Value:
+		name = "float"
+	case *intValue, *int64Value:
+		name = "int"
+	case *stringValue:
+		name = "string"
+	case *uintValue, *uint64Value:
+		name = "uint"
+	}
+	return
+}
+
+// FlagUsages Returns a string containing the usage information for all flags in
+// the FlagSet
+func (f *FlagSet) FlagUsages() string {
+	x := new(bytes.Buffer)
+
+	lines := make([]string, 0, len(f.formal))
+
+	maxlen := 0
+	f.VisitAll(func(flag *Flag) {
+		if len(flag.Deprecated) > 0 || flag.Hidden {
+			return
+		}
+
+		line := ""
+		if len(flag.Shorthand) > 0 && len(flag.ShorthandDeprecated) == 0 {
+			line = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
+		} else {
+			line = fmt.Sprintf("      --%s", flag.Name)
+		}
+
+		varname, usage := UnquoteUsage(flag)
+		if len(varname) > 0 {
+			line += " " + varname
+		}
+		if len(flag.NoOptDefVal) > 0 {
+			switch flag.Value.Type() {
+			case "string":
+				line += fmt.Sprintf("[=%q]", flag.NoOptDefVal)
+			case "bool":
+				if flag.NoOptDefVal != "true" {
+					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				}
+			default:
+				line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+			}
+		}
+
+		// This special character will be replaced with spacing once the
+		// correct alignment is calculated
+		line += "\x00"
+		if len(line) > maxlen {
+			maxlen = len(line)
+		}
+
+		line += usage
+		if !isZeroValue(flag.DefValue) {
+			if flag.Value.Type() == "string" {
+				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+			} else {
+				line += fmt.Sprintf(" (default %s)", flag.DefValue)
+			}
+		}
+
+		lines = append(lines, line)
+	})
+
+	for _, line := range lines {
+		sidx := strings.Index(line, "\x00")
+		spacing := strings.Repeat(" ", maxlen-sidx)
+		fmt.Fprintln(x, line[:sidx], spacing, line[sidx+1:])
+	}
+
+	return x.String()
+}
+
+// PrintDefaults prints to standard error the default values of all defined command-line flags.
+func PrintDefaults() {
+	CommandLine.PrintDefaults()
+}
+
+// defaultUsage is the default function to print a usage message.
+func defaultUsage(f *FlagSet) {
+	fmt.Fprintf(f.out(), "Usage of %s:\n", f.name)
+	f.PrintDefaults()
+}
+
+// NOTE: Usage is not just defaultUsage(CommandLine)
+// because it serves (via godoc flag Usage) as the example
+// for how to write your own usage function.
+
+// Usage prints to standard error a usage message documenting all defined command-line flags.
+// The function is a variable that may be changed to point to a custom function.
+// By default it prints a simple header and calls PrintDefaults; for details about the
+// format of the output and how to control it, see the documentation for PrintDefaults.
+var Usage = func() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	PrintDefaults()
+}
+
+// NFlag returns the number of flags that have been set.
+func (f *FlagSet) NFlag() int { return len(f.actual) }
+
+// NFlag returns the number of command-line flags that have been set.
+func NFlag() int { return len(CommandLine.actual) }
+
+// Arg returns the i'th argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func (f *FlagSet) Arg(i int) string {
+	if i < 0 || i >= len(f.args) {
+		return ""
+	}
+	return f.args[i]
+}
+
+// Arg returns the i'th command-line argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func Arg(i int) string {
+	return CommandLine.Arg(i)
+}
+
+// NArg is the number of arguments remaining after flags have been processed.
+func (f *FlagSet) NArg() int { return len(f.args) }
+
+// NArg is the number of arguments remaining after flags have been processed.
+func NArg() int { return len(CommandLine.args) }
+
+// Args returns the non-flag arguments.
+func (f *FlagSet) Args() []string { return f.args }
+
+// Args returns the non-flag command-line arguments.
+func Args() []string { return CommandLine.args }
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func (f *FlagSet) Var(value Value, name string, usage string) {
+	f.VarP(value, name, "", usage)
+}
+
+// VarPF is like VarP, but returns the flag created
+func (f *FlagSet) VarPF(value Value, name, shorthand, usage string) *Flag {
+	// Remember the default value as a string; it won't change.
+	flag := &Flag{
+		Name:      name,
+		Shorthand: shorthand,
+		Usage:     usage,
+		Value:     value,
+		DefValue:  value.String(),
+	}
+	f.AddFlag(flag)
+	return flag
+}
+
+// VarP is like Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
+	_ = f.VarPF(value, name, shorthand, usage)
+}
+
+// AddFlag will add the flag to the FlagSet
+func (f *FlagSet) AddFlag(flag *Flag) {
+	// Call normalizeFlagName function only once
+	normalizedFlagName := f.normalizeFlagName(flag.Name)
+
+	_, alreadythere := f.formal[normalizedFlagName]
+	if alreadythere {
+		msg := fmt.Sprintf("%s flag redefined: %s", f.name, flag.Name)
+		fmt.Fprintln(f.out(), msg)
+		panic(msg) // Happens only if flags are declared with identical names
+	}
+	if f.formal == nil {
+		f.formal = make(map[NormalizedName]*Flag)
+	}
+
+	flag.Name = string(normalizedFlagName)
+	f.formal[normalizedFlagName] = flag
+
+	if len(flag.Shorthand) == 0 {
+		return
+	}
+	if len(flag.Shorthand) > 1 {
+		fmt.Fprintf(f.out(), "%s shorthand more than ASCII character: %s\n", f.name, flag.Shorthand)
+		panic("shorthand is more than one character")
+	}
+	if f.shorthands == nil {
+		f.shorthands = make(map[byte]*Flag)
+	}
+	c := flag.Shorthand[0]
+	old, alreadythere := f.shorthands[c]
+	if alreadythere {
+		fmt.Fprintf(f.out(), "%s shorthand reused: %q for %s already used for %s\n", f.name, c, flag.Name, old.Name)
+		panic("shorthand redefinition")
+	}
+	f.shorthands[c] = flag
+}
+
+// AddFlagSet adds one FlagSet to another. If a flag is already present in f
+// the flag from newSet will be ignored
+func (f *FlagSet) AddFlagSet(newSet *FlagSet) {
+	if newSet == nil {
+		return
+	}
+	newSet.VisitAll(func(flag *Flag) {
+		if f.Lookup(flag.Name) == nil {
+			f.AddFlag(flag)
+		}
+	})
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func Var(value Value, name string, usage string) {
+	CommandLine.VarP(value, name, "", usage)
+}
+
+// VarP is like Var, but accepts a shorthand letter that can be used after a single dash.
+func VarP(value Value, name, shorthand, usage string) {
+	CommandLine.VarP(value, name, shorthand, usage)
+}
+
+// failf prints to standard error a formatted error and usage message and
+// returns the error.
+func (f *FlagSet) failf(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(f.out(), err)
+	f.usage()
+	return err
+}
+
+// usage calls the Usage method for the flag set, or the usage function if
+// the flag set is CommandLine.
+func (f *FlagSet) usage() {
+	if f == CommandLine {
+		Usage()
+	} else if f.Usage == nil {
+		defaultUsage(f)
+	} else {
+		f.Usage()
+	}
+}
+
+func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
+	if err := flag.Value.Set(value); err != nil {
+		return f.failf("invalid argument %q for %s: %v", value, origArg, err)
+	}
+	// mark as visited for Visit()
+	if f.actual == nil {
+		f.actual = make(map[NormalizedName]*Flag)
+	}
+	f.actual[f.normalizeFlagName(flag.Name)] = flag
+	flag.Changed = true
+	if len(flag.Deprecated) > 0 {
+		fmt.Fprintf(os.Stderr, "Flag --%s has been deprecated, %s\n", flag.Name, flag.Deprecated)
+	}
+	if len(flag.ShorthandDeprecated) > 0 && containsShorthand(origArg, flag.Shorthand) {
+		fmt.Fprintf(os.Stderr, "Flag shorthand -%s has been deprecated, %s\n", flag.Shorthand, flag.ShorthandDeprecated)
+	}
+	return nil
+}
+
+func containsShorthand(arg, shorthand string) bool {
+	// filter out flags --<flag_name>
+	if strings.HasPrefix(arg, "-") {
+		return false
+	}
+	arg = strings.SplitN(arg, "=", 2)[0]
+	return strings.Contains(arg, shorthand)
+}
+
+func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) {
+	a = args
+	name := s[2:]
+	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+		err = f.failf("bad flag syntax: %s", s)
+		return
+	}
+	split := strings.SplitN(name, "=", 2)
+	name = split[0]
+	flag, alreadythere := f.formal[f.normalizeFlagName(name)]
+	if !alreadythere {
+		if name == "help" { // special case for nice help message.
+			f.usage()
+			return a, ErrHelp
+		}
+		err = f.failf("unknown flag: --%s", name)
+		return
+	}
+	var value string
+	if len(split) == 2 {
+		// '--flag=arg'
+		value = split[1]
+	} else if len(flag.NoOptDefVal) > 0 {
+		// '--flag' (arg was optional)
+		value = flag.NoOptDefVal
+	} else if len(a) > 0 {
+		// '--flag arg'
+		value = a[0]
+		a = a[1:]
+	} else {
+		// '--flag' (arg was required)
+		err = f.failf("flag needs an argument: %s", s)
+		return
+	}
+	err = f.setFlag(flag, value, s)
+	return
+}
+
+func (f *FlagSet) parseSingleShortArg(shorthands string, args []string) (outShorts string, outArgs []string, err error) {
+	if strings.HasPrefix(shorthands, "test.") {
+		return
+	}
+	outArgs = args
+	outShorts = shorthands[1:]
+	c := shorthands[0]
+
+	flag, alreadythere := f.shorthands[c]
+	if !alreadythere {
+		if c == 'h' { // special case for nice help message.
+			f.usage()
+			err = ErrHelp
+			return
+		}
+		//TODO continue on error
+		err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+		return
+	}
+	var value string
+	if len(shorthands) > 2 && shorthands[1] == '=' {
+		value = shorthands[2:]
+		outShorts = ""
+	} else if len(flag.NoOptDefVal) > 0 {
+		value = flag.NoOptDefVal
+	} else if len(shorthands) > 1 {
+		value = shorthands[1:]
+		outShorts = ""
+	} else if len(args) > 0 {
+		value = args[0]
+		outArgs = args[1:]
+	} else {
+		err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
+		return
+	}
+	err = f.setFlag(flag, value, shorthands)
+	return
+}
+
+func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error) {
+	a = args
+	shorthands := s[1:]
+
+	for len(shorthands) > 0 {
+		shorthands, a, err = f.parseSingleShortArg(shorthands, args)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (f *FlagSet) parseArgs(args []string) (err error) {
+	for len(args) > 0 {
+		s := args[0]
+		args = args[1:]
+		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
+			if !f.interspersed {
+				f.args = append(f.args, s)
+				f.args = append(f.args, args...)
+				return nil
+			}
+			f.args = append(f.args, s)
+			continue
+		}
+
+		if s[1] == '-' {
+			if len(s) == 2 { // "--" terminates the flags
+				f.argsLenAtDash = len(f.args)
+				f.args = append(f.args, args...)
+				break
+			}
+			args, err = f.parseLongArg(s, args)
+		} else {
+			args, err = f.parseShortArg(s, args)
+		}
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// Parse parses flag definitions from the argument list, which should not
+// include the command name.  Must be called after all flags in the FlagSet
+// are defined and before flags are accessed by the program.
+// The return value will be ErrHelp if -help was set but not defined.
+func (f *FlagSet) Parse(arguments []string) error {
+	f.parsed = true
+	f.args = make([]string, 0, len(arguments))
+	err := f.parseArgs(arguments)
+	if err != nil {
+		switch f.errorHandling {
+		case ContinueOnError:
+			return err
+		case ExitOnError:
+			os.Exit(2)
+		case PanicOnError:
+			panic(err)
+		}
+	}
+	return nil
+}
+
+// Parsed reports whether f.Parse has been called.
+func (f *FlagSet) Parsed() bool {
+	return f.parsed
+}
+
+// Parse parses the command-line flags from os.Args[1:].  Must be called
+// after all flags are defined and before flags are accessed by the program.
+func Parse() {
+	// Ignore errors; CommandLine is set for ExitOnError.
+	CommandLine.Parse(os.Args[1:])
+}
+
+// SetInterspersed sets whether to support interspersed option/non-option arguments.
+func SetInterspersed(interspersed bool) {
+	CommandLine.SetInterspersed(interspersed)
+}
+
+// Parsed returns true if the command-line flags have been parsed.
+func Parsed() bool {
+	return CommandLine.Parsed()
+}
+
+// CommandLine is the default set of command-line flags, parsed from os.Args.
+var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
+
+// NewFlagSet returns a new, empty flag set with the specified name and
+// error handling property.
+func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
+	f := &FlagSet{
+		name:          name,
+		errorHandling: errorHandling,
+		argsLenAtDash: -1,
+		interspersed:  true,
+	}
+	return f
+}
+
+// SetInterspersed sets whether to support interspersed option/non-option arguments.
+func (f *FlagSet) SetInterspersed(interspersed bool) {
+	f.interspersed = interspersed
+}
+
+// Init sets the name and error handling property for a flag set.
+// By default, the zero FlagSet uses an empty name and the
+// ContinueOnError error handling policy.
+func (f *FlagSet) Init(name string, errorHandling ErrorHandling) {
+	f.name = name
+	f.errorHandling = errorHandling
+	f.argsLenAtDash = -1
+}

--- a/vendor/github.com/spf13/pflag/float32.go
+++ b/vendor/github.com/spf13/pflag/float32.go
@@ -1,0 +1,91 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- float32 Value
+type float32Value float32
+
+func newFloat32Value(val float32, p *float32) *float32Value {
+	*p = val
+	return (*float32Value)(p)
+}
+
+func (f *float32Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 32)
+	*f = float32Value(v)
+	return err
+}
+
+func (f *float32Value) Type() string {
+	return "float32"
+}
+
+func (f *float32Value) String() string { return fmt.Sprintf("%v", *f) }
+
+func float32Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseFloat(sval, 32)
+	if err != nil {
+		return 0, err
+	}
+	return float32(v), nil
+}
+
+// GetFloat32 return the float32 value of a flag with the given name
+func (f *FlagSet) GetFloat32(name string) (float32, error) {
+	val, err := f.getFlagType(name, "float32", float32Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(float32), nil
+}
+
+// Float32Var defines a float32 flag with specified name, default value, and usage string.
+// The argument p points to a float32 variable in which to store the value of the flag.
+func (f *FlagSet) Float32Var(p *float32, name string, value float32, usage string) {
+	f.VarP(newFloat32Value(value, p), name, "", usage)
+}
+
+// Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
+	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
+}
+
+// Float32Var defines a float32 flag with specified name, default value, and usage string.
+// The argument p points to a float32 variable in which to store the value of the flag.
+func Float32Var(p *float32, name string, value float32, usage string) {
+	CommandLine.VarP(newFloat32Value(value, p), name, "", usage)
+}
+
+// Float32VarP is like Float32Var, but accepts a shorthand letter that can be used after a single dash.
+func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
+	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+}
+
+// Float32 defines a float32 flag with specified name, default value, and usage string.
+// The return value is the address of a float32 variable that stores the value of the flag.
+func (f *FlagSet) Float32(name string, value float32, usage string) *float32 {
+	p := new(float32)
+	f.Float32VarP(p, name, "", value, usage)
+	return p
+}
+
+// Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string) *float32 {
+	p := new(float32)
+	f.Float32VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Float32 defines a float32 flag with specified name, default value, and usage string.
+// The return value is the address of a float32 variable that stores the value of the flag.
+func Float32(name string, value float32, usage string) *float32 {
+	return CommandLine.Float32P(name, "", value, usage)
+}
+
+// Float32P is like Float32, but accepts a shorthand letter that can be used after a single dash.
+func Float32P(name, shorthand string, value float32, usage string) *float32 {
+	return CommandLine.Float32P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/float64.go
+++ b/vendor/github.com/spf13/pflag/float64.go
@@ -1,0 +1,87 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- float64 Value
+type float64Value float64
+
+func newFloat64Value(val float64, p *float64) *float64Value {
+	*p = val
+	return (*float64Value)(p)
+}
+
+func (f *float64Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = float64Value(v)
+	return err
+}
+
+func (f *float64Value) Type() string {
+	return "float64"
+}
+
+func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+
+func float64Conv(sval string) (interface{}, error) {
+	return strconv.ParseFloat(sval, 64)
+}
+
+// GetFloat64 return the float64 value of a flag with the given name
+func (f *FlagSet) GetFloat64(name string) (float64, error) {
+	val, err := f.getFlagType(name, "float64", float64Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(float64), nil
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
+	f.VarP(newFloat64Value(value, p), name, "", usage)
+}
+
+// Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
+	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func Float64Var(p *float64, name string, value float64, usage string) {
+	CommandLine.VarP(newFloat64Value(value, p), name, "", usage)
+}
+
+// Float64VarP is like Float64Var, but accepts a shorthand letter that can be used after a single dash.
+func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
+	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func (f *FlagSet) Float64(name string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64VarP(p, name, "", value, usage)
+	return p
+}
+
+// Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func Float64(name string, value float64, usage string) *float64 {
+	return CommandLine.Float64P(name, "", value, usage)
+}
+
+// Float64P is like Float64, but accepts a shorthand letter that can be used after a single dash.
+func Float64P(name, shorthand string, value float64, usage string) *float64 {
+	return CommandLine.Float64P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/golangflag.go
+++ b/vendor/github.com/spf13/pflag/golangflag.go
@@ -1,0 +1,104 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pflag
+
+import (
+	goflag "flag"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var _ = fmt.Print
+
+// flagValueWrapper implements pflag.Value around a flag.Value.  The main
+// difference here is the addition of the Type method that returns a string
+// name of the type.  As this is generally unknown, we approximate that with
+// reflection.
+type flagValueWrapper struct {
+	inner    goflag.Value
+	flagType string
+}
+
+// We are just copying the boolFlag interface out of goflag as that is what
+// they use to decide if a flag should get "true" when no arg is given.
+type goBoolFlag interface {
+	goflag.Value
+	IsBoolFlag() bool
+}
+
+func wrapFlagValue(v goflag.Value) Value {
+	// If the flag.Value happens to also be a pflag.Value, just use it directly.
+	if pv, ok := v.(Value); ok {
+		return pv
+	}
+
+	pv := &flagValueWrapper{
+		inner: v,
+	}
+
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Interface || t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	pv.flagType = strings.TrimSuffix(t.Name(), "Value")
+	return pv
+}
+
+func (v *flagValueWrapper) String() string {
+	return v.inner.String()
+}
+
+func (v *flagValueWrapper) Set(s string) error {
+	return v.inner.Set(s)
+}
+
+func (v *flagValueWrapper) Type() string {
+	return v.flagType
+}
+
+// PFlagFromGoFlag will return a *pflag.Flag given a *flag.Flag
+// If the *flag.Flag.Name was a single character (ex: `v`) it will be accessiblei
+// with both `-v` and `--v` in flags. If the golang flag was more than a single
+// character (ex: `verbose`) it will only be accessible via `--verbose`
+func PFlagFromGoFlag(goflag *goflag.Flag) *Flag {
+	// Remember the default value as a string; it won't change.
+	flag := &Flag{
+		Name:  goflag.Name,
+		Usage: goflag.Usage,
+		Value: wrapFlagValue(goflag.Value),
+		// Looks like golang flags don't set DefValue correctly  :-(
+		//DefValue: goflag.DefValue,
+		DefValue: goflag.Value.String(),
+	}
+	// Ex: if the golang flag was -v, allow both -v and --v to work
+	if len(flag.Name) == 1 {
+		flag.Shorthand = flag.Name
+	}
+	if fv, ok := goflag.Value.(goBoolFlag); ok && fv.IsBoolFlag() {
+		flag.NoOptDefVal = "true"
+	}
+	return flag
+}
+
+// AddGoFlag will add the given *flag.Flag to the pflag.FlagSet
+func (f *FlagSet) AddGoFlag(goflag *goflag.Flag) {
+	if f.Lookup(goflag.Name) != nil {
+		return
+	}
+	newflag := PFlagFromGoFlag(goflag)
+	f.AddFlag(newflag)
+}
+
+// AddGoFlagSet will add the given *flag.FlagSet to the pflag.FlagSet
+func (f *FlagSet) AddGoFlagSet(newSet *goflag.FlagSet) {
+	if newSet == nil {
+		return
+	}
+	newSet.VisitAll(func(goflag *goflag.Flag) {
+		f.AddGoFlag(goflag)
+	})
+}

--- a/vendor/github.com/spf13/pflag/int.go
+++ b/vendor/github.com/spf13/pflag/int.go
@@ -1,0 +1,87 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int Value
+type intValue int
+
+func newIntValue(val int, p *int) *intValue {
+	*p = val
+	return (*intValue)(p)
+}
+
+func (i *intValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = intValue(v)
+	return err
+}
+
+func (i *intValue) Type() string {
+	return "int"
+}
+
+func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+
+func intConv(sval string) (interface{}, error) {
+	return strconv.Atoi(sval)
+}
+
+// GetInt return the int value of a flag with the given name
+func (f *FlagSet) GetInt(name string) (int, error) {
+	val, err := f.getFlagType(name, "int", intConv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(int), nil
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
+	f.VarP(newIntValue(value, p), name, "", usage)
+}
+
+// IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage string) {
+	f.VarP(newIntValue(value, p), name, shorthand, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func IntVar(p *int, name string, value int, usage string) {
+	CommandLine.VarP(newIntValue(value, p), name, "", usage)
+}
+
+// IntVarP is like IntVar, but accepts a shorthand letter that can be used after a single dash.
+func IntVarP(p *int, name, shorthand string, value int, usage string) {
+	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func (f *FlagSet) Int(name string, value int, usage string) *int {
+	p := new(int)
+	f.IntVarP(p, name, "", value, usage)
+	return p
+}
+
+// IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntP(name, shorthand string, value int, usage string) *int {
+	p := new(int)
+	f.IntVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func Int(name string, value int, usage string) *int {
+	return CommandLine.IntP(name, "", value, usage)
+}
+
+// IntP is like Int, but accepts a shorthand letter that can be used after a single dash.
+func IntP(name, shorthand string, value int, usage string) *int {
+	return CommandLine.IntP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/int32.go
+++ b/vendor/github.com/spf13/pflag/int32.go
@@ -1,0 +1,91 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int32 Value
+type int32Value int32
+
+func newInt32Value(val int32, p *int32) *int32Value {
+	*p = val
+	return (*int32Value)(p)
+}
+
+func (i *int32Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 32)
+	*i = int32Value(v)
+	return err
+}
+
+func (i *int32Value) Type() string {
+	return "int32"
+}
+
+func (i *int32Value) String() string { return fmt.Sprintf("%v", *i) }
+
+func int32Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseInt(sval, 0, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int32(v), nil
+}
+
+// GetInt32 return the int32 value of a flag with the given name
+func (f *FlagSet) GetInt32(name string) (int32, error) {
+	val, err := f.getFlagType(name, "int32", int32Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(int32), nil
+}
+
+// Int32Var defines an int32 flag with specified name, default value, and usage string.
+// The argument p points to an int32 variable in which to store the value of the flag.
+func (f *FlagSet) Int32Var(p *int32, name string, value int32, usage string) {
+	f.VarP(newInt32Value(value, p), name, "", usage)
+}
+
+// Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
+	f.VarP(newInt32Value(value, p), name, shorthand, usage)
+}
+
+// Int32Var defines an int32 flag with specified name, default value, and usage string.
+// The argument p points to an int32 variable in which to store the value of the flag.
+func Int32Var(p *int32, name string, value int32, usage string) {
+	CommandLine.VarP(newInt32Value(value, p), name, "", usage)
+}
+
+// Int32VarP is like Int32Var, but accepts a shorthand letter that can be used after a single dash.
+func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
+	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+}
+
+// Int32 defines an int32 flag with specified name, default value, and usage string.
+// The return value is the address of an int32 variable that stores the value of the flag.
+func (f *FlagSet) Int32(name string, value int32, usage string) *int32 {
+	p := new(int32)
+	f.Int32VarP(p, name, "", value, usage)
+	return p
+}
+
+// Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string) *int32 {
+	p := new(int32)
+	f.Int32VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int32 defines an int32 flag with specified name, default value, and usage string.
+// The return value is the address of an int32 variable that stores the value of the flag.
+func Int32(name string, value int32, usage string) *int32 {
+	return CommandLine.Int32P(name, "", value, usage)
+}
+
+// Int32P is like Int32, but accepts a shorthand letter that can be used after a single dash.
+func Int32P(name, shorthand string, value int32, usage string) *int32 {
+	return CommandLine.Int32P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/int64.go
+++ b/vendor/github.com/spf13/pflag/int64.go
@@ -1,0 +1,87 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int64 Value
+type int64Value int64
+
+func newInt64Value(val int64, p *int64) *int64Value {
+	*p = val
+	return (*int64Value)(p)
+}
+
+func (i *int64Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int64Value(v)
+	return err
+}
+
+func (i *int64Value) Type() string {
+	return "int64"
+}
+
+func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+func int64Conv(sval string) (interface{}, error) {
+	return strconv.ParseInt(sval, 0, 64)
+}
+
+// GetInt64 return the int64 value of a flag with the given name
+func (f *FlagSet) GetInt64(name string) (int64, error) {
+	val, err := f.getFlagType(name, "int64", int64Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(int64), nil
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
+	f.VarP(newInt64Value(value, p), name, "", usage)
+}
+
+// Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
+	f.VarP(newInt64Value(value, p), name, shorthand, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func Int64Var(p *int64, name string, value int64, usage string) {
+	CommandLine.VarP(newInt64Value(value, p), name, "", usage)
+}
+
+// Int64VarP is like Int64Var, but accepts a shorthand letter that can be used after a single dash.
+func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
+	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func (f *FlagSet) Int64(name string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64VarP(p, name, "", value, usage)
+	return p
+}
+
+// Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func Int64(name string, value int64, usage string) *int64 {
+	return CommandLine.Int64P(name, "", value, usage)
+}
+
+// Int64P is like Int64, but accepts a shorthand letter that can be used after a single dash.
+func Int64P(name, shorthand string, value int64, usage string) *int64 {
+	return CommandLine.Int64P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/int8.go
+++ b/vendor/github.com/spf13/pflag/int8.go
@@ -1,0 +1,91 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- int8 Value
+type int8Value int8
+
+func newInt8Value(val int8, p *int8) *int8Value {
+	*p = val
+	return (*int8Value)(p)
+}
+
+func (i *int8Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 8)
+	*i = int8Value(v)
+	return err
+}
+
+func (i *int8Value) Type() string {
+	return "int8"
+}
+
+func (i *int8Value) String() string { return fmt.Sprintf("%v", *i) }
+
+func int8Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseInt(sval, 0, 8)
+	if err != nil {
+		return 0, err
+	}
+	return int8(v), nil
+}
+
+// GetInt8 return the int8 value of a flag with the given name
+func (f *FlagSet) GetInt8(name string) (int8, error) {
+	val, err := f.getFlagType(name, "int8", int8Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(int8), nil
+}
+
+// Int8Var defines an int8 flag with specified name, default value, and usage string.
+// The argument p points to an int8 variable in which to store the value of the flag.
+func (f *FlagSet) Int8Var(p *int8, name string, value int8, usage string) {
+	f.VarP(newInt8Value(value, p), name, "", usage)
+}
+
+// Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
+	f.VarP(newInt8Value(value, p), name, shorthand, usage)
+}
+
+// Int8Var defines an int8 flag with specified name, default value, and usage string.
+// The argument p points to an int8 variable in which to store the value of the flag.
+func Int8Var(p *int8, name string, value int8, usage string) {
+	CommandLine.VarP(newInt8Value(value, p), name, "", usage)
+}
+
+// Int8VarP is like Int8Var, but accepts a shorthand letter that can be used after a single dash.
+func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
+	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+}
+
+// Int8 defines an int8 flag with specified name, default value, and usage string.
+// The return value is the address of an int8 variable that stores the value of the flag.
+func (f *FlagSet) Int8(name string, value int8, usage string) *int8 {
+	p := new(int8)
+	f.Int8VarP(p, name, "", value, usage)
+	return p
+}
+
+// Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string) *int8 {
+	p := new(int8)
+	f.Int8VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Int8 defines an int8 flag with specified name, default value, and usage string.
+// The return value is the address of an int8 variable that stores the value of the flag.
+func Int8(name string, value int8, usage string) *int8 {
+	return CommandLine.Int8P(name, "", value, usage)
+}
+
+// Int8P is like Int8, but accepts a shorthand letter that can be used after a single dash.
+func Int8P(name, shorthand string, value int8, usage string) *int8 {
+	return CommandLine.Int8P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/int_slice.go
+++ b/vendor/github.com/spf13/pflag/int_slice.go
@@ -1,0 +1,128 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// -- intSlice Value
+type intSliceValue struct {
+	value   *[]int
+	changed bool
+}
+
+func newIntSliceValue(val []int, p *[]int) *intSliceValue {
+	isv := new(intSliceValue)
+	isv.value = p
+	*isv.value = val
+	return isv
+}
+
+func (s *intSliceValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]int, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = strconv.Atoi(d)
+		if err != nil {
+			return err
+		}
+
+	}
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *intSliceValue) Type() string {
+	return "intSlice"
+}
+
+func (s *intSliceValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = fmt.Sprintf("%d", d)
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func intSliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
+	// Empty string would cause a slice with one (empty) entry
+	if len(val) == 0 {
+		return []int{}, nil
+	}
+	ss := strings.Split(val, ",")
+	out := make([]int, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = strconv.Atoi(d)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return out, nil
+}
+
+// GetIntSlice return the []int value of a flag with the given name
+func (f *FlagSet) GetIntSlice(name string) ([]int, error) {
+	val, err := f.getFlagType(name, "intSlice", intSliceConv)
+	if err != nil {
+		return []int{}, err
+	}
+	return val.([]int), nil
+}
+
+// IntSliceVar defines a intSlice flag with specified name, default value, and usage string.
+// The argument p points to a []int variable in which to store the value of the flag.
+func (f *FlagSet) IntSliceVar(p *[]int, name string, value []int, usage string) {
+	f.VarP(newIntSliceValue(value, p), name, "", usage)
+}
+
+// IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
+	f.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+}
+
+// IntSliceVar defines a int[] flag with specified name, default value, and usage string.
+// The argument p points to a int[] variable in which to store the value of the flag.
+func IntSliceVar(p *[]int, name string, value []int, usage string) {
+	CommandLine.VarP(newIntSliceValue(value, p), name, "", usage)
+}
+
+// IntSliceVarP is like IntSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func IntSliceVarP(p *[]int, name, shorthand string, value []int, usage string) {
+	CommandLine.VarP(newIntSliceValue(value, p), name, shorthand, usage)
+}
+
+// IntSlice defines a []int flag with specified name, default value, and usage string.
+// The return value is the address of a []int variable that stores the value of the flag.
+func (f *FlagSet) IntSlice(name string, value []int, usage string) *[]int {
+	p := []int{}
+	f.IntSliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntSliceP(name, shorthand string, value []int, usage string) *[]int {
+	p := []int{}
+	f.IntSliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// IntSlice defines a []int flag with specified name, default value, and usage string.
+// The return value is the address of a []int variable that stores the value of the flag.
+func IntSlice(name string, value []int, usage string) *[]int {
+	return CommandLine.IntSliceP(name, "", value, usage)
+}
+
+// IntSliceP is like IntSlice, but accepts a shorthand letter that can be used after a single dash.
+func IntSliceP(name, shorthand string, value []int, usage string) *[]int {
+	return CommandLine.IntSliceP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/ip.go
+++ b/vendor/github.com/spf13/pflag/ip.go
@@ -1,0 +1,96 @@
+package pflag
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+var _ = strings.TrimSpace
+
+// -- net.IP value
+type ipValue net.IP
+
+func newIPValue(val net.IP, p *net.IP) *ipValue {
+	*p = val
+	return (*ipValue)(p)
+}
+
+func (i *ipValue) String() string { return net.IP(*i).String() }
+func (i *ipValue) Set(s string) error {
+	ip := net.ParseIP(strings.TrimSpace(s))
+	if ip == nil {
+		return fmt.Errorf("failed to parse IP: %q", s)
+	}
+	*i = ipValue(ip)
+	return nil
+}
+
+func (i *ipValue) Type() string {
+	return "ip"
+}
+
+func ipConv(sval string) (interface{}, error) {
+	ip := net.ParseIP(sval)
+	if ip != nil {
+		return ip, nil
+	}
+	return nil, fmt.Errorf("invalid string being converted to IP address: %s", sval)
+}
+
+// GetIP return the net.IP value of a flag with the given name
+func (f *FlagSet) GetIP(name string) (net.IP, error) {
+	val, err := f.getFlagType(name, "ip", ipConv)
+	if err != nil {
+		return nil, err
+	}
+	return val.(net.IP), nil
+}
+
+// IPVar defines an net.IP flag with specified name, default value, and usage string.
+// The argument p points to an net.IP variable in which to store the value of the flag.
+func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {
+	f.VarP(newIPValue(value, p), name, "", usage)
+}
+
+// IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
+	f.VarP(newIPValue(value, p), name, shorthand, usage)
+}
+
+// IPVar defines an net.IP flag with specified name, default value, and usage string.
+// The argument p points to an net.IP variable in which to store the value of the flag.
+func IPVar(p *net.IP, name string, value net.IP, usage string) {
+	CommandLine.VarP(newIPValue(value, p), name, "", usage)
+}
+
+// IPVarP is like IPVar, but accepts a shorthand letter that can be used after a single dash.
+func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
+	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+}
+
+// IP defines an net.IP flag with specified name, default value, and usage string.
+// The return value is the address of an net.IP variable that stores the value of the flag.
+func (f *FlagSet) IP(name string, value net.IP, usage string) *net.IP {
+	p := new(net.IP)
+	f.IPVarP(p, name, "", value, usage)
+	return p
+}
+
+// IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string) *net.IP {
+	p := new(net.IP)
+	f.IPVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// IP defines an net.IP flag with specified name, default value, and usage string.
+// The return value is the address of an net.IP variable that stores the value of the flag.
+func IP(name string, value net.IP, usage string) *net.IP {
+	return CommandLine.IPP(name, "", value, usage)
+}
+
+// IPP is like IP, but accepts a shorthand letter that can be used after a single dash.
+func IPP(name, shorthand string, value net.IP, usage string) *net.IP {
+	return CommandLine.IPP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/ipmask.go
+++ b/vendor/github.com/spf13/pflag/ipmask.go
@@ -1,0 +1,122 @@
+package pflag
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// -- net.IPMask value
+type ipMaskValue net.IPMask
+
+func newIPMaskValue(val net.IPMask, p *net.IPMask) *ipMaskValue {
+	*p = val
+	return (*ipMaskValue)(p)
+}
+
+func (i *ipMaskValue) String() string { return net.IPMask(*i).String() }
+func (i *ipMaskValue) Set(s string) error {
+	ip := ParseIPv4Mask(s)
+	if ip == nil {
+		return fmt.Errorf("failed to parse IP mask: %q", s)
+	}
+	*i = ipMaskValue(ip)
+	return nil
+}
+
+func (i *ipMaskValue) Type() string {
+	return "ipMask"
+}
+
+// ParseIPv4Mask written in IP form (e.g. 255.255.255.0).
+// This function should really belong to the net package.
+func ParseIPv4Mask(s string) net.IPMask {
+	mask := net.ParseIP(s)
+	if mask == nil {
+		if len(s) != 8 {
+			return nil
+		}
+		// net.IPMask.String() actually outputs things like ffffff00
+		// so write a horrible parser for that as well  :-(
+		m := []int{}
+		for i := 0; i < 4; i++ {
+			b := "0x" + s[2*i:2*i+2]
+			d, err := strconv.ParseInt(b, 0, 0)
+			if err != nil {
+				return nil
+			}
+			m = append(m, int(d))
+		}
+		s := fmt.Sprintf("%d.%d.%d.%d", m[0], m[1], m[2], m[3])
+		mask = net.ParseIP(s)
+		if mask == nil {
+			return nil
+		}
+	}
+	return net.IPv4Mask(mask[12], mask[13], mask[14], mask[15])
+}
+
+func parseIPv4Mask(sval string) (interface{}, error) {
+	mask := ParseIPv4Mask(sval)
+	if mask == nil {
+		return nil, fmt.Errorf("unable to parse %s as net.IPMask", sval)
+	}
+	return mask, nil
+}
+
+// GetIPv4Mask return the net.IPv4Mask value of a flag with the given name
+func (f *FlagSet) GetIPv4Mask(name string) (net.IPMask, error) {
+	val, err := f.getFlagType(name, "ipMask", parseIPv4Mask)
+	if err != nil {
+		return nil, err
+	}
+	return val.(net.IPMask), nil
+}
+
+// IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
+// The argument p points to an net.IPMask variable in which to store the value of the flag.
+func (f *FlagSet) IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
+	f.VarP(newIPMaskValue(value, p), name, "", usage)
+}
+
+// IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
+	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
+// IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
+// The argument p points to an net.IPMask variable in which to store the value of the flag.
+func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
+	CommandLine.VarP(newIPMaskValue(value, p), name, "", usage)
+}
+
+// IPMaskVarP is like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
+func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
+	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
+// IPMask defines an net.IPMask flag with specified name, default value, and usage string.
+// The return value is the address of an net.IPMask variable that stores the value of the flag.
+func (f *FlagSet) IPMask(name string, value net.IPMask, usage string) *net.IPMask {
+	p := new(net.IPMask)
+	f.IPMaskVarP(p, name, "", value, usage)
+	return p
+}
+
+// IPMaskP is like IPMask, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+	p := new(net.IPMask)
+	f.IPMaskVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// IPMask defines an net.IPMask flag with specified name, default value, and usage string.
+// The return value is the address of an net.IPMask variable that stores the value of the flag.
+func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
+	return CommandLine.IPMaskP(name, "", value, usage)
+}
+
+// IPMaskP is like IP, but accepts a shorthand letter that can be used after a single dash.
+func IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
+	return CommandLine.IPMaskP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/ipnet.go
+++ b/vendor/github.com/spf13/pflag/ipnet.go
@@ -1,0 +1,100 @@
+package pflag
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IPNet adapts net.IPNet for use as a flag.
+type ipNetValue net.IPNet
+
+func (ipnet ipNetValue) String() string {
+	n := net.IPNet(ipnet)
+	return n.String()
+}
+
+func (ipnet *ipNetValue) Set(value string) error {
+	_, n, err := net.ParseCIDR(strings.TrimSpace(value))
+	if err != nil {
+		return err
+	}
+	*ipnet = ipNetValue(*n)
+	return nil
+}
+
+func (*ipNetValue) Type() string {
+	return "ipNet"
+}
+
+var _ = strings.TrimSpace
+
+func newIPNetValue(val net.IPNet, p *net.IPNet) *ipNetValue {
+	*p = val
+	return (*ipNetValue)(p)
+}
+
+func ipNetConv(sval string) (interface{}, error) {
+	_, n, err := net.ParseCIDR(strings.TrimSpace(sval))
+	if err == nil {
+		return *n, nil
+	}
+	return nil, fmt.Errorf("invalid string being converted to IPNet: %s", sval)
+}
+
+// GetIPNet return the net.IPNet value of a flag with the given name
+func (f *FlagSet) GetIPNet(name string) (net.IPNet, error) {
+	val, err := f.getFlagType(name, "ipNet", ipNetConv)
+	if err != nil {
+		return net.IPNet{}, err
+	}
+	return val.(net.IPNet), nil
+}
+
+// IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
+// The argument p points to an net.IPNet variable in which to store the value of the flag.
+func (f *FlagSet) IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
+	f.VarP(newIPNetValue(value, p), name, "", usage)
+}
+
+// IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
+	f.VarP(newIPNetValue(value, p), name, shorthand, usage)
+}
+
+// IPNetVar defines an net.IPNet flag with specified name, default value, and usage string.
+// The argument p points to an net.IPNet variable in which to store the value of the flag.
+func IPNetVar(p *net.IPNet, name string, value net.IPNet, usage string) {
+	CommandLine.VarP(newIPNetValue(value, p), name, "", usage)
+}
+
+// IPNetVarP is like IPNetVar, but accepts a shorthand letter that can be used after a single dash.
+func IPNetVarP(p *net.IPNet, name, shorthand string, value net.IPNet, usage string) {
+	CommandLine.VarP(newIPNetValue(value, p), name, shorthand, usage)
+}
+
+// IPNet defines an net.IPNet flag with specified name, default value, and usage string.
+// The return value is the address of an net.IPNet variable that stores the value of the flag.
+func (f *FlagSet) IPNet(name string, value net.IPNet, usage string) *net.IPNet {
+	p := new(net.IPNet)
+	f.IPNetVarP(p, name, "", value, usage)
+	return p
+}
+
+// IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPNetP(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
+	p := new(net.IPNet)
+	f.IPNetVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// IPNet defines an net.IPNet flag with specified name, default value, and usage string.
+// The return value is the address of an net.IPNet variable that stores the value of the flag.
+func IPNet(name string, value net.IPNet, usage string) *net.IPNet {
+	return CommandLine.IPNetP(name, "", value, usage)
+}
+
+// IPNetP is like IPNet, but accepts a shorthand letter that can be used after a single dash.
+func IPNetP(name, shorthand string, value net.IPNet, usage string) *net.IPNet {
+	return CommandLine.IPNetP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/string.go
+++ b/vendor/github.com/spf13/pflag/string.go
@@ -1,0 +1,82 @@
+package pflag
+
+import "fmt"
+
+// -- string Value
+type stringValue string
+
+func newStringValue(val string, p *string) *stringValue {
+	*p = val
+	return (*stringValue)(p)
+}
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+func (s *stringValue) Type() string {
+	return "string"
+}
+
+func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+
+func stringConv(sval string) (interface{}, error) {
+	return sval, nil
+}
+
+// GetString return the string value of a flag with the given name
+func (f *FlagSet) GetString(name string) (string, error) {
+	val, err := f.getFlagType(name, "string", stringConv)
+	if err != nil {
+		return "", err
+	}
+	return val.(string), nil
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
+	f.VarP(newStringValue(value, p), name, "", usage)
+}
+
+// StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, usage string) {
+	f.VarP(newStringValue(value, p), name, shorthand, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func StringVar(p *string, name string, value string, usage string) {
+	CommandLine.VarP(newStringValue(value, p), name, "", usage)
+}
+
+// StringVarP is like StringVar, but accepts a shorthand letter that can be used after a single dash.
+func StringVarP(p *string, name, shorthand string, value string, usage string) {
+	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func (f *FlagSet) String(name string, value string, usage string) *string {
+	p := new(string)
+	f.StringVarP(p, name, "", value, usage)
+	return p
+}
+
+// StringP is like String, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringP(name, shorthand string, value string, usage string) *string {
+	p := new(string)
+	f.StringVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func String(name string, value string, usage string) *string {
+	return CommandLine.StringP(name, "", value, usage)
+}
+
+// StringP is like String, but accepts a shorthand letter that can be used after a single dash.
+func StringP(name, shorthand string, value string, usage string) *string {
+	return CommandLine.StringP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/string_slice.go
+++ b/vendor/github.com/spf13/pflag/string_slice.go
@@ -1,0 +1,111 @@
+package pflag
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+)
+
+var _ = fmt.Fprint
+
+// -- stringSlice Value
+type stringSliceValue struct {
+	value   *[]string
+	changed bool
+}
+
+func newStringSliceValue(val []string, p *[]string) *stringSliceValue {
+	ssv := new(stringSliceValue)
+	ssv.value = p
+	*ssv.value = val
+	return ssv
+}
+
+func (s *stringSliceValue) Set(val string) error {
+	stringReader := strings.NewReader(val)
+	csvReader := csv.NewReader(stringReader)
+	v, err := csvReader.Read()
+	if err != nil {
+		return err
+	}
+	if !s.changed {
+		*s.value = v
+	} else {
+		*s.value = append(*s.value, v...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *stringSliceValue) Type() string {
+	return "stringSlice"
+}
+
+func (s *stringSliceValue) String() string { return "[" + strings.Join(*s.value, ",") + "]" }
+
+func stringSliceConv(sval string) (interface{}, error) {
+	sval = strings.Trim(sval, "[]")
+	// An empty string would cause a slice with one (empty) string
+	if len(sval) == 0 {
+		return []string{}, nil
+	}
+	v := strings.Split(sval, ",")
+	return v, nil
+}
+
+// GetStringSlice return the []string value of a flag with the given name
+func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
+	val, err := f.getFlagType(name, "stringSlice", stringSliceConv)
+	if err != nil {
+		return []string{}, err
+	}
+	return val.([]string), nil
+}
+
+// StringSliceVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a []string variable in which to store the value of the flag.
+func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string) {
+	f.VarP(newStringSliceValue(value, p), name, "", usage)
+}
+
+// StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
+	f.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+}
+
+// StringSliceVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a []string variable in which to store the value of the flag.
+func StringSliceVar(p *[]string, name string, value []string, usage string) {
+	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
+}
+
+// StringSliceVarP is like StringSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage string) {
+	CommandLine.VarP(newStringSliceValue(value, p), name, shorthand, usage)
+}
+
+// StringSlice defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a []string variable that stores the value of the flag.
+func (f *FlagSet) StringSlice(name string, value []string, usage string) *[]string {
+	p := []string{}
+	f.StringSliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage string) *[]string {
+	p := []string{}
+	f.StringSliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// StringSlice defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a []string variable that stores the value of the flag.
+func StringSlice(name string, value []string, usage string) *[]string {
+	return CommandLine.StringSliceP(name, "", value, usage)
+}
+
+// StringSliceP is like StringSlice, but accepts a shorthand letter that can be used after a single dash.
+func StringSliceP(name, shorthand string, value []string, usage string) *[]string {
+	return CommandLine.StringSliceP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/uint.go
+++ b/vendor/github.com/spf13/pflag/uint.go
@@ -1,0 +1,91 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint Value
+type uintValue uint
+
+func newUintValue(val uint, p *uint) *uintValue {
+	*p = val
+	return (*uintValue)(p)
+}
+
+func (i *uintValue) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uintValue(v)
+	return err
+}
+
+func (i *uintValue) Type() string {
+	return "uint"
+}
+
+func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+
+func uintConv(sval string) (interface{}, error) {
+	v, err := strconv.ParseUint(sval, 0, 0)
+	if err != nil {
+		return 0, err
+	}
+	return uint(v), nil
+}
+
+// GetUint return the uint value of a flag with the given name
+func (f *FlagSet) GetUint(name string) (uint, error) {
+	val, err := f.getFlagType(name, "uint", uintConv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(uint), nil
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
+	f.VarP(newUintValue(value, p), name, "", usage)
+}
+
+// UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage string) {
+	f.VarP(newUintValue(value, p), name, shorthand, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func UintVar(p *uint, name string, value uint, usage string) {
+	CommandLine.VarP(newUintValue(value, p), name, "", usage)
+}
+
+// UintVarP is like UintVar, but accepts a shorthand letter that can be used after a single dash.
+func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
+	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVarP(p, name, "", value, usage)
+	return p
+}
+
+// UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) UintP(name, shorthand string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint(name string, value uint, usage string) *uint {
+	return CommandLine.UintP(name, "", value, usage)
+}
+
+// UintP is like Uint, but accepts a shorthand letter that can be used after a single dash.
+func UintP(name, shorthand string, value uint, usage string) *uint {
+	return CommandLine.UintP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/uint16.go
+++ b/vendor/github.com/spf13/pflag/uint16.go
@@ -1,0 +1,89 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint16 value
+type uint16Value uint16
+
+func newUint16Value(val uint16, p *uint16) *uint16Value {
+	*p = val
+	return (*uint16Value)(p)
+}
+func (i *uint16Value) String() string { return fmt.Sprintf("%d", *i) }
+func (i *uint16Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 16)
+	*i = uint16Value(v)
+	return err
+}
+
+func (i *uint16Value) Type() string {
+	return "uint16"
+}
+
+func uint16Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseUint(sval, 0, 16)
+	if err != nil {
+		return 0, err
+	}
+	return uint16(v), nil
+}
+
+// GetUint16 return the uint16 value of a flag with the given name
+func (f *FlagSet) GetUint16(name string) (uint16, error) {
+	val, err := f.getFlagType(name, "uint16", uint16Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(uint16), nil
+}
+
+// Uint16Var defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (f *FlagSet) Uint16Var(p *uint16, name string, value uint16, usage string) {
+	f.VarP(newUint16Value(value, p), name, "", usage)
+}
+
+// Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
+	f.VarP(newUint16Value(value, p), name, shorthand, usage)
+}
+
+// Uint16Var defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func Uint16Var(p *uint16, name string, value uint16, usage string) {
+	CommandLine.VarP(newUint16Value(value, p), name, "", usage)
+}
+
+// Uint16VarP is like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
+	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+}
+
+// Uint16 defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (f *FlagSet) Uint16(name string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	f.Uint16VarP(p, name, "", value, usage)
+	return p
+}
+
+// Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	f.Uint16VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint16 defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint16(name string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16P(name, "", value, usage)
+}
+
+// Uint16P is like Uint16, but accepts a shorthand letter that can be used after a single dash.
+func Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/uint32.go
+++ b/vendor/github.com/spf13/pflag/uint32.go
@@ -1,0 +1,89 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint16 value
+type uint32Value uint32
+
+func newUint32Value(val uint32, p *uint32) *uint32Value {
+	*p = val
+	return (*uint32Value)(p)
+}
+func (i *uint32Value) String() string { return fmt.Sprintf("%d", *i) }
+func (i *uint32Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 32)
+	*i = uint32Value(v)
+	return err
+}
+
+func (i *uint32Value) Type() string {
+	return "uint32"
+}
+
+func uint32Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseUint(sval, 0, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+// GetUint32 return the uint32 value of a flag with the given name
+func (f *FlagSet) GetUint32(name string) (uint32, error) {
+	val, err := f.getFlagType(name, "uint32", uint32Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(uint32), nil
+}
+
+// Uint32Var defines a uint32 flag with specified name, default value, and usage string.
+// The argument p points to a uint32 variable in which to store the value of the flag.
+func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {
+	f.VarP(newUint32Value(value, p), name, "", usage)
+}
+
+// Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
+	f.VarP(newUint32Value(value, p), name, shorthand, usage)
+}
+
+// Uint32Var defines a uint32 flag with specified name, default value, and usage string.
+// The argument p points to a uint32  variable in which to store the value of the flag.
+func Uint32Var(p *uint32, name string, value uint32, usage string) {
+	CommandLine.VarP(newUint32Value(value, p), name, "", usage)
+}
+
+// Uint32VarP is like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
+	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+}
+
+// Uint32 defines a uint32 flag with specified name, default value, and usage string.
+// The return value is the address of a uint32  variable that stores the value of the flag.
+func (f *FlagSet) Uint32(name string, value uint32, usage string) *uint32 {
+	p := new(uint32)
+	f.Uint32VarP(p, name, "", value, usage)
+	return p
+}
+
+// Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
+	p := new(uint32)
+	f.Uint32VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint32 defines a uint32 flag with specified name, default value, and usage string.
+// The return value is the address of a uint32  variable that stores the value of the flag.
+func Uint32(name string, value uint32, usage string) *uint32 {
+	return CommandLine.Uint32P(name, "", value, usage)
+}
+
+// Uint32P is like Uint32, but accepts a shorthand letter that can be used after a single dash.
+func Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
+	return CommandLine.Uint32P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/uint64.go
+++ b/vendor/github.com/spf13/pflag/uint64.go
@@ -1,0 +1,91 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint64 Value
+type uint64Value uint64
+
+func newUint64Value(val uint64, p *uint64) *uint64Value {
+	*p = val
+	return (*uint64Value)(p)
+}
+
+func (i *uint64Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uint64Value(v)
+	return err
+}
+
+func (i *uint64Value) Type() string {
+	return "uint64"
+}
+
+func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+func uint64Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseUint(sval, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return uint64(v), nil
+}
+
+// GetUint64 return the uint64 value of a flag with the given name
+func (f *FlagSet) GetUint64(name string) (uint64, error) {
+	val, err := f.getFlagType(name, "uint64", uint64Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(uint64), nil
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
+	f.VarP(newUint64Value(value, p), name, "", usage)
+}
+
+// Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
+	f.VarP(newUint64Value(value, p), name, shorthand, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func Uint64Var(p *uint64, name string, value uint64, usage string) {
+	CommandLine.VarP(newUint64Value(value, p), name, "", usage)
+}
+
+// Uint64VarP is like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
+	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func (f *FlagSet) Uint64(name string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64VarP(p, name, "", value, usage)
+	return p
+}
+
+// Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func Uint64(name string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64P(name, "", value, usage)
+}
+
+// Uint64P is like Uint64, but accepts a shorthand letter that can be used after a single dash.
+func Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/uint8.go
+++ b/vendor/github.com/spf13/pflag/uint8.go
@@ -1,0 +1,91 @@
+package pflag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// -- uint8 Value
+type uint8Value uint8
+
+func newUint8Value(val uint8, p *uint8) *uint8Value {
+	*p = val
+	return (*uint8Value)(p)
+}
+
+func (i *uint8Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 8)
+	*i = uint8Value(v)
+	return err
+}
+
+func (i *uint8Value) Type() string {
+	return "uint8"
+}
+
+func (i *uint8Value) String() string { return fmt.Sprintf("%v", *i) }
+
+func uint8Conv(sval string) (interface{}, error) {
+	v, err := strconv.ParseUint(sval, 0, 8)
+	if err != nil {
+		return 0, err
+	}
+	return uint8(v), nil
+}
+
+// GetUint8 return the uint8 value of a flag with the given name
+func (f *FlagSet) GetUint8(name string) (uint8, error) {
+	val, err := f.getFlagType(name, "uint8", uint8Conv)
+	if err != nil {
+		return 0, err
+	}
+	return val.(uint8), nil
+}
+
+// Uint8Var defines a uint8 flag with specified name, default value, and usage string.
+// The argument p points to a uint8 variable in which to store the value of the flag.
+func (f *FlagSet) Uint8Var(p *uint8, name string, value uint8, usage string) {
+	f.VarP(newUint8Value(value, p), name, "", usage)
+}
+
+// Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
+	f.VarP(newUint8Value(value, p), name, shorthand, usage)
+}
+
+// Uint8Var defines a uint8 flag with specified name, default value, and usage string.
+// The argument p points to a uint8 variable in which to store the value of the flag.
+func Uint8Var(p *uint8, name string, value uint8, usage string) {
+	CommandLine.VarP(newUint8Value(value, p), name, "", usage)
+}
+
+// Uint8VarP is like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
+func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
+	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+}
+
+// Uint8 defines a uint8 flag with specified name, default value, and usage string.
+// The return value is the address of a uint8 variable that stores the value of the flag.
+func (f *FlagSet) Uint8(name string, value uint8, usage string) *uint8 {
+	p := new(uint8)
+	f.Uint8VarP(p, name, "", value, usage)
+	return p
+}
+
+// Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
+	p := new(uint8)
+	f.Uint8VarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// Uint8 defines a uint8 flag with specified name, default value, and usage string.
+// The return value is the address of a uint8 variable that stores the value of the flag.
+func Uint8(name string, value uint8, usage string) *uint8 {
+	return CommandLine.Uint8P(name, "", value, usage)
+}
+
+// Uint8P is like Uint8, but accepts a shorthand letter that can be used after a single dash.
+func Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
+	return CommandLine.Uint8P(name, shorthand, value, usage)
+}

--- a/vendor/github.com/xeipuuv/gojsonpointer/LICENSE-APACHE-2.0.txt
+++ b/vendor/github.com/xeipuuv/gojsonpointer/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xeipuuv/gojsonpointer/pointer.go
+++ b/vendor/github.com/xeipuuv/gojsonpointer/pointer.go
@@ -1,0 +1,217 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author  			xeipuuv
+// author-github 	https://github.com/xeipuuv
+// author-mail		xeipuuv@gmail.com
+//
+// repository-name	gojsonpointer
+// repository-desc	An implementation of JSON Pointer - Go language
+//
+// description		Main and unique file.
+//
+// created      	25-02-2013
+
+package gojsonpointer
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+const (
+	const_empty_pointer     = ``
+	const_pointer_separator = `/`
+
+	const_invalid_start = `JSON pointer must be empty or start with a "` + const_pointer_separator + `"`
+)
+
+type implStruct struct {
+	mode string // "SET" or "GET"
+
+	inDocument interface{}
+
+	setInValue interface{}
+
+	getOutNode interface{}
+	getOutKind reflect.Kind
+	outError   error
+}
+
+func NewJsonPointer(jsonPointerString string) (JsonPointer, error) {
+
+	var p JsonPointer
+	err := p.parse(jsonPointerString)
+	return p, err
+
+}
+
+type JsonPointer struct {
+	referenceTokens []string
+}
+
+// "Constructor", parses the given string JSON pointer
+func (p *JsonPointer) parse(jsonPointerString string) error {
+
+	var err error
+
+	if jsonPointerString != const_empty_pointer {
+		if !strings.HasPrefix(jsonPointerString, const_pointer_separator) {
+			err = errors.New(const_invalid_start)
+		} else {
+			referenceTokens := strings.Split(jsonPointerString, const_pointer_separator)
+			for _, referenceToken := range referenceTokens[1:] {
+				p.referenceTokens = append(p.referenceTokens, referenceToken)
+			}
+		}
+	}
+
+	return err
+}
+
+// Uses the pointer to retrieve a value from a JSON document
+func (p *JsonPointer) Get(document interface{}) (interface{}, reflect.Kind, error) {
+
+	is := &implStruct{mode: "GET", inDocument: document}
+	p.implementation(is)
+	return is.getOutNode, is.getOutKind, is.outError
+
+}
+
+// Uses the pointer to update a value from a JSON document
+func (p *JsonPointer) Set(document interface{}, value interface{}) (interface{}, error) {
+
+	is := &implStruct{mode: "SET", inDocument: document, setInValue: value}
+	p.implementation(is)
+	return document, is.outError
+
+}
+
+// Both Get and Set functions use the same implementation to avoid code duplication
+func (p *JsonPointer) implementation(i *implStruct) {
+
+	kind := reflect.Invalid
+
+	// Full document when empty
+	if len(p.referenceTokens) == 0 {
+		i.getOutNode = i.inDocument
+		i.outError = nil
+		i.getOutKind = kind
+		i.outError = nil
+		return
+	}
+
+	node := i.inDocument
+
+	for ti, token := range p.referenceTokens {
+
+		decodedToken := decodeReferenceToken(token)
+		isLastToken := ti == len(p.referenceTokens)-1
+
+		rValue := reflect.ValueOf(node)
+		kind = rValue.Kind()
+
+		switch kind {
+
+		case reflect.Map:
+			m := node.(map[string]interface{})
+			if _, ok := m[decodedToken]; ok {
+				node = m[decodedToken]
+				if isLastToken && i.mode == "SET" {
+					m[decodedToken] = i.setInValue
+				}
+			} else {
+				i.outError = errors.New(fmt.Sprintf("Object has no key '%s'", token))
+				i.getOutKind = kind
+				i.getOutNode = nil
+				return
+			}
+
+		case reflect.Slice:
+			s := node.([]interface{})
+			tokenIndex, err := strconv.Atoi(token)
+			if err != nil {
+				i.outError = errors.New(fmt.Sprintf("Invalid array index '%s'", token))
+				i.getOutKind = kind
+				i.getOutNode = nil
+				return
+			}
+			sLength := len(s)
+			if tokenIndex < 0 || tokenIndex >= sLength {
+				i.outError = errors.New(fmt.Sprintf("Out of bound array[0,%d] index '%d'", sLength, tokenIndex))
+				i.getOutKind = kind
+				i.getOutNode = nil
+				return
+			}
+
+			node = s[tokenIndex]
+			if isLastToken && i.mode == "SET" {
+				s[tokenIndex] = i.setInValue
+			}
+
+		default:
+			i.outError = errors.New(fmt.Sprintf("Invalid token reference '%s'", token))
+			i.getOutKind = kind
+			i.getOutNode = nil
+			return
+		}
+
+	}
+
+	rValue := reflect.ValueOf(node)
+	kind = rValue.Kind()
+
+	i.getOutNode = node
+	i.getOutKind = kind
+	i.outError = nil
+}
+
+// Pointer to string representation function
+func (p *JsonPointer) String() string {
+
+	if len(p.referenceTokens) == 0 {
+		return const_empty_pointer
+	}
+
+	pointerString := const_pointer_separator + strings.Join(p.referenceTokens, const_pointer_separator)
+
+	return pointerString
+}
+
+// Specific JSON pointer encoding here
+// ~0 => ~
+// ~1 => /
+// ... and vice versa
+
+const (
+	const_encoded_reference_token_0 = `~0`
+	const_encoded_reference_token_1 = `~1`
+	const_decoded_reference_token_0 = `~`
+	const_decoded_reference_token_1 = `/`
+)
+
+func decodeReferenceToken(token string) string {
+	step1 := strings.Replace(token, const_encoded_reference_token_1, const_decoded_reference_token_1, -1)
+	step2 := strings.Replace(step1, const_encoded_reference_token_0, const_decoded_reference_token_0, -1)
+	return step2
+}
+
+func encodeReferenceToken(token string) string {
+	step1 := strings.Replace(token, const_decoded_reference_token_1, const_encoded_reference_token_1, -1)
+	step2 := strings.Replace(step1, const_decoded_reference_token_0, const_encoded_reference_token_0, -1)
+	return step2
+}

--- a/vendor/github.com/xeipuuv/gojsonreference/LICENSE-APACHE-2.0.txt
+++ b/vendor/github.com/xeipuuv/gojsonreference/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xeipuuv/gojsonreference/reference.go
+++ b/vendor/github.com/xeipuuv/gojsonreference/reference.go
@@ -1,0 +1,141 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author  			xeipuuv
+// author-github 	https://github.com/xeipuuv
+// author-mail		xeipuuv@gmail.com
+//
+// repository-name	gojsonreference
+// repository-desc	An implementation of JSON Reference - Go language
+//
+// description		Main and unique file.
+//
+// created      	26-02-2013
+
+package gojsonreference
+
+import (
+	"errors"
+	"github.com/xeipuuv/gojsonpointer"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	const_fragment_char = `#`
+)
+
+func NewJsonReference(jsonReferenceString string) (JsonReference, error) {
+
+	var r JsonReference
+	err := r.parse(jsonReferenceString)
+	return r, err
+
+}
+
+type JsonReference struct {
+	referenceUrl     *url.URL
+	referencePointer gojsonpointer.JsonPointer
+
+	HasFullUrl      bool
+	HasUrlPathOnly  bool
+	HasFragmentOnly bool
+	HasFileScheme   bool
+	HasFullFilePath bool
+}
+
+func (r *JsonReference) GetUrl() *url.URL {
+	return r.referenceUrl
+}
+
+func (r *JsonReference) GetPointer() *gojsonpointer.JsonPointer {
+	return &r.referencePointer
+}
+
+func (r *JsonReference) String() string {
+
+	if r.referenceUrl != nil {
+		return r.referenceUrl.String()
+	}
+
+	if r.HasFragmentOnly {
+		return const_fragment_char + r.referencePointer.String()
+	}
+
+	return r.referencePointer.String()
+}
+
+func (r *JsonReference) IsCanonical() bool {
+	return (r.HasFileScheme && r.HasFullFilePath) || (!r.HasFileScheme && r.HasFullUrl)
+}
+
+// "Constructor", parses the given string JSON reference
+func (r *JsonReference) parse(jsonReferenceString string) (err error) {
+
+	r.referenceUrl, err = url.Parse(jsonReferenceString)
+	if err != nil {
+		return
+	}
+	refUrl := r.referenceUrl
+
+	if refUrl.Scheme != "" && refUrl.Host != "" {
+		r.HasFullUrl = true
+	} else {
+		if refUrl.Path != "" {
+			r.HasUrlPathOnly = true
+		} else if refUrl.RawQuery == "" && refUrl.Fragment != "" {
+			r.HasFragmentOnly = true
+		}
+	}
+
+	r.HasFileScheme = refUrl.Scheme == "file"
+	if runtime.GOOS == "windows" {
+		// on Windows, a file URL may have an extra leading slash, and if it
+		// doesn't then its first component will be treated as the host by the
+		// Go runtime
+		if refUrl.Host == "" && strings.HasPrefix(refUrl.Path, "/") {
+			r.HasFullFilePath = filepath.IsAbs(refUrl.Path[1:])
+		} else {
+			r.HasFullFilePath = filepath.IsAbs(refUrl.Host + refUrl.Path)
+		}
+	} else {
+		r.HasFullFilePath = filepath.IsAbs(refUrl.Path)
+	}
+
+	// invalid json-pointer error means url has no json-pointer fragment. simply ignore error
+	r.referencePointer, _ = gojsonpointer.NewJsonPointer(refUrl.Fragment)
+
+	return
+}
+
+// Creates a new reference from a parent and a child
+// If the child cannot inherit from the parent, an error is returned
+func (r *JsonReference) Inherits(child JsonReference) (*JsonReference, error) {
+	childUrl := child.GetUrl()
+	parentUrl := r.GetUrl()
+	if childUrl == nil {
+		return nil, errors.New("childUrl is nil!")
+	}
+	if parentUrl == nil {
+		return nil, errors.New("parentUrl is nil!")
+	}
+
+	ref, err := NewJsonReference(parentUrl.ResolveReference(childUrl).String())
+	if err != nil {
+		return nil, err
+	}
+	return &ref, err
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/LICENSE-APACHE-2.0.txt
+++ b/vendor/github.com/xeipuuv/gojsonschema/LICENSE-APACHE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 xeipuuv
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/xeipuuv/gojsonschema/errors.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/errors.go
@@ -1,0 +1,242 @@
+package gojsonschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	// RequiredError. ErrorDetails: property string
+	RequiredError struct {
+		ResultErrorFields
+	}
+
+	// InvalidTypeError. ErrorDetails: expected, given
+	InvalidTypeError struct {
+		ResultErrorFields
+	}
+
+	// NumberAnyOfError. ErrorDetails: -
+	NumberAnyOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberOneOfError. ErrorDetails: -
+	NumberOneOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberAllOfError. ErrorDetails: -
+	NumberAllOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberNotError. ErrorDetails: -
+	NumberNotError struct {
+		ResultErrorFields
+	}
+
+	// MissingDependencyError. ErrorDetails: dependency
+	MissingDependencyError struct {
+		ResultErrorFields
+	}
+
+	// InternalError. ErrorDetails: error
+	InternalError struct {
+		ResultErrorFields
+	}
+
+	// EnumError. ErrorDetails: allowed
+	EnumError struct {
+		ResultErrorFields
+	}
+
+	// ArrayNoAdditionalItemsError. ErrorDetails: -
+	ArrayNoAdditionalItemsError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMinItemsError. ErrorDetails: min
+	ArrayMinItemsError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMaxItemsError. ErrorDetails: max
+	ArrayMaxItemsError struct {
+		ResultErrorFields
+	}
+
+	// ItemsMustBeUniqueError. ErrorDetails: type
+	ItemsMustBeUniqueError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMinPropertiesError. ErrorDetails: min
+	ArrayMinPropertiesError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMaxPropertiesError. ErrorDetails: max
+	ArrayMaxPropertiesError struct {
+		ResultErrorFields
+	}
+
+	// AdditionalPropertyNotAllowedError. ErrorDetails: property
+	AdditionalPropertyNotAllowedError struct {
+		ResultErrorFields
+	}
+
+	// InvalidPropertyPatternError. ErrorDetails: property, pattern
+	InvalidPropertyPatternError struct {
+		ResultErrorFields
+	}
+
+	// StringLengthGTEError. ErrorDetails: min
+	StringLengthGTEError struct {
+		ResultErrorFields
+	}
+
+	// StringLengthLTEError. ErrorDetails: max
+	StringLengthLTEError struct {
+		ResultErrorFields
+	}
+
+	// DoesNotMatchPatternError. ErrorDetails: pattern
+	DoesNotMatchPatternError struct {
+		ResultErrorFields
+	}
+
+	// DoesNotMatchFormatError. ErrorDetails: format
+	DoesNotMatchFormatError struct {
+		ResultErrorFields
+	}
+
+	// MultipleOfError. ErrorDetails: multiple
+	MultipleOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberGTEError. ErrorDetails: min
+	NumberGTEError struct {
+		ResultErrorFields
+	}
+
+	// NumberGTError. ErrorDetails: min
+	NumberGTError struct {
+		ResultErrorFields
+	}
+
+	// NumberLTEError. ErrorDetails: max
+	NumberLTEError struct {
+		ResultErrorFields
+	}
+
+	// NumberLTError. ErrorDetails: max
+	NumberLTError struct {
+		ResultErrorFields
+	}
+)
+
+// newError takes a ResultError type and sets the type, context, description, details, value, and field
+func newError(err ResultError, context *jsonContext, value interface{}, locale locale, details ErrorDetails) {
+	var t string
+	var d string
+	switch err.(type) {
+	case *RequiredError:
+		t = "required"
+		d = locale.Required()
+	case *InvalidTypeError:
+		t = "invalid_type"
+		d = locale.InvalidType()
+	case *NumberAnyOfError:
+		t = "number_any_of"
+		d = locale.NumberAnyOf()
+	case *NumberOneOfError:
+		t = "number_one_of"
+		d = locale.NumberOneOf()
+	case *NumberAllOfError:
+		t = "number_all_of"
+		d = locale.NumberAllOf()
+	case *NumberNotError:
+		t = "number_not"
+		d = locale.NumberNot()
+	case *MissingDependencyError:
+		t = "missing_dependency"
+		d = locale.MissingDependency()
+	case *InternalError:
+		t = "internal"
+		d = locale.Internal()
+	case *EnumError:
+		t = "enum"
+		d = locale.Enum()
+	case *ArrayNoAdditionalItemsError:
+		t = "array_no_additional_items"
+		d = locale.ArrayNoAdditionalItems()
+	case *ArrayMinItemsError:
+		t = "array_min_items"
+		d = locale.ArrayMinItems()
+	case *ArrayMaxItemsError:
+		t = "array_max_items"
+		d = locale.ArrayMaxItems()
+	case *ItemsMustBeUniqueError:
+		t = "unique"
+		d = locale.Unique()
+	case *ArrayMinPropertiesError:
+		t = "array_min_properties"
+		d = locale.ArrayMinProperties()
+	case *ArrayMaxPropertiesError:
+		t = "array_max_properties"
+		d = locale.ArrayMaxProperties()
+	case *AdditionalPropertyNotAllowedError:
+		t = "additional_property_not_allowed"
+		d = locale.AdditionalPropertyNotAllowed()
+	case *InvalidPropertyPatternError:
+		t = "invalid_property_pattern"
+		d = locale.InvalidPropertyPattern()
+	case *StringLengthGTEError:
+		t = "string_gte"
+		d = locale.StringGTE()
+	case *StringLengthLTEError:
+		t = "string_lte"
+		d = locale.StringLTE()
+	case *DoesNotMatchPatternError:
+		t = "pattern"
+		d = locale.DoesNotMatchPattern()
+	case *DoesNotMatchFormatError:
+		t = "format"
+		d = locale.DoesNotMatchFormat()
+	case *MultipleOfError:
+		t = "multiple_of"
+		d = locale.MultipleOf()
+	case *NumberGTEError:
+		t = "number_gte"
+		d = locale.NumberGTE()
+	case *NumberGTError:
+		t = "number_gt"
+		d = locale.NumberGT()
+	case *NumberLTEError:
+		t = "number_lte"
+		d = locale.NumberLTE()
+	case *NumberLTError:
+		t = "number_lt"
+		d = locale.NumberLT()
+	}
+
+	err.SetType(t)
+	err.SetContext(context)
+	err.SetValue(value)
+	err.SetDetails(details)
+	details["field"] = err.Field()
+	err.SetDescription(formatErrorDescription(d, details))
+}
+
+// formatErrorDescription takes a string in this format: %field% is required
+// and converts it to a string with replacements. The fields come from
+// the ErrorDetails struct and vary for each type of error.
+func formatErrorDescription(s string, details ErrorDetails) string {
+	for name, val := range details {
+		s = strings.Replace(s, "%"+strings.ToLower(name)+"%", fmt.Sprintf("%v", val), -1)
+	}
+
+	return s
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/format_checkers.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/format_checkers.go
@@ -1,0 +1,178 @@
+package gojsonschema
+
+import (
+	"net"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type (
+	// FormatChecker is the interface all formatters added to FormatCheckerChain must implement
+	FormatChecker interface {
+		IsFormat(input string) bool
+	}
+
+	// FormatCheckerChain holds the formatters
+	FormatCheckerChain struct {
+		formatters map[string]FormatChecker
+	}
+
+	// EmailFormatter verifies email address formats
+	EmailFormatChecker struct{}
+
+	// IPV4FormatChecker verifies IP addresses in the ipv4 format
+	IPV4FormatChecker struct{}
+
+	// IPV6FormatChecker verifies IP addresses in the ipv6 format
+	IPV6FormatChecker struct{}
+
+	// DateTimeFormatChecker verifies date/time formats per RFC3339 5.6
+	//
+	// Valid formats:
+	// 		Partial Time: HH:MM:SS
+	//		Full Date: YYYY-MM-DD
+	// 		Full Time: HH:MM:SSZ-07:00
+	//		Date Time: YYYY-MM-DDTHH:MM:SSZ-0700
+	//
+	// 	Where
+	//		YYYY = 4DIGIT year
+	//		MM = 2DIGIT month ; 01-12
+	//		DD = 2DIGIT day-month ; 01-28, 01-29, 01-30, 01-31 based on month/year
+	//		HH = 2DIGIT hour ; 00-23
+	//		MM = 2DIGIT ; 00-59
+	//		SS = 2DIGIT ; 00-58, 00-60 based on leap second rules
+	//		T = Literal
+	//		Z = Literal
+	//
+	//	Note: Nanoseconds are also suported in all formats
+	//
+	// http://tools.ietf.org/html/rfc3339#section-5.6
+	DateTimeFormatChecker struct{}
+
+	// URIFormatCheckers validates a URI with a valid Scheme per RFC3986
+	URIFormatChecker struct{}
+
+	// HostnameFormatChecker validates a hostname is in the correct format
+	HostnameFormatChecker struct{}
+
+	// UUIDFormatChecker validates a UUID is in the correct format
+	UUIDFormatChecker struct{}
+)
+
+var (
+	// Formatters holds the valid formatters, and is a public variable
+	// so library users can add custom formatters
+	FormatCheckers = FormatCheckerChain{
+		formatters: map[string]FormatChecker{
+			"date-time": DateTimeFormatChecker{},
+			"hostname":  HostnameFormatChecker{},
+			"email":     EmailFormatChecker{},
+			"ipv4":      IPV4FormatChecker{},
+			"ipv6":      IPV6FormatChecker{},
+			"uri":       URIFormatChecker{},
+			"uuid":      UUIDFormatChecker{},
+		},
+	}
+
+	// Regex credit: https://github.com/asaskevich/govalidator
+	rxEmail = regexp.MustCompile("^(((([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+(\\.([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+)*)|((\\x22)((((\\x20|\\x09)*(\\x0d\\x0a))?(\\x20|\\x09)+)?(([\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(\\([\\x01-\\x09\\x0b\\x0c\\x0d-\\x7f]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]))))*(((\\x20|\\x09)*(\\x0d\\x0a))?(\\x20|\\x09)+)?(\\x22)))@((([a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(([a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])([a-zA-Z]|\\d|-|\\.|_|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*([a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.)+(([a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(([a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])([a-zA-Z]|\\d|-|\\.|_|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*([a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.?$")
+
+	// Regex credit: https://www.socketloop.com/tutorials/golang-validate-hostname
+	rxHostname = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`)
+
+	rxUUID = regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
+)
+
+// Add adds a FormatChecker to the FormatCheckerChain
+// The name used will be the value used for the format key in your json schema
+func (c *FormatCheckerChain) Add(name string, f FormatChecker) *FormatCheckerChain {
+	c.formatters[name] = f
+
+	return c
+}
+
+// Remove deletes a FormatChecker from the FormatCheckerChain (if it exists)
+func (c *FormatCheckerChain) Remove(name string) *FormatCheckerChain {
+	delete(c.formatters, name)
+
+	return c
+}
+
+// Has checks to see if the FormatCheckerChain holds a FormatChecker with the given name
+func (c *FormatCheckerChain) Has(name string) bool {
+	_, ok := c.formatters[name]
+
+	return ok
+}
+
+// IsFormat will check an input against a FormatChecker with the given name
+// to see if it is the correct format
+func (c *FormatCheckerChain) IsFormat(name string, input interface{}) bool {
+	f, ok := c.formatters[name]
+
+	if !ok {
+		return false
+	}
+
+	if !isKind(input, reflect.String) {
+		return false
+	}
+
+	inputString := input.(string)
+
+	return f.IsFormat(inputString)
+}
+
+func (f EmailFormatChecker) IsFormat(input string) bool {
+	return rxEmail.MatchString(input)
+}
+
+// Credit: https://github.com/asaskevich/govalidator
+func (f IPV4FormatChecker) IsFormat(input string) bool {
+	ip := net.ParseIP(input)
+	return ip != nil && strings.Contains(input, ".")
+}
+
+// Credit: https://github.com/asaskevich/govalidator
+func (f IPV6FormatChecker) IsFormat(input string) bool {
+	ip := net.ParseIP(input)
+	return ip != nil && strings.Contains(input, ":")
+}
+
+func (f DateTimeFormatChecker) IsFormat(input string) bool {
+	formats := []string{
+		"15:04:05",
+		"15:04:05Z07:00",
+		"2006-01-02",
+		time.RFC3339,
+		time.RFC3339Nano,
+	}
+
+	for _, format := range formats {
+		if _, err := time.Parse(format, input); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (f URIFormatChecker) IsFormat(input string) bool {
+	u, err := url.Parse(input)
+	if err != nil || u.Scheme == "" {
+		return false
+	}
+
+	return true
+}
+
+func (f HostnameFormatChecker) IsFormat(input string) bool {
+	return rxHostname.MatchString(input) && len(input) < 256
+}
+
+func (f UUIDFormatChecker) IsFormat(input string) bool {
+	return rxUUID.MatchString(input)
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/internalLog.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/internalLog.go
@@ -1,0 +1,37 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Very simple log wrapper.
+//					Used for debugging/testing purposes.
+//
+// created          01-01-2015
+
+package gojsonschema
+
+import (
+	"log"
+)
+
+const internalLogEnabled = false
+
+func internalLog(format string, v ...interface{}) {
+	log.Printf(format, v...)
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/jsonContext.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/jsonContext.go
@@ -1,0 +1,72 @@
+// Copyright 2013 MongoDB, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           tolsen
+// author-github    https://github.com/tolsen
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Implements a persistent (immutable w/ shared structure) singly-linked list of strings for the purpose of storing a json context
+//
+// created          04-09-2013
+
+package gojsonschema
+
+import "bytes"
+
+// jsonContext implements a persistent linked-list of strings
+type jsonContext struct {
+	head string
+	tail *jsonContext
+}
+
+func newJsonContext(head string, tail *jsonContext) *jsonContext {
+	return &jsonContext{head, tail}
+}
+
+// String displays the context in reverse.
+// This plays well with the data structure's persistent nature with
+// Cons and a json document's tree structure.
+func (c *jsonContext) String(del ...string) string {
+	byteArr := make([]byte, 0, c.stringLen())
+	buf := bytes.NewBuffer(byteArr)
+	c.writeStringToBuffer(buf, del)
+
+	return buf.String()
+}
+
+func (c *jsonContext) stringLen() int {
+	length := 0
+	if c.tail != nil {
+		length = c.tail.stringLen() + 1 // add 1 for "."
+	}
+
+	length += len(c.head)
+	return length
+}
+
+func (c *jsonContext) writeStringToBuffer(buf *bytes.Buffer, del []string) {
+	if c.tail != nil {
+		c.tail.writeStringToBuffer(buf, del)
+
+		if len(del) > 0 {
+			buf.WriteString(del[0])
+		} else {
+			buf.WriteString(".")
+		}
+	}
+
+	buf.WriteString(c.head)
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/jsonLoader.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/jsonLoader.go
@@ -1,0 +1,314 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description		Different strategies to load JSON files.
+// 					Includes References (file and HTTP), JSON strings and Go types.
+//
+// created          01-02-2015
+
+package gojsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+var osFS = osFileSystem(os.Open)
+
+// JSON loader interface
+
+type JSONLoader interface {
+	jsonSource() interface{}
+	loadJSON() (interface{}, error)
+	loadSchema() (*Schema, error)
+}
+
+// osFileSystem is a functional wrapper for os.Open that implements http.FileSystem.
+type osFileSystem func(string) (*os.File, error)
+
+func (o osFileSystem) Open(name string) (http.File, error) {
+	return o(name)
+}
+
+// JSON Reference loader
+// references are used to load JSONs from files and HTTP
+
+type jsonReferenceLoader struct {
+	fs     http.FileSystem
+	source string
+}
+
+func (l *jsonReferenceLoader) jsonSource() interface{} {
+	return l.source
+}
+
+// NewReferenceLoader returns a JSON reference loader using the given source and the local OS file system.
+func NewReferenceLoader(source string) *jsonReferenceLoader {
+	return &jsonReferenceLoader{
+		fs:     osFS,
+		source: source,
+	}
+}
+
+// NewReferenceLoaderFileSystem returns a JSON reference loader using the given source and file system.
+func NewReferenceLoaderFileSystem(source string, fs http.FileSystem) *jsonReferenceLoader {
+	return &jsonReferenceLoader{
+		fs:     fs,
+		source: source,
+	}
+}
+
+func (l *jsonReferenceLoader) loadJSON() (interface{}, error) {
+
+	var err error
+
+	reference, err := gojsonreference.NewJsonReference(l.jsonSource().(string))
+	if err != nil {
+		return nil, err
+	}
+
+	refToUrl := reference
+	refToUrl.GetUrl().Fragment = ""
+
+	var document interface{}
+
+	if reference.HasFileScheme {
+
+		filename := strings.Replace(refToUrl.String(), "file://", "", -1)
+		if runtime.GOOS == "windows" {
+			// on Windows, a file URL may have an extra leading slash, use slashes
+			// instead of backslashes, and have spaces escaped
+			if strings.HasPrefix(filename, "/") {
+				filename = filename[1:]
+			}
+			filename = filepath.FromSlash(filename)
+			filename = strings.Replace(filename, "%20", " ", -1)
+		}
+
+		document, err = l.loadFromFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+	} else {
+
+		document, err = l.loadFromHTTP(refToUrl.String())
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	return document, nil
+
+}
+
+func (l *jsonReferenceLoader) loadSchema() (*Schema, error) {
+
+	var err error
+
+	d := Schema{}
+	d.pool = newSchemaPool(l.fs)
+	d.referencePool = newSchemaReferencePool()
+
+	d.documentReference, err = gojsonreference.NewJsonReference(l.jsonSource().(string))
+	if err != nil {
+		return nil, err
+	}
+
+	spd, err := d.pool.GetDocument(d.documentReference)
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.parse(spd.Document)
+	if err != nil {
+		return nil, err
+	}
+
+	return &d, nil
+
+}
+
+func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) {
+
+	resp, err := http.Get(address)
+	if err != nil {
+		return nil, err
+	}
+
+	// must return HTTP Status 200 OK
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(formatErrorDescription(Locale.httpBadStatus(), ErrorDetails{"status": resp.Status}))
+	}
+
+	bodyBuff, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
+
+}
+
+func (l *jsonReferenceLoader) loadFromFile(path string) (interface{}, error) {
+	f, err := l.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	bodyBuff, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
+
+}
+
+// JSON string loader
+
+type jsonStringLoader struct {
+	source string
+}
+
+func (l *jsonStringLoader) jsonSource() interface{} {
+	return l.source
+}
+
+func NewStringLoader(source string) *jsonStringLoader {
+	return &jsonStringLoader{source: source}
+}
+
+func (l *jsonStringLoader) loadJSON() (interface{}, error) {
+
+	return decodeJsonUsingNumber(strings.NewReader(l.jsonSource().(string)))
+
+}
+
+func (l *jsonStringLoader) loadSchema() (*Schema, error) {
+
+	var err error
+
+	document, err := l.loadJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	d := Schema{}
+	d.pool = newSchemaPool(osFS)
+	d.referencePool = newSchemaReferencePool()
+	d.documentReference, err = gojsonreference.NewJsonReference("#")
+	d.pool.SetStandaloneDocument(document)
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.parse(document)
+	if err != nil {
+		return nil, err
+	}
+
+	return &d, nil
+
+}
+
+// JSON Go (types) loader
+// used to load JSONs from the code as maps, interface{}, structs ...
+
+type jsonGoLoader struct {
+	source interface{}
+}
+
+func (l *jsonGoLoader) jsonSource() interface{} {
+	return l.source
+}
+
+func NewGoLoader(source interface{}) *jsonGoLoader {
+	return &jsonGoLoader{source: source}
+}
+
+func (l *jsonGoLoader) loadJSON() (interface{}, error) {
+
+	// convert it to a compliant JSON first to avoid types "mismatches"
+
+	jsonBytes, err := json.Marshal(l.jsonSource())
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(jsonBytes))
+
+}
+
+func (l *jsonGoLoader) loadSchema() (*Schema, error) {
+
+	var err error
+
+	document, err := l.loadJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	d := Schema{}
+	d.pool = newSchemaPool(osFS)
+	d.referencePool = newSchemaReferencePool()
+	d.documentReference, err = gojsonreference.NewJsonReference("#")
+	d.pool.SetStandaloneDocument(document)
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.parse(document)
+	if err != nil {
+		return nil, err
+	}
+
+	return &d, nil
+
+}
+
+func decodeJsonUsingNumber(r io.Reader) (interface{}, error) {
+
+	var document interface{}
+
+	decoder := json.NewDecoder(r)
+	decoder.UseNumber()
+
+	err := decoder.Decode(&document)
+	if err != nil {
+		return nil, err
+	}
+
+	return document, nil
+
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/locales.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/locales.go
@@ -1,0 +1,275 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Contains const string and messages.
+//
+// created          01-01-2015
+
+package gojsonschema
+
+type (
+	// locale is an interface for definining custom error strings
+	locale interface {
+		Required() string
+		InvalidType() string
+		NumberAnyOf() string
+		NumberOneOf() string
+		NumberAllOf() string
+		NumberNot() string
+		MissingDependency() string
+		Internal() string
+		Enum() string
+		ArrayNoAdditionalItems() string
+		ArrayMinItems() string
+		ArrayMaxItems() string
+		Unique() string
+		ArrayMinProperties() string
+		ArrayMaxProperties() string
+		AdditionalPropertyNotAllowed() string
+		InvalidPropertyPattern() string
+		StringGTE() string
+		StringLTE() string
+		DoesNotMatchPattern() string
+		DoesNotMatchFormat() string
+		MultipleOf() string
+		NumberGTE() string
+		NumberGT() string
+		NumberLTE() string
+		NumberLT() string
+
+		// Schema validations
+		RegexPattern() string
+		GreaterThanZero() string
+		MustBeOfA() string
+		MustBeOfAn() string
+		CannotBeUsedWithout() string
+		CannotBeGT() string
+		MustBeOfType() string
+		MustBeValidRegex() string
+		MustBeValidFormat() string
+		MustBeGTEZero() string
+		KeyCannotBeGreaterThan() string
+		KeyItemsMustBeOfType() string
+		KeyItemsMustBeUnique() string
+		ReferenceMustBeCanonical() string
+		NotAValidType() string
+		Duplicated() string
+		httpBadStatus() string
+
+		// ErrorFormat
+		ErrorFormat() string
+	}
+
+	// DefaultLocale is the default locale for this package
+	DefaultLocale struct{}
+)
+
+func (l DefaultLocale) Required() string {
+	return `%property% is required`
+}
+
+func (l DefaultLocale) InvalidType() string {
+	return `Invalid type. Expected: %expected%, given: %given%`
+}
+
+func (l DefaultLocale) NumberAnyOf() string {
+	return `Must validate at least one schema (anyOf)`
+}
+
+func (l DefaultLocale) NumberOneOf() string {
+	return `Must validate one and only one schema (oneOf)`
+}
+
+func (l DefaultLocale) NumberAllOf() string {
+	return `Must validate all the schemas (allOf)`
+}
+
+func (l DefaultLocale) NumberNot() string {
+	return `Must not validate the schema (not)`
+}
+
+func (l DefaultLocale) MissingDependency() string {
+	return `Has a dependency on %dependency%`
+}
+
+func (l DefaultLocale) Internal() string {
+	return `Internal Error %error%`
+}
+
+func (l DefaultLocale) Enum() string {
+	return `%field% must be one of the following: %allowed%`
+}
+
+func (l DefaultLocale) ArrayNoAdditionalItems() string {
+	return `No additional items allowed on array`
+}
+
+func (l DefaultLocale) ArrayMinItems() string {
+	return `Array must have at least %min% items`
+}
+
+func (l DefaultLocale) ArrayMaxItems() string {
+	return `Array must have at most %max% items`
+}
+
+func (l DefaultLocale) Unique() string {
+	return `%type% items must be unique`
+}
+
+func (l DefaultLocale) ArrayMinProperties() string {
+	return `Must have at least %min% properties`
+}
+
+func (l DefaultLocale) ArrayMaxProperties() string {
+	return `Must have at most %max% properties`
+}
+
+func (l DefaultLocale) AdditionalPropertyNotAllowed() string {
+	return `Additional property %property% is not allowed`
+}
+
+func (l DefaultLocale) InvalidPropertyPattern() string {
+	return `Property "%property%" does not match pattern %pattern%`
+}
+
+func (l DefaultLocale) StringGTE() string {
+	return `String length must be greater than or equal to %min%`
+}
+
+func (l DefaultLocale) StringLTE() string {
+	return `String length must be less than or equal to %max%`
+}
+
+func (l DefaultLocale) DoesNotMatchPattern() string {
+	return `Does not match pattern '%pattern%'`
+}
+
+func (l DefaultLocale) DoesNotMatchFormat() string {
+	return `Does not match format '%format%'`
+}
+
+func (l DefaultLocale) MultipleOf() string {
+	return `Must be a multiple of %multiple%`
+}
+
+func (l DefaultLocale) NumberGTE() string {
+	return `Must be greater than or equal to %min%`
+}
+
+func (l DefaultLocale) NumberGT() string {
+	return `Must be greater than %min%`
+}
+
+func (l DefaultLocale) NumberLTE() string {
+	return `Must be less than or equal to %max%`
+}
+
+func (l DefaultLocale) NumberLT() string {
+	return `Must be less than %max%`
+}
+
+// Schema validators
+func (l DefaultLocale) RegexPattern() string {
+	return `Invalid regex pattern '%pattern%'`
+}
+
+func (l DefaultLocale) GreaterThanZero() string {
+	return `%number% must be strictly greater than 0`
+}
+
+func (l DefaultLocale) MustBeOfA() string {
+	return `%x% must be of a %y%`
+}
+
+func (l DefaultLocale) MustBeOfAn() string {
+	return `%x% must be of an %y%`
+}
+
+func (l DefaultLocale) CannotBeUsedWithout() string {
+	return `%x% cannot be used without %y%`
+}
+
+func (l DefaultLocale) CannotBeGT() string {
+	return `%x% cannot be greater than %y%`
+}
+
+func (l DefaultLocale) MustBeOfType() string {
+	return `%key% must be of type %type%`
+}
+
+func (l DefaultLocale) MustBeValidRegex() string {
+	return `%key% must be a valid regex`
+}
+
+func (l DefaultLocale) MustBeValidFormat() string {
+	return `%key% must be a valid format %given%`
+}
+
+func (l DefaultLocale) MustBeGTEZero() string {
+	return `%key% must be greater than or equal to 0`
+}
+
+func (l DefaultLocale) KeyCannotBeGreaterThan() string {
+	return `%key% cannot be greater than %y%`
+}
+
+func (l DefaultLocale) KeyItemsMustBeOfType() string {
+	return `%key% items must be %type%`
+}
+
+func (l DefaultLocale) KeyItemsMustBeUnique() string {
+	return `%key% items must be unique`
+}
+
+func (l DefaultLocale) ReferenceMustBeCanonical() string {
+	return `Reference %reference% must be canonical`
+}
+
+func (l DefaultLocale) NotAValidType() string {
+	return `%type% is not a valid type -- `
+}
+
+func (l DefaultLocale) Duplicated() string {
+	return `%type% type is duplicated`
+}
+
+func (l DefaultLocale) httpBadStatus() string {
+	return `Could not read schema from HTTP, response status is %status%`
+}
+
+// Replacement options: field, description, context, value
+func (l DefaultLocale) ErrorFormat() string {
+	return `%field%: %description%`
+}
+
+const (
+	STRING_NUMBER                     = "number"
+	STRING_ARRAY_OF_STRINGS           = "array of strings"
+	STRING_ARRAY_OF_SCHEMAS           = "array of schemas"
+	STRING_SCHEMA                     = "schema"
+	STRING_SCHEMA_OR_ARRAY_OF_STRINGS = "schema or array of strings"
+	STRING_PROPERTIES                 = "properties"
+	STRING_DEPENDENCY                 = "dependency"
+	STRING_PROPERTY                   = "property"
+	STRING_UNDEFINED                  = "undefined"
+	STRING_CONTEXT_ROOT               = "(root)"
+	STRING_ROOT_SCHEMA_PROPERTY       = "(root)"
+)

--- a/vendor/github.com/xeipuuv/gojsonschema/result.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/result.go
@@ -1,0 +1,171 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Result and ResultError implementations.
+//
+// created          01-01-2015
+
+package gojsonschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	// ErrorDetails is a map of details specific to each error.
+	// While the values will vary, every error will contain a "field" value
+	ErrorDetails map[string]interface{}
+
+	// ResultError is the interface that library errors must implement
+	ResultError interface {
+		Field() string
+		SetType(string)
+		Type() string
+		SetContext(*jsonContext)
+		Context() *jsonContext
+		SetDescription(string)
+		Description() string
+		SetValue(interface{})
+		Value() interface{}
+		SetDetails(ErrorDetails)
+		Details() ErrorDetails
+	}
+
+	// ResultErrorFields holds the fields for each ResultError implementation.
+	// ResultErrorFields implements the ResultError interface, so custom errors
+	// can be defined by just embedding this type
+	ResultErrorFields struct {
+		errorType   string       // A string with the type of error (i.e. invalid_type)
+		context     *jsonContext // Tree like notation of the part that failed the validation. ex (root).a.b ...
+		description string       // A human readable error message
+		value       interface{}  // Value given by the JSON file that is the source of the error
+		details     ErrorDetails
+	}
+
+	Result struct {
+		errors []ResultError
+		// Scores how well the validation matched. Useful in generating
+		// better error messages for anyOf and oneOf.
+		score int
+	}
+)
+
+// Field outputs the field name without the root context
+// i.e. firstName or person.firstName instead of (root).firstName or (root).person.firstName
+func (v *ResultErrorFields) Field() string {
+	if p, ok := v.Details()["property"]; ok {
+		if str, isString := p.(string); isString {
+			return str
+		}
+	}
+
+	return strings.TrimPrefix(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
+}
+
+func (v *ResultErrorFields) SetType(errorType string) {
+	v.errorType = errorType
+}
+
+func (v *ResultErrorFields) Type() string {
+	return v.errorType
+}
+
+func (v *ResultErrorFields) SetContext(context *jsonContext) {
+	v.context = context
+}
+
+func (v *ResultErrorFields) Context() *jsonContext {
+	return v.context
+}
+
+func (v *ResultErrorFields) SetDescription(description string) {
+	v.description = description
+}
+
+func (v *ResultErrorFields) Description() string {
+	return v.description
+}
+
+func (v *ResultErrorFields) SetValue(value interface{}) {
+	v.value = value
+}
+
+func (v *ResultErrorFields) Value() interface{} {
+	return v.value
+}
+
+func (v *ResultErrorFields) SetDetails(details ErrorDetails) {
+	v.details = details
+}
+
+func (v *ResultErrorFields) Details() ErrorDetails {
+	return v.details
+}
+
+func (v ResultErrorFields) String() string {
+	// as a fallback, the value is displayed go style
+	valueString := fmt.Sprintf("%v", v.value)
+
+	// marshal the go value value to json
+	if v.value == nil {
+		valueString = TYPE_NULL
+	} else {
+		if vs, err := marshalToJsonString(v.value); err == nil {
+			if vs == nil {
+				valueString = TYPE_NULL
+			} else {
+				valueString = *vs
+			}
+		}
+	}
+
+	return formatErrorDescription(Locale.ErrorFormat(), ErrorDetails{
+		"context":     v.context.String(),
+		"description": v.description,
+		"value":       valueString,
+		"field":       v.Field(),
+	})
+}
+
+func (v *Result) Valid() bool {
+	return len(v.errors) == 0
+}
+
+func (v *Result) Errors() []ResultError {
+	return v.errors
+}
+
+func (v *Result) addError(err ResultError, context *jsonContext, value interface{}, details ErrorDetails) {
+	newError(err, context, value, Locale, details)
+	v.errors = append(v.errors, err)
+	v.score -= 2 // results in a net -1 when added to the +1 we get at the end of the validation function
+}
+
+// Used to copy errors from a sub-schema to the main one
+func (v *Result) mergeErrors(otherResult *Result) {
+	v.errors = append(v.errors, otherResult.Errors()...)
+	v.score += otherResult.score
+}
+
+func (v *Result) incrementScore() {
+	v.score++
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/schema.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/schema.go
@@ -1,0 +1,908 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Defines Schema, the main entry to every subSchema.
+//                  Contains the parsing logic and error checking.
+//
+// created          26-02-2013
+
+package gojsonschema
+
+import (
+	//	"encoding/json"
+	"errors"
+	"reflect"
+	"regexp"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+var (
+	// Locale is the default locale to use
+	// Library users can overwrite with their own implementation
+	Locale locale = DefaultLocale{}
+)
+
+func NewSchema(l JSONLoader) (*Schema, error) {
+	return l.loadSchema()
+}
+
+type Schema struct {
+	documentReference gojsonreference.JsonReference
+	rootSchema        *subSchema
+	pool              *schemaPool
+	referencePool     *schemaReferencePool
+}
+
+func (d *Schema) parse(document interface{}) error {
+	d.rootSchema = &subSchema{property: STRING_ROOT_SCHEMA_PROPERTY}
+	return d.parseSchema(document, d.rootSchema)
+}
+
+func (d *Schema) SetRootSchemaName(name string) {
+	d.rootSchema.property = name
+}
+
+// Parses a subSchema
+//
+// Pretty long function ( sorry :) )... but pretty straight forward, repetitive and boring
+// Not much magic involved here, most of the job is to validate the key names and their values,
+// then the values are copied into subSchema struct
+//
+func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema) error {
+
+	if !isKind(documentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_OBJECT,
+				"given":    STRING_SCHEMA,
+			},
+		))
+	}
+
+	m := documentNode.(map[string]interface{})
+
+	if currentSchema == d.rootSchema {
+		currentSchema.ref = &d.documentReference
+	}
+
+	// $subSchema
+	if existsMapKey(m, KEY_SCHEMA) {
+		if !isKind(m[KEY_SCHEMA], reflect.String) {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": TYPE_STRING,
+					"given":    KEY_SCHEMA,
+				},
+			))
+		}
+		schemaRef := m[KEY_SCHEMA].(string)
+		schemaReference, err := gojsonreference.NewJsonReference(schemaRef)
+		currentSchema.subSchema = &schemaReference
+		if err != nil {
+			return err
+		}
+	}
+
+	// $ref
+	if existsMapKey(m, KEY_REF) && !isKind(m[KEY_REF], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_REF,
+			},
+		))
+	}
+	if k, ok := m[KEY_REF].(string); ok {
+
+		if sch, ok := d.referencePool.Get(currentSchema.ref.String() + k); ok {
+
+			currentSchema.refSchema = sch
+
+		} else {
+
+			var err error
+			err = d.parseReference(documentNode, currentSchema, k)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+
+	// definitions
+	if existsMapKey(m, KEY_DEFINITIONS) {
+		if isKind(m[KEY_DEFINITIONS], reflect.Map) {
+			currentSchema.definitions = make(map[string]*subSchema)
+			for dk, dv := range m[KEY_DEFINITIONS].(map[string]interface{}) {
+				if isKind(dv, reflect.Map) {
+					newSchema := &subSchema{property: KEY_DEFINITIONS, parent: currentSchema, ref: currentSchema.ref}
+					currentSchema.definitions[dk] = newSchema
+					err := d.parseSchema(dv, newSchema)
+					if err != nil {
+						return errors.New(err.Error())
+					}
+				} else {
+					return errors.New(formatErrorDescription(
+						Locale.InvalidType(),
+						ErrorDetails{
+							"expected": STRING_ARRAY_OF_SCHEMAS,
+							"given":    KEY_DEFINITIONS,
+						},
+					))
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_ARRAY_OF_SCHEMAS,
+					"given":    KEY_DEFINITIONS,
+				},
+			))
+		}
+
+	}
+
+	// id
+	if existsMapKey(m, KEY_ID) && !isKind(m[KEY_ID], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_ID,
+			},
+		))
+	}
+	if k, ok := m[KEY_ID].(string); ok {
+		currentSchema.id = &k
+	}
+
+	// title
+	if existsMapKey(m, KEY_TITLE) && !isKind(m[KEY_TITLE], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_TITLE,
+			},
+		))
+	}
+	if k, ok := m[KEY_TITLE].(string); ok {
+		currentSchema.title = &k
+	}
+
+	// description
+	if existsMapKey(m, KEY_DESCRIPTION) && !isKind(m[KEY_DESCRIPTION], reflect.String) {
+		return errors.New(formatErrorDescription(
+			Locale.InvalidType(),
+			ErrorDetails{
+				"expected": TYPE_STRING,
+				"given":    KEY_DESCRIPTION,
+			},
+		))
+	}
+	if k, ok := m[KEY_DESCRIPTION].(string); ok {
+		currentSchema.description = &k
+	}
+
+	// type
+	if existsMapKey(m, KEY_TYPE) {
+		if isKind(m[KEY_TYPE], reflect.String) {
+			if k, ok := m[KEY_TYPE].(string); ok {
+				err := currentSchema.types.Add(k)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			if isKind(m[KEY_TYPE], reflect.Slice) {
+				arrayOfTypes := m[KEY_TYPE].([]interface{})
+				for _, typeInArray := range arrayOfTypes {
+					if reflect.ValueOf(typeInArray).Kind() != reflect.String {
+						return errors.New(formatErrorDescription(
+							Locale.InvalidType(),
+							ErrorDetails{
+								"expected": TYPE_STRING + "/" + STRING_ARRAY_OF_STRINGS,
+								"given":    KEY_TYPE,
+							},
+						))
+					} else {
+						currentSchema.types.Add(typeInArray.(string))
+					}
+				}
+
+			} else {
+				return errors.New(formatErrorDescription(
+					Locale.InvalidType(),
+					ErrorDetails{
+						"expected": TYPE_STRING + "/" + STRING_ARRAY_OF_STRINGS,
+						"given":    KEY_TYPE,
+					},
+				))
+			}
+		}
+	}
+
+	// properties
+	if existsMapKey(m, KEY_PROPERTIES) {
+		err := d.parseProperties(m[KEY_PROPERTIES], currentSchema)
+		if err != nil {
+			return err
+		}
+	}
+
+	// additionalProperties
+	if existsMapKey(m, KEY_ADDITIONAL_PROPERTIES) {
+		if isKind(m[KEY_ADDITIONAL_PROPERTIES], reflect.Bool) {
+			currentSchema.additionalProperties = m[KEY_ADDITIONAL_PROPERTIES].(bool)
+		} else if isKind(m[KEY_ADDITIONAL_PROPERTIES], reflect.Map) {
+			newSchema := &subSchema{property: KEY_ADDITIONAL_PROPERTIES, parent: currentSchema, ref: currentSchema.ref}
+			currentSchema.additionalProperties = newSchema
+			err := d.parseSchema(m[KEY_ADDITIONAL_PROPERTIES], newSchema)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": TYPE_BOOLEAN + "/" + STRING_SCHEMA,
+					"given":    KEY_ADDITIONAL_PROPERTIES,
+				},
+			))
+		}
+	}
+
+	// patternProperties
+	if existsMapKey(m, KEY_PATTERN_PROPERTIES) {
+		if isKind(m[KEY_PATTERN_PROPERTIES], reflect.Map) {
+			patternPropertiesMap := m[KEY_PATTERN_PROPERTIES].(map[string]interface{})
+			if len(patternPropertiesMap) > 0 {
+				currentSchema.patternProperties = make(map[string]*subSchema)
+				for k, v := range patternPropertiesMap {
+					_, err := regexp.MatchString(k, "")
+					if err != nil {
+						return errors.New(formatErrorDescription(
+							Locale.RegexPattern(),
+							ErrorDetails{"pattern": k},
+						))
+					}
+					newSchema := &subSchema{property: k, parent: currentSchema, ref: currentSchema.ref}
+					err = d.parseSchema(v, newSchema)
+					if err != nil {
+						return errors.New(err.Error())
+					}
+					currentSchema.patternProperties[k] = newSchema
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_SCHEMA,
+					"given":    KEY_PATTERN_PROPERTIES,
+				},
+			))
+		}
+	}
+
+	// dependencies
+	if existsMapKey(m, KEY_DEPENDENCIES) {
+		err := d.parseDependencies(m[KEY_DEPENDENCIES], currentSchema)
+		if err != nil {
+			return err
+		}
+	}
+
+	// items
+	if existsMapKey(m, KEY_ITEMS) {
+		if isKind(m[KEY_ITEMS], reflect.Slice) {
+			for _, itemElement := range m[KEY_ITEMS].([]interface{}) {
+				if isKind(itemElement, reflect.Map) {
+					newSchema := &subSchema{parent: currentSchema, property: KEY_ITEMS}
+					newSchema.ref = currentSchema.ref
+					currentSchema.AddItemsChild(newSchema)
+					err := d.parseSchema(itemElement, newSchema)
+					if err != nil {
+						return err
+					}
+				} else {
+					return errors.New(formatErrorDescription(
+						Locale.InvalidType(),
+						ErrorDetails{
+							"expected": STRING_SCHEMA + "/" + STRING_ARRAY_OF_SCHEMAS,
+							"given":    KEY_ITEMS,
+						},
+					))
+				}
+				currentSchema.itemsChildrenIsSingleSchema = false
+			}
+		} else if isKind(m[KEY_ITEMS], reflect.Map) {
+			newSchema := &subSchema{parent: currentSchema, property: KEY_ITEMS}
+			newSchema.ref = currentSchema.ref
+			currentSchema.AddItemsChild(newSchema)
+			err := d.parseSchema(m[KEY_ITEMS], newSchema)
+			if err != nil {
+				return err
+			}
+			currentSchema.itemsChildrenIsSingleSchema = true
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_SCHEMA + "/" + STRING_ARRAY_OF_SCHEMAS,
+					"given":    KEY_ITEMS,
+				},
+			))
+		}
+	}
+
+	// additionalItems
+	if existsMapKey(m, KEY_ADDITIONAL_ITEMS) {
+		if isKind(m[KEY_ADDITIONAL_ITEMS], reflect.Bool) {
+			currentSchema.additionalItems = m[KEY_ADDITIONAL_ITEMS].(bool)
+		} else if isKind(m[KEY_ADDITIONAL_ITEMS], reflect.Map) {
+			newSchema := &subSchema{property: KEY_ADDITIONAL_ITEMS, parent: currentSchema, ref: currentSchema.ref}
+			currentSchema.additionalItems = newSchema
+			err := d.parseSchema(m[KEY_ADDITIONAL_ITEMS], newSchema)
+			if err != nil {
+				return errors.New(err.Error())
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": TYPE_BOOLEAN + "/" + STRING_SCHEMA,
+					"given":    KEY_ADDITIONAL_ITEMS,
+				},
+			))
+		}
+	}
+
+	// validation : number / integer
+
+	if existsMapKey(m, KEY_MULTIPLE_OF) {
+		multipleOfValue := mustBeNumber(m[KEY_MULTIPLE_OF])
+		if multipleOfValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.InvalidType(),
+				ErrorDetails{
+					"expected": STRING_NUMBER,
+					"given":    KEY_MULTIPLE_OF,
+				},
+			))
+		}
+		if *multipleOfValue <= 0 {
+			return errors.New(formatErrorDescription(
+				Locale.GreaterThanZero(),
+				ErrorDetails{"number": KEY_MULTIPLE_OF},
+			))
+		}
+		currentSchema.multipleOf = multipleOfValue
+	}
+
+	if existsMapKey(m, KEY_MINIMUM) {
+		minimumValue := mustBeNumber(m[KEY_MINIMUM])
+		if minimumValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_MINIMUM, "y": STRING_NUMBER},
+			))
+		}
+		currentSchema.minimum = minimumValue
+	}
+
+	if existsMapKey(m, KEY_EXCLUSIVE_MINIMUM) {
+		if isKind(m[KEY_EXCLUSIVE_MINIMUM], reflect.Bool) {
+			if currentSchema.minimum == nil {
+				return errors.New(formatErrorDescription(
+					Locale.CannotBeUsedWithout(),
+					ErrorDetails{"x": KEY_EXCLUSIVE_MINIMUM, "y": KEY_MINIMUM},
+				))
+			}
+			exclusiveMinimumValue := m[KEY_EXCLUSIVE_MINIMUM].(bool)
+			currentSchema.exclusiveMinimum = exclusiveMinimumValue
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_EXCLUSIVE_MINIMUM, "y": TYPE_BOOLEAN},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_MAXIMUM) {
+		maximumValue := mustBeNumber(m[KEY_MAXIMUM])
+		if maximumValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_MAXIMUM, "y": STRING_NUMBER},
+			))
+		}
+		currentSchema.maximum = maximumValue
+	}
+
+	if existsMapKey(m, KEY_EXCLUSIVE_MAXIMUM) {
+		if isKind(m[KEY_EXCLUSIVE_MAXIMUM], reflect.Bool) {
+			if currentSchema.maximum == nil {
+				return errors.New(formatErrorDescription(
+					Locale.CannotBeUsedWithout(),
+					ErrorDetails{"x": KEY_EXCLUSIVE_MAXIMUM, "y": KEY_MAXIMUM},
+				))
+			}
+			exclusiveMaximumValue := m[KEY_EXCLUSIVE_MAXIMUM].(bool)
+			currentSchema.exclusiveMaximum = exclusiveMaximumValue
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_EXCLUSIVE_MAXIMUM, "y": STRING_NUMBER},
+			))
+		}
+	}
+
+	if currentSchema.minimum != nil && currentSchema.maximum != nil {
+		if *currentSchema.minimum > *currentSchema.maximum {
+			return errors.New(formatErrorDescription(
+				Locale.CannotBeGT(),
+				ErrorDetails{"x": KEY_MINIMUM, "y": KEY_MAXIMUM},
+			))
+		}
+	}
+
+	// validation : string
+
+	if existsMapKey(m, KEY_MIN_LENGTH) {
+		minLengthIntegerValue := mustBeInteger(m[KEY_MIN_LENGTH])
+		if minLengthIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MIN_LENGTH, "y": TYPE_INTEGER},
+			))
+		}
+		if *minLengthIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MIN_LENGTH},
+			))
+		}
+		currentSchema.minLength = minLengthIntegerValue
+	}
+
+	if existsMapKey(m, KEY_MAX_LENGTH) {
+		maxLengthIntegerValue := mustBeInteger(m[KEY_MAX_LENGTH])
+		if maxLengthIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MAX_LENGTH, "y": TYPE_INTEGER},
+			))
+		}
+		if *maxLengthIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MAX_LENGTH},
+			))
+		}
+		currentSchema.maxLength = maxLengthIntegerValue
+	}
+
+	if currentSchema.minLength != nil && currentSchema.maxLength != nil {
+		if *currentSchema.minLength > *currentSchema.maxLength {
+			return errors.New(formatErrorDescription(
+				Locale.CannotBeGT(),
+				ErrorDetails{"x": KEY_MIN_LENGTH, "y": KEY_MAX_LENGTH},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_PATTERN) {
+		if isKind(m[KEY_PATTERN], reflect.String) {
+			regexpObject, err := regexp.Compile(m[KEY_PATTERN].(string))
+			if err != nil {
+				return errors.New(formatErrorDescription(
+					Locale.MustBeValidRegex(),
+					ErrorDetails{"key": KEY_PATTERN},
+				))
+			}
+			currentSchema.pattern = regexpObject
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_PATTERN, "y": TYPE_STRING},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_FORMAT) {
+		formatString, ok := m[KEY_FORMAT].(string)
+		if ok && FormatCheckers.Has(formatString) {
+			currentSchema.format = formatString
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeValidFormat(),
+				ErrorDetails{"key": KEY_FORMAT, "given": m[KEY_FORMAT]},
+			))
+		}
+	}
+
+	// validation : object
+
+	if existsMapKey(m, KEY_MIN_PROPERTIES) {
+		minPropertiesIntegerValue := mustBeInteger(m[KEY_MIN_PROPERTIES])
+		if minPropertiesIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MIN_PROPERTIES, "y": TYPE_INTEGER},
+			))
+		}
+		if *minPropertiesIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MIN_PROPERTIES},
+			))
+		}
+		currentSchema.minProperties = minPropertiesIntegerValue
+	}
+
+	if existsMapKey(m, KEY_MAX_PROPERTIES) {
+		maxPropertiesIntegerValue := mustBeInteger(m[KEY_MAX_PROPERTIES])
+		if maxPropertiesIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MAX_PROPERTIES, "y": TYPE_INTEGER},
+			))
+		}
+		if *maxPropertiesIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MAX_PROPERTIES},
+			))
+		}
+		currentSchema.maxProperties = maxPropertiesIntegerValue
+	}
+
+	if currentSchema.minProperties != nil && currentSchema.maxProperties != nil {
+		if *currentSchema.minProperties > *currentSchema.maxProperties {
+			return errors.New(formatErrorDescription(
+				Locale.KeyCannotBeGreaterThan(),
+				ErrorDetails{"key": KEY_MIN_PROPERTIES, "y": KEY_MAX_PROPERTIES},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_REQUIRED) {
+		if isKind(m[KEY_REQUIRED], reflect.Slice) {
+			requiredValues := m[KEY_REQUIRED].([]interface{})
+			for _, requiredValue := range requiredValues {
+				if isKind(requiredValue, reflect.String) {
+					err := currentSchema.AddRequired(requiredValue.(string))
+					if err != nil {
+						return err
+					}
+				} else {
+					return errors.New(formatErrorDescription(
+						Locale.KeyItemsMustBeOfType(),
+						ErrorDetails{"key": KEY_REQUIRED, "type": TYPE_STRING},
+					))
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_REQUIRED, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	// validation : array
+
+	if existsMapKey(m, KEY_MIN_ITEMS) {
+		minItemsIntegerValue := mustBeInteger(m[KEY_MIN_ITEMS])
+		if minItemsIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MIN_ITEMS, "y": TYPE_INTEGER},
+			))
+		}
+		if *minItemsIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MIN_ITEMS},
+			))
+		}
+		currentSchema.minItems = minItemsIntegerValue
+	}
+
+	if existsMapKey(m, KEY_MAX_ITEMS) {
+		maxItemsIntegerValue := mustBeInteger(m[KEY_MAX_ITEMS])
+		if maxItemsIntegerValue == nil {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_MAX_ITEMS, "y": TYPE_INTEGER},
+			))
+		}
+		if *maxItemsIntegerValue < 0 {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeGTEZero(),
+				ErrorDetails{"key": KEY_MAX_ITEMS},
+			))
+		}
+		currentSchema.maxItems = maxItemsIntegerValue
+	}
+
+	if existsMapKey(m, KEY_UNIQUE_ITEMS) {
+		if isKind(m[KEY_UNIQUE_ITEMS], reflect.Bool) {
+			currentSchema.uniqueItems = m[KEY_UNIQUE_ITEMS].(bool)
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfA(),
+				ErrorDetails{"x": KEY_UNIQUE_ITEMS, "y": TYPE_BOOLEAN},
+			))
+		}
+	}
+
+	// validation : all
+
+	if existsMapKey(m, KEY_ENUM) {
+		if isKind(m[KEY_ENUM], reflect.Slice) {
+			for _, v := range m[KEY_ENUM].([]interface{}) {
+				err := currentSchema.AddEnum(v)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ENUM, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	// validation : subSchema
+
+	if existsMapKey(m, KEY_ONE_OF) {
+		if isKind(m[KEY_ONE_OF], reflect.Slice) {
+			for _, v := range m[KEY_ONE_OF].([]interface{}) {
+				newSchema := &subSchema{property: KEY_ONE_OF, parent: currentSchema, ref: currentSchema.ref}
+				currentSchema.AddOneOf(newSchema)
+				err := d.parseSchema(v, newSchema)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ONE_OF, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_ANY_OF) {
+		if isKind(m[KEY_ANY_OF], reflect.Slice) {
+			for _, v := range m[KEY_ANY_OF].([]interface{}) {
+				newSchema := &subSchema{property: KEY_ANY_OF, parent: currentSchema, ref: currentSchema.ref}
+				currentSchema.AddAnyOf(newSchema)
+				err := d.parseSchema(v, newSchema)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ANY_OF, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_ALL_OF) {
+		if isKind(m[KEY_ALL_OF], reflect.Slice) {
+			for _, v := range m[KEY_ALL_OF].([]interface{}) {
+				newSchema := &subSchema{property: KEY_ALL_OF, parent: currentSchema, ref: currentSchema.ref}
+				currentSchema.AddAllOf(newSchema)
+				err := d.parseSchema(v, newSchema)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_ANY_OF, "y": TYPE_ARRAY},
+			))
+		}
+	}
+
+	if existsMapKey(m, KEY_NOT) {
+		if isKind(m[KEY_NOT], reflect.Map) {
+			newSchema := &subSchema{property: KEY_NOT, parent: currentSchema, ref: currentSchema.ref}
+			currentSchema.SetNot(newSchema)
+			err := d.parseSchema(m[KEY_NOT], newSchema)
+			if err != nil {
+				return err
+			}
+		} else {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfAn(),
+				ErrorDetails{"x": KEY_NOT, "y": TYPE_OBJECT},
+			))
+		}
+	}
+
+	return nil
+}
+
+func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSchema, reference string) (e error) {
+
+	var err error
+
+	jsonReference, err := gojsonreference.NewJsonReference(reference)
+	if err != nil {
+		return err
+	}
+
+	standaloneDocument := d.pool.GetStandaloneDocument()
+
+	if jsonReference.HasFullUrl {
+		currentSchema.ref = &jsonReference
+	} else {
+		inheritedReference, err := currentSchema.ref.Inherits(jsonReference)
+		if err != nil {
+			return err
+		}
+		currentSchema.ref = inheritedReference
+	}
+
+	jsonPointer := currentSchema.ref.GetPointer()
+
+	var refdDocumentNode interface{}
+
+	if standaloneDocument != nil {
+
+		var err error
+		refdDocumentNode, _, err = jsonPointer.Get(standaloneDocument)
+		if err != nil {
+			return err
+		}
+
+	} else {
+
+		var err error
+		dsp, err := d.pool.GetDocument(*currentSchema.ref)
+		if err != nil {
+			return err
+		}
+
+		refdDocumentNode, _, err = jsonPointer.Get(dsp.Document)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	if !isKind(refdDocumentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.MustBeOfType(),
+			ErrorDetails{"key": STRING_SCHEMA, "type": TYPE_OBJECT},
+		))
+	}
+
+	// returns the loaded referenced subSchema for the caller to update its current subSchema
+	newSchemaDocument := refdDocumentNode.(map[string]interface{})
+
+	newSchema := &subSchema{property: KEY_REF, parent: currentSchema, ref: currentSchema.ref}
+	d.referencePool.Add(currentSchema.ref.String()+reference, newSchema)
+
+	err = d.parseSchema(newSchemaDocument, newSchema)
+	if err != nil {
+		return err
+	}
+
+	currentSchema.refSchema = newSchema
+
+	return nil
+
+}
+
+func (d *Schema) parseProperties(documentNode interface{}, currentSchema *subSchema) error {
+
+	if !isKind(documentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.MustBeOfType(),
+			ErrorDetails{"key": STRING_PROPERTIES, "type": TYPE_OBJECT},
+		))
+	}
+
+	m := documentNode.(map[string]interface{})
+	for k := range m {
+		schemaProperty := k
+		newSchema := &subSchema{property: schemaProperty, parent: currentSchema, ref: currentSchema.ref}
+		currentSchema.AddPropertiesChild(newSchema)
+		err := d.parseSchema(m[k], newSchema)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *Schema) parseDependencies(documentNode interface{}, currentSchema *subSchema) error {
+
+	if !isKind(documentNode, reflect.Map) {
+		return errors.New(formatErrorDescription(
+			Locale.MustBeOfType(),
+			ErrorDetails{"key": KEY_DEPENDENCIES, "type": TYPE_OBJECT},
+		))
+	}
+
+	m := documentNode.(map[string]interface{})
+	currentSchema.dependencies = make(map[string]interface{})
+
+	for k := range m {
+		switch reflect.ValueOf(m[k]).Kind() {
+
+		case reflect.Slice:
+			values := m[k].([]interface{})
+			var valuesToRegister []string
+
+			for _, value := range values {
+				if !isKind(value, reflect.String) {
+					return errors.New(formatErrorDescription(
+						Locale.MustBeOfType(),
+						ErrorDetails{
+							"key":  STRING_DEPENDENCY,
+							"type": STRING_SCHEMA_OR_ARRAY_OF_STRINGS,
+						},
+					))
+				} else {
+					valuesToRegister = append(valuesToRegister, value.(string))
+				}
+				currentSchema.dependencies[k] = valuesToRegister
+			}
+
+		case reflect.Map:
+			depSchema := &subSchema{property: k, parent: currentSchema, ref: currentSchema.ref}
+			err := d.parseSchema(m[k], depSchema)
+			if err != nil {
+				return err
+			}
+			currentSchema.dependencies[k] = depSchema
+
+		default:
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfType(),
+				ErrorDetails{
+					"key":  STRING_DEPENDENCY,
+					"type": STRING_SCHEMA_OR_ARRAY_OF_STRINGS,
+				},
+			))
+		}
+
+	}
+
+	return nil
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/schemaPool.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/schemaPool.go
@@ -1,0 +1,110 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description		Defines resources pooling.
+//                  Eases referencing and avoids downloading the same resource twice.
+//
+// created          26-02-2013
+
+package gojsonschema
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+type schemaPoolDocument struct {
+	Document interface{}
+}
+
+type schemaPool struct {
+	schemaPoolDocuments map[string]*schemaPoolDocument
+	standaloneDocument  interface{}
+	fs                  http.FileSystem
+}
+
+func newSchemaPool(fs http.FileSystem) *schemaPool {
+
+	p := &schemaPool{}
+	p.schemaPoolDocuments = make(map[string]*schemaPoolDocument)
+	p.standaloneDocument = nil
+	p.fs = fs
+
+	return p
+}
+
+func (p *schemaPool) SetStandaloneDocument(document interface{}) {
+	p.standaloneDocument = document
+}
+
+func (p *schemaPool) GetStandaloneDocument() (document interface{}) {
+	return p.standaloneDocument
+}
+
+func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*schemaPoolDocument, error) {
+
+	if internalLogEnabled {
+		internalLog("Get Document ( %s )", reference.String())
+	}
+
+	var err error
+
+	// It is not possible to load anything that is not canonical...
+	if !reference.IsCanonical() {
+		return nil, errors.New(formatErrorDescription(
+			Locale.ReferenceMustBeCanonical(),
+			ErrorDetails{"reference": reference},
+		))
+	}
+
+	refToUrl := reference
+	refToUrl.GetUrl().Fragment = ""
+
+	var spd *schemaPoolDocument
+
+	// Try to find the requested document in the pool
+	for k := range p.schemaPoolDocuments {
+		if k == refToUrl.String() {
+			spd = p.schemaPoolDocuments[k]
+		}
+	}
+
+	if spd != nil {
+		if internalLogEnabled {
+			internalLog(" From pool")
+		}
+		return spd, nil
+	}
+
+	jsonReferenceLoader := NewReferenceLoaderFileSystem(reference.String(), p.fs)
+	document, err := jsonReferenceLoader.loadJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	spd = &schemaPoolDocument{Document: document}
+	// add the document to the pool for potential later use
+	p.schemaPoolDocuments[refToUrl.String()] = spd
+
+	return spd, nil
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/schemaReferencePool.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/schemaReferencePool.go
@@ -1,0 +1,67 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Pool of referenced schemas.
+//
+// created          25-06-2013
+
+package gojsonschema
+
+import (
+	"fmt"
+)
+
+type schemaReferencePool struct {
+	documents map[string]*subSchema
+}
+
+func newSchemaReferencePool() *schemaReferencePool {
+
+	p := &schemaReferencePool{}
+	p.documents = make(map[string]*subSchema)
+
+	return p
+}
+
+func (p *schemaReferencePool) Get(ref string) (r *subSchema, o bool) {
+
+	if internalLogEnabled {
+		internalLog(fmt.Sprintf("Schema Reference ( %s )", ref))
+	}
+
+	if sch, ok := p.documents[ref]; ok {
+		if internalLogEnabled {
+			internalLog(fmt.Sprintf(" From pool"))
+		}
+		return sch, true
+	}
+
+	return nil, false
+}
+
+func (p *schemaReferencePool) Add(ref string, sch *subSchema) {
+
+	if internalLogEnabled {
+		internalLog(fmt.Sprintf("Add Schema Reference %s to pool", ref))
+	}
+
+	p.documents[ref] = sch
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/schemaType.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/schemaType.go
@@ -1,0 +1,83 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Helper structure to handle schema types, and the combination of them.
+//
+// created          28-02-2013
+
+package gojsonschema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type jsonSchemaType struct {
+	types []string
+}
+
+// Is the schema typed ? that is containing at least one type
+// When not typed, the schema does not need any type validation
+func (t *jsonSchemaType) IsTyped() bool {
+	return len(t.types) > 0
+}
+
+func (t *jsonSchemaType) Add(etype string) error {
+
+	if !isStringInSlice(JSON_TYPES, etype) {
+		return errors.New(formatErrorDescription(Locale.NotAValidType(), ErrorDetails{"type": etype}))
+	}
+
+	if t.Contains(etype) {
+		return errors.New(formatErrorDescription(Locale.Duplicated(), ErrorDetails{"type": etype}))
+	}
+
+	t.types = append(t.types, etype)
+
+	return nil
+}
+
+func (t *jsonSchemaType) Contains(etype string) bool {
+
+	for _, v := range t.types {
+		if v == etype {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *jsonSchemaType) String() string {
+
+	if len(t.types) == 0 {
+		return STRING_UNDEFINED // should never happen
+	}
+
+	// Displayed as a list [type1,type2,...]
+	if len(t.types) > 1 {
+		return fmt.Sprintf("[%s]", strings.Join(t.types, ","))
+	}
+
+	// Only one type: name only
+	return t.types[0]
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/subSchema.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/subSchema.go
@@ -1,0 +1,227 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Defines the structure of a sub-subSchema.
+//                  A sub-subSchema can contain other sub-schemas.
+//
+// created          27-02-2013
+
+package gojsonschema
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
+const (
+	KEY_SCHEMA                = "$subSchema"
+	KEY_ID                    = "$id"
+	KEY_REF                   = "$ref"
+	KEY_TITLE                 = "title"
+	KEY_DESCRIPTION           = "description"
+	KEY_TYPE                  = "type"
+	KEY_ITEMS                 = "items"
+	KEY_ADDITIONAL_ITEMS      = "additionalItems"
+	KEY_PROPERTIES            = "properties"
+	KEY_PATTERN_PROPERTIES    = "patternProperties"
+	KEY_ADDITIONAL_PROPERTIES = "additionalProperties"
+	KEY_DEFINITIONS           = "definitions"
+	KEY_MULTIPLE_OF           = "multipleOf"
+	KEY_MINIMUM               = "minimum"
+	KEY_MAXIMUM               = "maximum"
+	KEY_EXCLUSIVE_MINIMUM     = "exclusiveMinimum"
+	KEY_EXCLUSIVE_MAXIMUM     = "exclusiveMaximum"
+	KEY_MIN_LENGTH            = "minLength"
+	KEY_MAX_LENGTH            = "maxLength"
+	KEY_PATTERN               = "pattern"
+	KEY_FORMAT                = "format"
+	KEY_MIN_PROPERTIES        = "minProperties"
+	KEY_MAX_PROPERTIES        = "maxProperties"
+	KEY_DEPENDENCIES          = "dependencies"
+	KEY_REQUIRED              = "required"
+	KEY_MIN_ITEMS             = "minItems"
+	KEY_MAX_ITEMS             = "maxItems"
+	KEY_UNIQUE_ITEMS          = "uniqueItems"
+	KEY_ENUM                  = "enum"
+	KEY_ONE_OF                = "oneOf"
+	KEY_ANY_OF                = "anyOf"
+	KEY_ALL_OF                = "allOf"
+	KEY_NOT                   = "not"
+)
+
+type subSchema struct {
+
+	// basic subSchema meta properties
+	id          *string
+	title       *string
+	description *string
+
+	property string
+
+	// Types associated with the subSchema
+	types jsonSchemaType
+
+	// Reference url
+	ref *gojsonreference.JsonReference
+	// Schema referenced
+	refSchema *subSchema
+	// Json reference
+	subSchema *gojsonreference.JsonReference
+
+	// hierarchy
+	parent                      *subSchema
+	definitions                 map[string]*subSchema
+	definitionsChildren         []*subSchema
+	itemsChildren               []*subSchema
+	itemsChildrenIsSingleSchema bool
+	propertiesChildren          []*subSchema
+
+	// validation : number / integer
+	multipleOf       *float64
+	maximum          *float64
+	exclusiveMaximum bool
+	minimum          *float64
+	exclusiveMinimum bool
+
+	// validation : string
+	minLength *int
+	maxLength *int
+	pattern   *regexp.Regexp
+	format    string
+
+	// validation : object
+	minProperties *int
+	maxProperties *int
+	required      []string
+
+	dependencies         map[string]interface{}
+	additionalProperties interface{}
+	patternProperties    map[string]*subSchema
+
+	// validation : array
+	minItems    *int
+	maxItems    *int
+	uniqueItems bool
+
+	additionalItems interface{}
+
+	// validation : all
+	enum []string
+
+	// validation : subSchema
+	oneOf []*subSchema
+	anyOf []*subSchema
+	allOf []*subSchema
+	not   *subSchema
+}
+
+func (s *subSchema) AddEnum(i interface{}) error {
+
+	is, err := marshalToJsonString(i)
+	if err != nil {
+		return err
+	}
+
+	if isStringInSlice(s.enum, *is) {
+		return errors.New(formatErrorDescription(
+			Locale.KeyItemsMustBeUnique(),
+			ErrorDetails{"key": KEY_ENUM},
+		))
+	}
+
+	s.enum = append(s.enum, *is)
+
+	return nil
+}
+
+func (s *subSchema) ContainsEnum(i interface{}) (bool, error) {
+
+	is, err := marshalToJsonString(i)
+	if err != nil {
+		return false, err
+	}
+
+	return isStringInSlice(s.enum, *is), nil
+}
+
+func (s *subSchema) AddOneOf(subSchema *subSchema) {
+	s.oneOf = append(s.oneOf, subSchema)
+}
+
+func (s *subSchema) AddAllOf(subSchema *subSchema) {
+	s.allOf = append(s.allOf, subSchema)
+}
+
+func (s *subSchema) AddAnyOf(subSchema *subSchema) {
+	s.anyOf = append(s.anyOf, subSchema)
+}
+
+func (s *subSchema) SetNot(subSchema *subSchema) {
+	s.not = subSchema
+}
+
+func (s *subSchema) AddRequired(value string) error {
+
+	if isStringInSlice(s.required, value) {
+		return errors.New(formatErrorDescription(
+			Locale.KeyItemsMustBeUnique(),
+			ErrorDetails{"key": KEY_REQUIRED},
+		))
+	}
+
+	s.required = append(s.required, value)
+
+	return nil
+}
+
+func (s *subSchema) AddDefinitionChild(child *subSchema) {
+	s.definitionsChildren = append(s.definitionsChildren, child)
+}
+
+func (s *subSchema) AddItemsChild(child *subSchema) {
+	s.itemsChildren = append(s.itemsChildren, child)
+}
+
+func (s *subSchema) AddPropertiesChild(child *subSchema) {
+	s.propertiesChildren = append(s.propertiesChildren, child)
+}
+
+func (s *subSchema) PatternPropertiesString() string {
+
+	if s.patternProperties == nil || len(s.patternProperties) == 0 {
+		return STRING_UNDEFINED // should never happen
+	}
+
+	patternPropertiesKeySlice := []string{}
+	for pk, _ := range s.patternProperties {
+		patternPropertiesKeySlice = append(patternPropertiesKeySlice, `"`+pk+`"`)
+	}
+
+	if len(patternPropertiesKeySlice) == 1 {
+		return patternPropertiesKeySlice[0]
+	}
+
+	return "[" + strings.Join(patternPropertiesKeySlice, ",") + "]"
+
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/types.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/types.go
@@ -1,0 +1,58 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Contains const types for schema and JSON.
+//
+// created          28-02-2013
+
+package gojsonschema
+
+const (
+	TYPE_ARRAY   = `array`
+	TYPE_BOOLEAN = `boolean`
+	TYPE_INTEGER = `integer`
+	TYPE_NUMBER  = `number`
+	TYPE_NULL    = `null`
+	TYPE_OBJECT  = `object`
+	TYPE_STRING  = `string`
+)
+
+var JSON_TYPES []string
+var SCHEMA_TYPES []string
+
+func init() {
+	JSON_TYPES = []string{
+		TYPE_ARRAY,
+		TYPE_BOOLEAN,
+		TYPE_INTEGER,
+		TYPE_NUMBER,
+		TYPE_NULL,
+		TYPE_OBJECT,
+		TYPE_STRING}
+
+	SCHEMA_TYPES = []string{
+		TYPE_ARRAY,
+		TYPE_BOOLEAN,
+		TYPE_INTEGER,
+		TYPE_NUMBER,
+		TYPE_OBJECT,
+		TYPE_STRING}
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/utils.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/utils.go
@@ -1,0 +1,203 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Various utility functions.
+//
+// created          26-02-2013
+
+package gojsonschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+)
+
+func isKind(what interface{}, kind reflect.Kind) bool {
+	return reflect.ValueOf(what).Kind() == kind
+}
+
+func existsMapKey(m map[string]interface{}, k string) bool {
+	_, ok := m[k]
+	return ok
+}
+
+func isStringInSlice(s []string, what string) bool {
+	for i := range s {
+		if s[i] == what {
+			return true
+		}
+	}
+	return false
+}
+
+func marshalToJsonString(value interface{}) (*string, error) {
+
+	mBytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	sBytes := string(mBytes)
+	return &sBytes, nil
+}
+
+func isJsonNumber(what interface{}) bool {
+
+	switch what.(type) {
+
+	case json.Number:
+		return true
+	}
+
+	return false
+}
+
+func checkJsonNumber(what interface{}) (isValidFloat64 bool, isValidInt64 bool, isValidInt32 bool) {
+
+	jsonNumber := what.(json.Number)
+
+	f64, errFloat64 := jsonNumber.Float64()
+	s64 := strconv.FormatFloat(f64, 'f', -1, 64)
+	_, errInt64 := strconv.ParseInt(s64, 10, 64)
+
+	isValidFloat64 = errFloat64 == nil
+	isValidInt64 = errInt64 == nil
+
+	_, errInt32 := strconv.ParseInt(s64, 10, 32)
+	isValidInt32 = isValidInt64 && errInt32 == nil
+
+	return
+
+}
+
+// same as ECMA Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
+const (
+	max_json_float = float64(1<<53 - 1)  // 9007199254740991.0 	 2^53 - 1
+	min_json_float = -float64(1<<53 - 1) //-9007199254740991.0	-2^53 - 1
+)
+
+func isFloat64AnInteger(f float64) bool {
+
+	if math.IsNaN(f) || math.IsInf(f, 0) || f < min_json_float || f > max_json_float {
+		return false
+	}
+
+	return f == float64(int64(f)) || f == float64(uint64(f))
+}
+
+func mustBeInteger(what interface{}) *int {
+
+	if isJsonNumber(what) {
+
+		number := what.(json.Number)
+
+		_, _, isValidInt32 := checkJsonNumber(number)
+
+		if isValidInt32 {
+
+			int64Value, err := number.Int64()
+			if err != nil {
+				return nil
+			}
+
+			int32Value := int(int64Value)
+			return &int32Value
+
+		} else {
+			return nil
+		}
+
+	}
+
+	return nil
+}
+
+func mustBeNumber(what interface{}) *float64 {
+
+	if isJsonNumber(what) {
+
+		number := what.(json.Number)
+		float64Value, err := number.Float64()
+
+		if err == nil {
+			return &float64Value
+		} else {
+			return nil
+		}
+
+	}
+
+	return nil
+
+}
+
+// formats a number so that it is displayed as the smallest string possible
+func resultErrorFormatJsonNumber(n json.Number) string {
+
+	if int64Value, err := n.Int64(); err == nil {
+		return fmt.Sprintf("%d", int64Value)
+	}
+
+	float64Value, _ := n.Float64()
+
+	return fmt.Sprintf("%g", float64Value)
+}
+
+// formats a number so that it is displayed as the smallest string possible
+func resultErrorFormatNumber(n float64) string {
+
+	if isFloat64AnInteger(n) {
+		return fmt.Sprintf("%d", int64(n))
+	}
+
+	return fmt.Sprintf("%g", n)
+}
+
+func convertDocumentNode(val interface{}) interface{} {
+
+	if lval, ok := val.([]interface{}); ok {
+
+		res := []interface{}{}
+		for _, v := range lval {
+			res = append(res, convertDocumentNode(v))
+		}
+
+		return res
+
+	}
+
+	if mval, ok := val.(map[interface{}]interface{}); ok {
+
+		res := map[string]interface{}{}
+
+		for k, v := range mval {
+			res[k.(string)] = convertDocumentNode(v)
+		}
+
+		return res
+
+	}
+
+	return val
+}

--- a/vendor/github.com/xeipuuv/gojsonschema/validation.go
+++ b/vendor/github.com/xeipuuv/gojsonschema/validation.go
@@ -1,0 +1,829 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author           xeipuuv
+// author-github    https://github.com/xeipuuv
+// author-mail      xeipuuv@gmail.com
+//
+// repository-name  gojsonschema
+// repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
+//
+// description      Extends Schema and subSchema, implements the validation phase.
+//
+// created          28-02-2013
+
+package gojsonschema
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+func Validate(ls JSONLoader, ld JSONLoader) (*Result, error) {
+
+	var err error
+
+	// load schema
+
+	schema, err := NewSchema(ls)
+	if err != nil {
+		return nil, err
+	}
+
+	// begine validation
+
+	return schema.Validate(ld)
+
+}
+
+func (v *Schema) Validate(l JSONLoader) (*Result, error) {
+
+	// load document
+
+	root, err := l.loadJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	// begin validation
+
+	result := &Result{}
+	context := newJsonContext(STRING_CONTEXT_ROOT, nil)
+	v.rootSchema.validateRecursive(v.rootSchema, root, result, context)
+
+	return result, nil
+
+}
+
+func (v *subSchema) subValidateWithContext(document interface{}, context *jsonContext) *Result {
+	result := &Result{}
+	v.validateRecursive(v, document, result, context)
+	return result
+}
+
+// Walker function to validate the json recursively against the subSchema
+func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateRecursive %s", context.String())
+		internalLog(" %v", currentNode)
+	}
+
+	// Handle referenced schemas, returns directly when a $ref is found
+	if currentSubSchema.refSchema != nil {
+		v.validateRecursive(currentSubSchema.refSchema, currentNode, result, context)
+		return
+	}
+
+	// Check for null value
+	if currentNode == nil {
+		if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_NULL) {
+			result.addError(
+				new(InvalidTypeError),
+				context,
+				currentNode,
+				ErrorDetails{
+					"expected": currentSubSchema.types.String(),
+					"given":    TYPE_NULL,
+				},
+			)
+			return
+		}
+
+		currentSubSchema.validateSchema(currentSubSchema, currentNode, result, context)
+		v.validateCommon(currentSubSchema, currentNode, result, context)
+
+	} else { // Not a null value
+
+		if isJsonNumber(currentNode) {
+
+			value := currentNode.(json.Number)
+
+			_, isValidInt64, _ := checkJsonNumber(value)
+
+			validType := currentSubSchema.types.Contains(TYPE_NUMBER) || (isValidInt64 && currentSubSchema.types.Contains(TYPE_INTEGER))
+
+			if currentSubSchema.types.IsTyped() && !validType {
+
+				givenType := TYPE_INTEGER
+				if !isValidInt64 {
+					givenType = TYPE_NUMBER
+				}
+
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    givenType,
+					},
+				)
+				return
+			}
+
+			currentSubSchema.validateSchema(currentSubSchema, value, result, context)
+			v.validateNumber(currentSubSchema, value, result, context)
+			v.validateCommon(currentSubSchema, value, result, context)
+			v.validateString(currentSubSchema, value, result, context)
+
+		} else {
+
+			rValue := reflect.ValueOf(currentNode)
+			rKind := rValue.Kind()
+
+			switch rKind {
+
+			// Slice => JSON array
+
+			case reflect.Slice:
+
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_ARRAY) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_ARRAY,
+						},
+					)
+					return
+				}
+
+				castCurrentNode := currentNode.([]interface{})
+
+				currentSubSchema.validateSchema(currentSubSchema, castCurrentNode, result, context)
+
+				v.validateArray(currentSubSchema, castCurrentNode, result, context)
+				v.validateCommon(currentSubSchema, castCurrentNode, result, context)
+
+			// Map => JSON object
+
+			case reflect.Map:
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_OBJECT) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_OBJECT,
+						},
+					)
+					return
+				}
+
+				castCurrentNode, ok := currentNode.(map[string]interface{})
+				if !ok {
+					castCurrentNode = convertDocumentNode(currentNode).(map[string]interface{})
+				}
+
+				currentSubSchema.validateSchema(currentSubSchema, castCurrentNode, result, context)
+
+				v.validateObject(currentSubSchema, castCurrentNode, result, context)
+				v.validateCommon(currentSubSchema, castCurrentNode, result, context)
+
+				for _, pSchema := range currentSubSchema.propertiesChildren {
+					nextNode, ok := castCurrentNode[pSchema.property]
+					if ok {
+						subContext := newJsonContext(pSchema.property, context)
+						v.validateRecursive(pSchema, nextNode, result, subContext)
+					}
+				}
+
+			// Simple JSON values : string, number, boolean
+
+			case reflect.Bool:
+
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_BOOLEAN) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_BOOLEAN,
+						},
+					)
+					return
+				}
+
+				value := currentNode.(bool)
+
+				currentSubSchema.validateSchema(currentSubSchema, value, result, context)
+				v.validateNumber(currentSubSchema, value, result, context)
+				v.validateCommon(currentSubSchema, value, result, context)
+				v.validateString(currentSubSchema, value, result, context)
+
+			case reflect.String:
+
+				if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_STRING) {
+					result.addError(
+						new(InvalidTypeError),
+						context,
+						currentNode,
+						ErrorDetails{
+							"expected": currentSubSchema.types.String(),
+							"given":    TYPE_STRING,
+						},
+					)
+					return
+				}
+
+				value := currentNode.(string)
+
+				currentSubSchema.validateSchema(currentSubSchema, value, result, context)
+				v.validateNumber(currentSubSchema, value, result, context)
+				v.validateCommon(currentSubSchema, value, result, context)
+				v.validateString(currentSubSchema, value, result, context)
+
+			}
+
+		}
+
+	}
+
+	result.incrementScore()
+}
+
+// Different kinds of validation there, subSchema / common / array / object / string...
+func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateSchema %s", context.String())
+		internalLog(" %v", currentNode)
+	}
+
+	if len(currentSubSchema.anyOf) > 0 {
+
+		validatedAnyOf := false
+		var bestValidationResult *Result
+
+		for _, anyOfSchema := range currentSubSchema.anyOf {
+			if !validatedAnyOf {
+				validationResult := anyOfSchema.subValidateWithContext(currentNode, context)
+				validatedAnyOf = validationResult.Valid()
+
+				if !validatedAnyOf && (bestValidationResult == nil || validationResult.score > bestValidationResult.score) {
+					bestValidationResult = validationResult
+				}
+			}
+		}
+		if !validatedAnyOf {
+
+			result.addError(new(NumberAnyOfError), context, currentNode, ErrorDetails{})
+
+			if bestValidationResult != nil {
+				// add error messages of closest matching subSchema as
+				// that's probably the one the user was trying to match
+				result.mergeErrors(bestValidationResult)
+			}
+		}
+	}
+
+	if len(currentSubSchema.oneOf) > 0 {
+
+		nbValidated := 0
+		var bestValidationResult *Result
+
+		for _, oneOfSchema := range currentSubSchema.oneOf {
+			validationResult := oneOfSchema.subValidateWithContext(currentNode, context)
+			if validationResult.Valid() {
+				nbValidated++
+			} else if nbValidated == 0 && (bestValidationResult == nil || validationResult.score > bestValidationResult.score) {
+				bestValidationResult = validationResult
+			}
+		}
+
+		if nbValidated != 1 {
+
+			result.addError(new(NumberOneOfError), context, currentNode, ErrorDetails{})
+
+			if nbValidated == 0 {
+				// add error messages of closest matching subSchema as
+				// that's probably the one the user was trying to match
+				result.mergeErrors(bestValidationResult)
+			}
+		}
+
+	}
+
+	if len(currentSubSchema.allOf) > 0 {
+		nbValidated := 0
+
+		for _, allOfSchema := range currentSubSchema.allOf {
+			validationResult := allOfSchema.subValidateWithContext(currentNode, context)
+			if validationResult.Valid() {
+				nbValidated++
+			}
+			result.mergeErrors(validationResult)
+		}
+
+		if nbValidated != len(currentSubSchema.allOf) {
+			result.addError(new(NumberAllOfError), context, currentNode, ErrorDetails{})
+		}
+	}
+
+	if currentSubSchema.not != nil {
+		validationResult := currentSubSchema.not.subValidateWithContext(currentNode, context)
+		if validationResult.Valid() {
+			result.addError(new(NumberNotError), context, currentNode, ErrorDetails{})
+		}
+	}
+
+	if currentSubSchema.dependencies != nil && len(currentSubSchema.dependencies) > 0 {
+		if isKind(currentNode, reflect.Map) {
+			for elementKey := range currentNode.(map[string]interface{}) {
+				if dependency, ok := currentSubSchema.dependencies[elementKey]; ok {
+					switch dependency := dependency.(type) {
+
+					case []string:
+						for _, dependOnKey := range dependency {
+							if _, dependencyResolved := currentNode.(map[string]interface{})[dependOnKey]; !dependencyResolved {
+								result.addError(
+									new(MissingDependencyError),
+									context,
+									currentNode,
+									ErrorDetails{"dependency": dependOnKey},
+								)
+							}
+						}
+
+					case *subSchema:
+						dependency.validateRecursive(dependency, currentNode, result, context)
+
+					}
+				}
+			}
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateCommon(currentSubSchema *subSchema, value interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateCommon %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	// enum:
+	if len(currentSubSchema.enum) > 0 {
+		has, err := currentSubSchema.ContainsEnum(value)
+		if err != nil {
+			result.addError(new(InternalError), context, value, ErrorDetails{"error": err})
+		}
+		if !has {
+			result.addError(
+				new(EnumError),
+				context,
+				value,
+				ErrorDetails{
+					"allowed": strings.Join(currentSubSchema.enum, ", "),
+				},
+			)
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateArray %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	nbItems := len(value)
+
+	// TODO explain
+	if currentSubSchema.itemsChildrenIsSingleSchema {
+		for i := range value {
+			subContext := newJsonContext(strconv.Itoa(i), context)
+			validationResult := currentSubSchema.itemsChildren[0].subValidateWithContext(value[i], subContext)
+			result.mergeErrors(validationResult)
+		}
+	} else {
+		if currentSubSchema.itemsChildren != nil && len(currentSubSchema.itemsChildren) > 0 {
+
+			nbItems := len(currentSubSchema.itemsChildren)
+			nbValues := len(value)
+
+			if nbItems == nbValues {
+				for i := 0; i != nbItems; i++ {
+					subContext := newJsonContext(strconv.Itoa(i), context)
+					validationResult := currentSubSchema.itemsChildren[i].subValidateWithContext(value[i], subContext)
+					result.mergeErrors(validationResult)
+				}
+			} else if nbItems < nbValues {
+				switch currentSubSchema.additionalItems.(type) {
+				case bool:
+					if !currentSubSchema.additionalItems.(bool) {
+						result.addError(new(ArrayNoAdditionalItemsError), context, value, ErrorDetails{})
+					}
+				case *subSchema:
+					additionalItemSchema := currentSubSchema.additionalItems.(*subSchema)
+					for i := nbItems; i != nbValues; i++ {
+						subContext := newJsonContext(strconv.Itoa(i), context)
+						validationResult := additionalItemSchema.subValidateWithContext(value[i], subContext)
+						result.mergeErrors(validationResult)
+					}
+				}
+			}
+		}
+	}
+
+	// minItems & maxItems
+	if currentSubSchema.minItems != nil {
+		if nbItems < int(*currentSubSchema.minItems) {
+			result.addError(
+				new(ArrayMinItemsError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minItems},
+			)
+		}
+	}
+	if currentSubSchema.maxItems != nil {
+		if nbItems > int(*currentSubSchema.maxItems) {
+			result.addError(
+				new(ArrayMaxItemsError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxItems},
+			)
+		}
+	}
+
+	// uniqueItems:
+	if currentSubSchema.uniqueItems {
+		var stringifiedItems []string
+		for _, v := range value {
+			vString, err := marshalToJsonString(v)
+			if err != nil {
+				result.addError(new(InternalError), context, value, ErrorDetails{"err": err})
+			}
+			if isStringInSlice(stringifiedItems, *vString) {
+				result.addError(
+					new(ItemsMustBeUniqueError),
+					context,
+					value,
+					ErrorDetails{"type": TYPE_ARRAY},
+				)
+			}
+			stringifiedItems = append(stringifiedItems, *vString)
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string]interface{}, result *Result, context *jsonContext) {
+
+	if internalLogEnabled {
+		internalLog("validateObject %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	// minProperties & maxProperties:
+	if currentSubSchema.minProperties != nil {
+		if len(value) < int(*currentSubSchema.minProperties) {
+			result.addError(
+				new(ArrayMinPropertiesError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minProperties},
+			)
+		}
+	}
+	if currentSubSchema.maxProperties != nil {
+		if len(value) > int(*currentSubSchema.maxProperties) {
+			result.addError(
+				new(ArrayMaxPropertiesError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxProperties},
+			)
+		}
+	}
+
+	// required:
+	for _, requiredProperty := range currentSubSchema.required {
+		_, ok := value[requiredProperty]
+		if ok {
+			result.incrementScore()
+		} else {
+			result.addError(
+				new(RequiredError),
+				context,
+				value,
+				ErrorDetails{"property": requiredProperty},
+			)
+		}
+	}
+
+	// additionalProperty & patternProperty:
+	if currentSubSchema.additionalProperties != nil {
+
+		switch currentSubSchema.additionalProperties.(type) {
+		case bool:
+
+			if !currentSubSchema.additionalProperties.(bool) {
+
+				for pk := range value {
+
+					found := false
+					for _, spValue := range currentSubSchema.propertiesChildren {
+						if pk == spValue.property {
+							found = true
+						}
+					}
+
+					pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
+
+					if found {
+
+						if pp_has && !pp_match {
+							result.addError(
+								new(AdditionalPropertyNotAllowedError),
+								context,
+								value,
+								ErrorDetails{"property": pk},
+							)
+						}
+
+					} else {
+
+						if !pp_has || !pp_match {
+							result.addError(
+								new(AdditionalPropertyNotAllowedError),
+								context,
+								value,
+								ErrorDetails{"property": pk},
+							)
+						}
+
+					}
+				}
+			}
+
+		case *subSchema:
+
+			additionalPropertiesSchema := currentSubSchema.additionalProperties.(*subSchema)
+			for pk := range value {
+
+				found := false
+				for _, spValue := range currentSubSchema.propertiesChildren {
+					if pk == spValue.property {
+						found = true
+					}
+				}
+
+				pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
+
+				if found {
+
+					if pp_has && !pp_match {
+						validationResult := additionalPropertiesSchema.subValidateWithContext(value[pk], context)
+						result.mergeErrors(validationResult)
+					}
+
+				} else {
+
+					if !pp_has || !pp_match {
+						validationResult := additionalPropertiesSchema.subValidateWithContext(value[pk], context)
+						result.mergeErrors(validationResult)
+					}
+
+				}
+
+			}
+		}
+	} else {
+
+		for pk := range value {
+
+			pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
+
+			if pp_has && !pp_match {
+
+				result.addError(
+					new(InvalidPropertyPatternError),
+					context,
+					value,
+					ErrorDetails{
+						"property": pk,
+						"pattern":  currentSubSchema.PatternPropertiesString(),
+					},
+				)
+			}
+
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validatePatternProperty(currentSubSchema *subSchema, key string, value interface{}, result *Result, context *jsonContext) (has bool, matched bool) {
+
+	if internalLogEnabled {
+		internalLog("validatePatternProperty %s", context.String())
+		internalLog(" %s %v", key, value)
+	}
+
+	has = false
+
+	validatedkey := false
+
+	for pk, pv := range currentSubSchema.patternProperties {
+		if matches, _ := regexp.MatchString(pk, key); matches {
+			has = true
+			subContext := newJsonContext(key, context)
+			validationResult := pv.subValidateWithContext(value, subContext)
+			result.mergeErrors(validationResult)
+			if validationResult.Valid() {
+				validatedkey = true
+			}
+		}
+	}
+
+	if !validatedkey {
+		return has, false
+	}
+
+	result.incrementScore()
+
+	return has, true
+}
+
+func (v *subSchema) validateString(currentSubSchema *subSchema, value interface{}, result *Result, context *jsonContext) {
+
+	// Ignore JSON numbers
+	if isJsonNumber(value) {
+		return
+	}
+
+	// Ignore non strings
+	if !isKind(value, reflect.String) {
+		return
+	}
+
+	if internalLogEnabled {
+		internalLog("validateString %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	stringValue := value.(string)
+
+	// minLength & maxLength:
+	if currentSubSchema.minLength != nil {
+		if utf8.RuneCount([]byte(stringValue)) < int(*currentSubSchema.minLength) {
+			result.addError(
+				new(StringLengthGTEError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minLength},
+			)
+		}
+	}
+	if currentSubSchema.maxLength != nil {
+		if utf8.RuneCount([]byte(stringValue)) > int(*currentSubSchema.maxLength) {
+			result.addError(
+				new(StringLengthLTEError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxLength},
+			)
+		}
+	}
+
+	// pattern:
+	if currentSubSchema.pattern != nil {
+		if !currentSubSchema.pattern.MatchString(stringValue) {
+			result.addError(
+				new(DoesNotMatchPatternError),
+				context,
+				value,
+				ErrorDetails{"pattern": currentSubSchema.pattern},
+			)
+
+		}
+	}
+
+	// format
+	if currentSubSchema.format != "" {
+		if !FormatCheckers.IsFormat(currentSubSchema.format, stringValue) {
+			result.addError(
+				new(DoesNotMatchFormatError),
+				context,
+				value,
+				ErrorDetails{"format": currentSubSchema.format},
+			)
+		}
+	}
+
+	result.incrementScore()
+}
+
+func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{}, result *Result, context *jsonContext) {
+
+	// Ignore non numbers
+	if !isJsonNumber(value) {
+		return
+	}
+
+	if internalLogEnabled {
+		internalLog("validateNumber %s", context.String())
+		internalLog(" %v", value)
+	}
+
+	number := value.(json.Number)
+	float64Value, _ := number.Float64()
+
+	// multipleOf:
+	if currentSubSchema.multipleOf != nil {
+
+		if !isFloat64AnInteger(float64Value / *currentSubSchema.multipleOf) {
+			result.addError(
+				new(MultipleOfError),
+				context,
+				resultErrorFormatJsonNumber(number),
+				ErrorDetails{"multiple": *currentSubSchema.multipleOf},
+			)
+		}
+	}
+
+	//maximum & exclusiveMaximum:
+	if currentSubSchema.maximum != nil {
+		if currentSubSchema.exclusiveMaximum {
+			if float64Value >= *currentSubSchema.maximum {
+				result.addError(
+					new(NumberLTError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"max": resultErrorFormatNumber(*currentSubSchema.maximum),
+					},
+				)
+			}
+		} else {
+			if float64Value > *currentSubSchema.maximum {
+				result.addError(
+					new(NumberLTEError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"max": resultErrorFormatNumber(*currentSubSchema.maximum),
+					},
+				)
+			}
+		}
+	}
+
+	//minimum & exclusiveMinimum:
+	if currentSubSchema.minimum != nil {
+		if currentSubSchema.exclusiveMinimum {
+			if float64Value <= *currentSubSchema.minimum {
+				result.addError(
+					new(NumberGTError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"min": resultErrorFormatNumber(*currentSubSchema.minimum),
+					},
+				)
+			}
+		} else {
+			if float64Value < *currentSubSchema.minimum {
+				result.addError(
+					new(NumberGTEError),
+					context,
+					resultErrorFormatJsonNumber(number),
+					ErrorDetails{
+						"min": resultErrorFormatNumber(*currentSubSchema.minimum),
+					},
+				)
+			}
+		}
+	}
+
+	result.incrementScore()
+}

--- a/vendor/go4.org/LICENSE
+++ b/vendor/go4.org/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go4.org/errorutil/highlight.go
+++ b/vendor/go4.org/errorutil/highlight.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errorutil helps make better error messages.
+package errorutil // import "go4.org/errorutil"
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// HighlightBytePosition takes a reader and the location in bytes of a parse
+// error (for instance, from json.SyntaxError.Offset) and returns the line, column,
+// and pretty-printed context around the error with an arrow indicating the exact
+// position of the syntax error.
+func HighlightBytePosition(f io.Reader, pos int64) (line, col int, highlight string) {
+	line = 1
+	br := bufio.NewReader(f)
+	lastLine := ""
+	thisLine := new(bytes.Buffer)
+	for n := int64(0); n < pos; n++ {
+		b, err := br.ReadByte()
+		if err != nil {
+			break
+		}
+		if b == '\n' {
+			lastLine = thisLine.String()
+			thisLine.Reset()
+			line++
+			col = 1
+		} else {
+			col++
+			thisLine.WriteByte(b)
+		}
+	}
+	if line > 1 {
+		highlight += fmt.Sprintf("%5d: %s\n", line-1, lastLine)
+	}
+	highlight += fmt.Sprintf("%5d: %s\n", line, thisLine.String())
+	highlight += fmt.Sprintf("%s^\n", strings.Repeat(" ", col+5))
+	return
+}


### PR DESCRIPTION
This PR vendors all OCI image spec Go dependencies using glide and glide-vc.

Additionally it adds a hacking guide since we accumulated quite some tools/prerequisites for various make targets. The hacking guide documents them.

Fixes #76, #162