### PR TITLE
improve walk function on returning result

### DIFF
--- a/image/walker.go
+++ b/image/walker.go
@@ -16,16 +16,11 @@ package image
 
 import (
 	"archive/tar"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
-)
-
-var (
-	errEOW = fmt.Errorf("end of walk") // error to signal stop walking
 )
 
 // walkFunc is a function type that gets called for each file or directory visited by the Walker.


### PR DESCRIPTION
1. walk functions had better to return `nil` in the case of no-error.
2. walk functions may not be defined as variable, but as function argument directly.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>