### PR TITLE
serialization: remove windows-specific layers+base rootfs

### DIFF
--- a/serialization.md
+++ b/serialization.md
@@ -327,7 +327,6 @@ Note: whitespace has been added to this example for clarity. Whitespace is OPTIO
         <ul>
           <li>
             <code>type</code> is usually set to <code>layers</code>.
-	    There is also a Windows-specific value <code>layers+base</code> that allows a base layer to be specified in a field of <code>rootfs</code> called <code>base_layer</code>.
           </li>
           <li>
             <code>diff_ids</code> is an array of layer content hashes (<code>DiffIDs</code>), in order from bottom-most to top-most.


### PR DESCRIPTION
The `rootfs.type` field previously allowed a `type` of `layers+base` to
signify that there the layers must be applied to a base image. This was
required to support windows containers in Docker initially but has since
been replaced with a more compatible mechanism. It has no relevence for
OCI.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #186.

@opencontainers/image-spec-maintainers PTAL