### PR TITLE
bugfix: walk function exit incorrectly

### DIFF
--- a/image/walker.go
+++ b/image/walker.go
@@ -16,11 +16,16 @@ package image
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+)
+
+var (
+	errEOW = fmt.Errorf("end of walk") // error to signal stop walking
 )
 
 // walkFunc is a function type that gets called for each file or directory visited by the Walker.


### PR DESCRIPTION
Sorry it is my previous fault by #201 .
That patch leads the walk function exit incorrectly.
it is because that function `filepatch.Walk()` must not return error when meeting path mismatch error. Instead it should return nil. And the checking should be done in the end of walk.
Here I fix the bug in this patch. I retrieve old assertion block. I've run `create` , `validate` and `unpack` command according to the command manual successfully.
I will improve the mechanism gracefully.
PTAL, Thanks lots!
Signed-off-by: xiekeyang <xiekeyang@huawei.com>