### PR TITLE
image: slash separation between algo and hash

### DIFF
--- a/image/config.go
+++ b/image/config.go
@@ -51,7 +51,7 @@ type config struct {
 
 func findConfig(w walker, d *descriptor) (*config, error) {
 	var c config
-	cpath := filepath.Join("blobs", d.normalizeDigest())
+	cpath := filepath.Join("blobs", d.algo(), d.hash())
 
 	switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() || filepath.Clean(path) != cpath {

--- a/image/manifest.go
+++ b/image/manifest.go
@@ -38,7 +38,7 @@ type manifest struct {
 
 func findManifest(w walker, d *descriptor) (*manifest, error) {
 	var m manifest
-	mpath := filepath.Join("blobs", d.normalizeDigest())
+	mpath := filepath.Join("blobs", d.algo(), d.hash())
 
 	switch err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
 		if info.IsDir() || filepath.Clean(path) != mpath {
@@ -98,8 +98,8 @@ func (m *manifest) unpack(w walker, dest string) error {
 				return nil
 			}
 
-			dd, err := filepath.Rel("blobs", filepath.Clean(path))
-			if err != nil || d.normalizeDigest() != dd {
+			dd, err := filepath.Rel(filepath.Join("blobs", d.algo()), filepath.Clean(path))
+			if err != nil || d.hash() != dd {
 				return nil
 			}
 


### PR DESCRIPTION
Fix up oci-image-tool to look for hashes under `blobs/{algo}` as per https://github.com/opencontainers/image-spec/issues/208

This isn't addressing any language change required

```bash
$ tree 
.
├── blobs
│   └── sha256
│       ├── 086acbc3376eedf5a3d9c969a0d446e803600091f133288e8f5643a46e801976
│       ├── 98b338c114d348c417532b8a3bafd364f5d0c8f3541c01d0652e7c043d7d9056
│       └── bc6eb737e26b988486a6e8d5ac29167ae7aaaae7ba98fac406e4722a4eb219bb
├── oci-layout
└── refs
    └── latest

3 directories, 5 files

$ oci-image-tool validate --ref latest .                                                             
.: OK # nevermind here, I just noticed it and I have plan to fix this up :) net is that tests pass
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>