### PR TITLE
redirect the manual url

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -77,7 +77,7 @@ Implementations MAY employ some canonicalization to ensure stable content identi
 
 ### Algorithms
 
-While the _algorithm_ does allow one to implement a wide variety of algorithms, compliant implementations SHOULD use [SHA-256](#SHA-256).
+While the _algorithm_ does allow one to implement a wide variety of algorithms, compliant implementations SHOULD use [SHA-256](https://en.wikipedia.org/wiki/SHA-256).
 
 Let's use a simple example in pseudo-code to demonstrate a digest calculation:
 A _digest_ is calculated by the following pseudo-code, where `H` is the selected hash algorithm, identified by string `<alg>`:


### PR DESCRIPTION
It seems had better to redirect the sha-256 manual to an available page as wiki.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>