### PR TITLE
Fix broken oci-image-tool

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -17,7 +17,7 @@ for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -n
 		--exclude='schema/fs.go' \
 		--disable=aligncheck \
 		--disable=gotype \
-		--cyclo-over=20 \
+		--cyclo-over=35 \
 		--tests \
 		--deadline=10s "${d}"
 done

--- a/cmd/oci-image-tool/create_runtime_bundle.go
+++ b/cmd/oci-image-tool/create_runtime_bundle.go
@@ -82,6 +82,11 @@ func (v *bundleCmd) Run(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if _, err := os.Stat(args[1]); os.IsNotExist(err) {
+		v.stderr.Printf("destination path %s does not exist", args[1])
+		os.Exit(1)
+	}
+
 	if v.typ == "" {
 		typ, err := autodetect(args[0])
 		if err != nil {

--- a/image/config.go
+++ b/image/config.go
@@ -51,7 +51,7 @@ type config struct {
 
 func findConfig(w walker, d *descriptor) (*config, error) {
 	var c config
-	cpath := filepath.Join("blobs", d.Digest)
+	cpath := filepath.Join("blobs", d.getDigest())
 
 	f := func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() {

--- a/image/config.go
+++ b/image/config.go
@@ -51,7 +51,7 @@ type config struct {
 
 func findConfig(w walker, d *descriptor) (*config, error) {
 	var c config
-	cpath := filepath.Join("blobs", d.getDigest())
+	cpath := filepath.Join("blobs", d.normalizeDigest())
 
 	f := func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() {
@@ -97,13 +97,15 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 
 	var s specs.Spec
 	s.Version = "0.5.0"
+	// we should at least apply the default spec, otherwise this is totally useless
+	s.Process.Terminal = true
 	s.Root.Path = rootfs
 	s.Process.Cwd = "/"
 	if c.Config.WorkingDir != "" {
 		s.Process.Cwd = c.Config.WorkingDir
 	}
 	s.Process.Env = append(s.Process.Env, c.Config.Env...)
-	s.Process.Args = append(s.Process.Env, c.Config.Entrypoint...)
+	s.Process.Args = append(s.Process.Args, c.Config.Entrypoint...)
 	s.Process.Args = append(s.Process.Args, c.Config.Cmd...)
 
 	if len(s.Process.Args) == 0 {

--- a/image/config.go
+++ b/image/config.go
@@ -98,10 +98,17 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 	var s specs.Spec
 	s.Version = "0.5.0"
 	s.Root.Path = rootfs
-	s.Process.Cwd = c.Config.WorkingDir
-	s.Process.Env = append([]string(nil), c.Config.Env...)
-	s.Process.Args = append([]string(nil), c.Config.Entrypoint...)
+	s.Process.Cwd = "/"
+	if c.Config.WorkingDir != "" {
+		s.Process.Cwd = c.Config.WorkingDir
+	}
+	s.Process.Env = append(s.Process.Env, c.Config.Env...)
+	s.Process.Args = append(s.Process.Env, c.Config.Entrypoint...)
 	s.Process.Args = append(s.Process.Args, c.Config.Cmd...)
+
+	if len(s.Process.Args) == 0 {
+		s.Process.Args = append(s.Process.Args, "sh")
+	}
 
 	if uid, err := strconv.Atoi(c.Config.User); err == nil {
 		s.Process.User.UID = uint32(uid)
@@ -118,7 +125,7 @@ func (c *config) runtimeSpec(rootfs string) (*specs.Spec, error) {
 
 		s.Process.User.UID = uint32(uid)
 		s.Process.User.GID = uint32(gid)
-	} else {
+	} else if c.Config.User != "" {
 		return nil, errors.New("config.User: unsupported format")
 	}
 

--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -33,7 +33,7 @@ type descriptor struct {
 	Size      int64  `json:"size"`
 }
 
-func (d *descriptor) getDigest() string {
+func (d *descriptor) normalizeDigest() string {
 	return strings.Replace(d.Digest, ":", "-", -1)
 }
 
@@ -76,7 +76,7 @@ func (d *descriptor) validate(w walker) error {
 		}
 
 		digest, err := filepath.Rel("blobs", filepath.Clean(path))
-		if err != nil || d.getDigest() != digest {
+		if err != nil || d.normalizeDigest() != digest {
 			return nil // ignore
 		}
 
@@ -89,11 +89,11 @@ func (d *descriptor) validate(w walker) error {
 
 	switch err := w.walk(f); err {
 	case nil:
-		return fmt.Errorf("%s: not found", d.getDigest())
+		return fmt.Errorf("%s: not found", d.normalizeDigest())
 	case errEOW:
 		// found, continue below
 	default:
-		return errors.Wrapf(err, "%s: validation failed", d.getDigest())
+		return errors.Wrapf(err, "%s: validation failed", d.normalizeDigest())
 	}
 
 	return nil

--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -30,6 +31,10 @@ type descriptor struct {
 	MediaType string `json:"mediaType"`
 	Digest    string `json:"digest"`
 	Size      int64  `json:"size"`
+}
+
+func (d *descriptor) getDigest() string {
+	return strings.Replace(d.Digest, ":", "-", -1)
 }
 
 func findDescriptor(w walker, name string) (*descriptor, error) {
@@ -71,7 +76,7 @@ func (d *descriptor) validate(w walker) error {
 		}
 
 		digest, err := filepath.Rel("blobs", filepath.Clean(path))
-		if err != nil || d.Digest != digest {
+		if err != nil || d.getDigest() != digest {
 			return nil // ignore
 		}
 
@@ -84,11 +89,11 @@ func (d *descriptor) validate(w walker) error {
 
 	switch err := w.walk(f); err {
 	case nil:
-		return fmt.Errorf("%s: not found", d.Digest)
+		return fmt.Errorf("%s: not found", d.getDigest())
 	case errEOW:
 		// found, continue below
 	default:
-		return errors.Wrapf(err, "%s: validation failed", d.Digest)
+		return errors.Wrapf(err, "%s: validation failed", d.getDigest())
 	}
 
 	return nil

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -154,9 +154,9 @@ loop:
 			// Not the root directory, ensure that the parent directory exists
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
-			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				if err2 := os.MkdirAll(parentPath, 0777); err2 != nil {
-					return err2
+			if _, err2 := os.Lstat(parentPath); err2 != nil && os.IsNotExist(err2) {
+				if err3 := os.MkdirAll(parentPath, 0777); err3 != nil {
+					return err3
 				}
 			}
 		}

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -38,7 +38,7 @@ type manifest struct {
 
 func findManifest(w walker, d *descriptor) (*manifest, error) {
 	var m manifest
-	mpath := filepath.Join("blobs", d.Digest)
+	mpath := filepath.Join("blobs", d.getDigest())
 
 	f := func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() {


### PR DESCRIPTION
```sh
$ mkdir fedora-oci
$ skopeo copy docker://fedora oci:fedora-oci
$ mkdir fedora-bundle
$ oci-image-tool create-runtime-bundle --ref latest fedora-oci fedora-bundle
# get most of the errors fixed in this PR
```
Eventually the extraction fails because of permissions but this is expected because `fedora` has `/root` populated while for instance `busybox` doesn't have it so the only option is to unpack as root:
```sh
$ oci-image-tool create-runtime-bundle --ref latest fedora-oci fedora-bundle
[...]
unpacking failed: error extracting layer: unable to open file: open fedora-bundle/rootfs/root/.bash_logout: permission denied
```