### PR TITLE
image-layout: More explicit blob filenames

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -38,9 +38,8 @@ $ shasum -a 256 ./blobs/sha256-afff3924849e458c5ef237db5f89539274d5e609db5db935e
 afff3924849e458c5ef237db5f89539274d5e609db5db935ed3959c90f1f2d51 ./blobs/sha256-afff3924849e458c5ef237db5f89539274d5e609db5db935ed3959c90f1f2d51
 ```
 
-Object names in the `refs` subdirectories MUST NOT include characters outside of the set of "A" to "Z", "a" to "z", "0" to "9", the hyphen `-`, the dot `.`, and the underscore `_`.
-Object names in the `blobs` subdirectories are composed of hash algorithm, hash digest and separator. Hash digest MUST NOT include characters outside of the set of "A" to "F", "a" to "f", "0" to "9". Separator MUST NOT include characters outside of the hyphen `-`, the dot `.`, and the underscore `_`.
-Hash algorithm identifiers containing the colon `:` will be converted to the hyphen `-`.
+Filenames in the `refs` subdirectories MUST NOT include characters outside of the set of "A" to "Z", "a" to "z", "0" to "9", the hyphen `-`, the dot `.`, and the underscore `_`.
+Filenames in the `blobs` subdirectories MUST be a [hash algorithm](descriptor.md#digests-and-verification), hyphen `-`, and hex-encoded hash of the content.
 For example `sha256:5b` will map to the layout `blobs/sha256-5b`.
 The blobs directory MAY contain blobs which are not referenced by any of the refs.
 The blobs directory MAY be missing referenced blobs, in which case the missing blobs SHOULD be fulfilled by an external blob store.


### PR DESCRIPTION
There's no reason to allow a blacklisted range of separators; just
require a hyphen.  Similarly, hex has a well defined charset that is
within the previous restrictions without us having to reiterate here.

The current spec wording around digest hash algorithm's isn't all that
strong, but if we have a charset restriction on hash algorithms that
should be documented in the descriptor file.  I've updated that part
of these docs to link to the descriptor file's table of hash algorithm
IDs (currently just 'sha256').

Also replace "Object names" with "filenames", to make the distinction
between blob names like sha256:5b... and filenames like sha256-5b...

This language was last touched by #199, if folks want to look at the
earlier discussion.