### PR TITLE
fix typo and regular expression of algorithim

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -60,7 +60,7 @@ The digest string matches the following grammar:
 
 ```
 digest      := algorithm ":" hex
-algorithm   := /[A-Fa-f0-9_+.-]+/
+algorithm   := /[a-z0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 

--- a/schema/defs-image.json
+++ b/schema/defs-image.json
@@ -9,7 +9,7 @@
     "digest": {
       "description": "the cryptographic checksum digest of the object, in the pattern '<hash>:<hexadecimal digest>'",
       "type": "string",
-      "pattern": "^[a-z0-9]+:[a-fA-F0-9]+$"
+      "pattern": "^[a-z0-9_+.-]+:[a-fA-F0-9]+$"
     },
     "manifestDescriptor": {
       "id": "https://opencontainers.org/schema/image/manifestDescriptor",


### PR DESCRIPTION
regular expression of algorithim in defs-image.json:
	"pattern": "^[a-z0-9]+:[a-fA-F0-9]+$"
make descriptor.md consistent with it.

Signed-off-by: Deng Guangxing <dengguangxing@huawei.com>