### PR TITLE
oci-image-tool.1: Fix "oci-image-tools" -> "oci-image-tool" typos

### DIFF
--- a/cmd/oci-image-tool/man/oci-image-tool.1.md
+++ b/cmd/oci-image-tool/man/oci-image-tool.1.md
@@ -20,11 +20,11 @@ oci-image-tool \- OCI (Open Container Initiative) image tool
 # COMMANDS
 **create-runtime-bundle**
   Create an OCI image runtime bundle
-  See **oci-image-tools-create-runtime-bundle(1)** for full documentation on the **create-runtime-bundle** command.
+  See **oci-image-tool-create-runtime-bundle(1)** for full documentation on the **create-runtime-bundle** command.
 
 **unpack**
   Unpack an image or image source layout
-  See **oci-image-tools-unpack(1)** for full documentation on the **unpack** command.
+  See **oci-image-tool-unpack(1)** for full documentation on the **unpack** command.
 
 **validate**
   Validate one or more image files


### PR DESCRIPTION
Generated with:

    $ sed -i 's/oci-image-tools/oci-image-tool/g' $(git grep -l oci-image-tools)

Typos are from e60ff1d6 (cmd/oci-image-tool: add manuals, 2016-07-22, #180).