### PR TITLE
image: convert colon to hypen for path digests.

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -51,7 +51,7 @@ type config struct {
 
 func findConfig(w walker, d *descriptor) (*config, error) {
 	var c config
-	cpath := filepath.Join("blobs", d.Digest)
+	cpath := filepath.Join("blobs", pathDigest(d.Digest))
 
 	f := func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() {

--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -65,13 +65,14 @@ func findDescriptor(w walker, name string) (*descriptor, error) {
 }
 
 func (d *descriptor) validate(w walker) error {
+	pd := pathDigest(d.Digest)
 	f := func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() {
 			return nil
 		}
 
 		digest, err := filepath.Rel("blobs", filepath.Clean(path))
-		if err != nil || d.Digest != digest {
+		if err != nil || pd != digest {
 			return nil // ignore
 		}
 

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -38,7 +38,7 @@ type manifest struct {
 
 func findManifest(w walker, d *descriptor) (*manifest, error) {
 	var m manifest
-	mpath := filepath.Join("blobs", d.Digest)
+	mpath := filepath.Join("blobs", pathDigest(d.Digest))
 
 	f := func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() {
@@ -101,13 +101,15 @@ func (m *manifest) unpack(w walker, dest string) error {
 			continue
 		}
 
+		pd := pathDigest(d.Digest)
+
 		f := func(path string, info os.FileInfo, r io.Reader) error {
 			if info.IsDir() {
 				return nil
 			}
 
 			dd, err := filepath.Rel("blobs", filepath.Clean(path))
-			if err != nil || d.Digest != dd {
+			if err != nil || pd != dd {
 				return nil // ignore
 			}
 

--- a/image/util.go
+++ b/image/util.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import "strings"
+
+func pathDigest(digest string) string {
+	return strings.Replace(digest, ":", "-", 1)
+}


### PR DESCRIPTION
Noticed trying to validate and unpack a (I think) valid oci image layout.

@philips @s-urbaniak Are there some tests for oci-image-tool in the work? I haven't written a test because probably a generic tests could have covered this.