### PR TITLE
media-types.md: add foreign layer media type

### DIFF
--- a/media-types.md
+++ b/media-types.md
@@ -6,6 +6,7 @@ The following `mediaType` MIME types are used by the formats described here, and
 - `application/vnd.oci.image.manifest.list.v1+json`: [Manifest list](manifest.md#manifest-list)
 - `application/vnd.oci.image.manifest.v1+json`: [Image manifest format](manifest.md#image-manifest)
 - `application/vnd.oci.image.serialization.rootfs.tar.gzip`: ["Layer", as a gzipped tar archive](serialization.md#creating-an-image-filesystem-changeset)
+- `application/vnd.oci.image.serialization.rootfs.foreign.tar.gzip`: ["Layer", as a gzipped tar that should never be pushed](serialization.md#creating-an-image-filesystem-changeset)
 - `application/vnd.oci.image.serialization.config.v1+json`: [Container config JSON](serialization.md#image-json-description)
 
 ## Compatibility Matrix


### PR DESCRIPTION
Relates to #169

This patch adds a new media type to indicate to implementation that the descriptor which it refers isn't supposed to be pushed or carried in an image layout.

Not sure everyone likes _foreign_ - I don't have a strong opinion either so suggestions are welcome.

/cc @stevvooe @vbatts @philips 

Are there other places I should update for this? Is there a place where we have a description of each media type?

Signed-off-by: Antonio Murdaca <runcom@redhat.com>