### PR TITLE
layer: add introductory comments

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -1,6 +1,12 @@
-# Creating an Image Filesystem Changeset
+# OpenContainers Image Layers Specification
 
-An example of creating an Image Filesystem Changeset follows.
+This specification describes how to serialize a filesystem and filesystem changes like removed files into a blob called a layer.
+To create a complete filesystem one or more layers are ordered on top of each other.
+This document will use a concrete example to illustrate how to create and consume these filesystem layers.
+
+## Creating an Image Layers Based on Filesystem Changes
+
+An example of creating image filesystem layers follows.
 
 An image root filesystem is first created as an empty directory.
 Here is the initial empty directory structure for a changeset using the randomly-generated directory name `c3167915dc9d` ([actual layer DiffIDs are generated based on the content](#id_desc)).
@@ -28,8 +34,9 @@ bin/my-app-binary
 bin/my-app-tools
 ```
 
-To make changes to the filesystem of this container image, create a new directory, such as `f60c56784b83`, and initialize it with a snapshot of the parent image's root filesystem, so that the directory is identical to that of `c3167915dc9d`.
-NOTE: a copy-on-write or union filesystem can make this very efficient:
+To make changes to the filesystem of this image, create a new directory, such as `f60c56784b83`, and initialize it with a snapshot of the parent image's root filesystem, so that the directory is identical to that of `c3167915dc9d`.
+
+**Implementor's Note:** a copy-on-write or union filesystem can make this very efficient.
 
 ```
 f60c56784b83/


### PR DESCRIPTION
Fixes #220

Discussed with stevvooe, I think this makes it make sense:

```
<philips> Brandon Philips stevvooe is it a "Changeset" or a "layer"
14:53 S<stevvooe> layers represent a changeset
14:53 P<philips> Brandon Philips I feel like layer.md is trying to
discuss how layers are generated. The idea of a changeset is really part
of the image manifest.
14:54 changeset == image manifest?
https://github.com/opencontainers/image-spec/blob/master/manifest.md#example-image-manifest
14:55 S<stevvooe> well, the manifest describes the resources that make
up an image
14:55 the fact that they are changesets is an implementation detail of
the image format
14:56 P<philips> Brandon Philips Right, it just feels awkward that the
term changeset isn't really used in the manifest list where you actually
have a set of layers
14:56 To my mind we can just drop the idea of a Changeset and say there
is a layer, and a list of layers in the image manifest
14:57 S<stevvooe> no
14:57 the meaning of the layers is not a concern of the manifest
specification
14:57 what needs to be described is the relationship expressed in the
configuration
14:57 they don't really become layers until interpreted in the context
of the image config
14:59 P<philips> Brandon Philips sigh, https://www.opencontainers.org/
is down
15:01 stevvooe: hrm, which configuration?
15:02 stevvooe: this configuration?
https://github.com/opencontainers/image-spec/blob/master/serialization.md#image-json-description
15:02 S<stevvooe>
https://github.com/opencontainers/image-spec/blob/master/serialization.md
15:02 yes
15:02 (which we should rename to config)
15:03 P<philips> Brandon Philips "Each layer is a set of filesystem
changes"
15:03 So the list of layers is a "changeset"?
15:03 S<stevvooe> i would call each layer a changeset
15:04 since there are multiple changes per layer
15:04 P<philips> Brandon Philips But, then the changesets are put into
an array called "layers"
15:05 S<stevvooe> originally, this has been called "dependencies"
15:05 W<wking> Trevor stevvooe: I don't think you need to interpret them
in the context of the image config to call them "layers".  Anything with
a type of application/vnd.oci.image.serialization.rootfs.tar.gzip is a
layer, whether it's mentioned by a manifest or not
15:05 S<stevvooe> *this was
15:05 P<philips> Brandon Philips Having a hard time understanding how
having both changeset and layer helps to add contrast to the spec
15:06 S<stevvooe> the list of resources in the manifest's layers field
is really just a list of items that the configuration target requires to
run
15:06 the relationship and how to process those items is encoded into
the image config
15:07 P<philips> Brandon Philips The spec doesn't say that:  The array
MUST have the base image at index 0. Subsequent layers MUST then follow
in the order in which they are to be layered on top of each other.
15:07 P<philips> Brandon Philips like the manifest list gives semantic
meaning to the ordering of that list
15:09 S<stevvooe> That language probably goes a little far
15:09 really, they need to be ordered by fetch priority
15:10 P<philips> Brandon Philips because application order is defined in
the rootfs diff_ids array?
https://github.com/opencontainers/image-spec/blob/master/serialization.md#image-json-description
15:10 S<stevvooe> yep
15:10 P<philips> Brandon Philips OK, and a diff == changeset?
15:10 S<stevvooe> i know it is odd.
15:10 pretty much
15:10 P<philips> Brandon Philips stevvvvoe :)
15:10 S<stevvooe> yes
15:10 P<philips> Brandon Philips heh, ok
15:11 (trying to increase stevvooe verbosity)
15:11 S<stevvooe> --verbose is not a valid flag for command stevvooe
15:12 W<wking> Trevor relaxing the application-order requirement on
layers means you can't use a config/manifest pair to do diff-ID <-> blob
digest lookups, and are back to needing an external database for that
sort of thing
15:13 S<stevvooe> i would not recommend doing that
15:13 W<wking> Trevor can't clients that care user Descriptor.size to
guess download order?
15:13 S<stevvooe> and that is exactly why
15:13 size ordered downloading won't work well
15:14 W<wking> Trevor Because you also need some weight preferring blobs
that get unpacked first?
15:14 P<philips> Brandon Philips stevvooe: :)
15:16 S<stevvooe> wking: it's not even as abstract as that: one cannot
build an image if they don't first have the base
15:16 philips: looks like the nameservers aren't even resolving
opencontainers.org
15:17 P<philips> Brandon Philips stevvooe: LF is working on it...
15:17 S<stevvooe> great!
15:17 W<wking> Trevor stevvooe: so you have one channel trying to fetch
the blobs in application order, and another jumping that queue to fetch
the biggest blobs?
15:17 if you only have one channel, you'll always want to fetch in
application order
15:18 if you have additional channels, you want parallel fetches for
anything that will take a while to fetch
15:18 S<stevvooe> in docker, there is an arbitrary parallelism limit
15:18 W<wking> Trevor does the limit matter?  All non-primary channels
can work on the the biggest-first queue together
15:19 S<stevvooe> kind of, you need to balance the size of the pipe with
priority
15:20 W<wking> Trevor this gets sticky if some blobs are only fetchable
over slow channels (e.g. if you have to use Descriptor.urls, and the URL
you get from there is over a slow pipe
15:20 S<stevvooe> the layer ordering in the manifest effectively
provides a hint to the order you'd like the downloads to finish
15:20 W<wking> Trevor I'm just not seeing how you can know much about
that ordering at manifest-writing time beyond what you can deduce from
the application order and blob size
15:21 S<stevvooe> during write? you have a list of layers, base first
15:22 in fact, you can cut-through push the whole process
15:22 start at the base layer, push it, add to manifest, push next, add
to manifest, etc. then push manifest
```