### PR TITLE
manifest: layer federation

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -32,13 +32,13 @@ The following fields contain the primary properties that constitute a Descriptor
   This property exists so that a client will have an expected size for the content before processing.
   If the length of the retrieved content does not match the specified length, the content SHOULD NOT be trusted.
 
+- **`urls`** *array*
+
+  This OPTIONAL property specifies a list of URLs from which this object MAY be downloaded.
+
 ### Reserved
 
 The following field keys MUST NOT be used in descriptors specified in other OCI specifications:
-
-- **`urls`** *array*
-
-  This key is RESERVED for future versions of the specification.
 
 - **`data`** *string*
 


### PR DESCRIPTION
Bringing up discussion on layer federation..

The docker v2s2 schema also has them https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-field-descriptions and docker itself it's already using this feature for Windows layer.

This will allow people to implement layer federation functionality in their own registry. ISVs who want to host their layers somewhere else are now free to do so. It will be up to whatever client/server implementation to fully support them. The basic idea still remains and OCI would be fine by having this standardized.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>