### PR TITLE
image tool: use slash separated hierarchy for blob storage

### DIFF
--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -34,7 +34,7 @@ type descriptor struct {
 }
 
 func (d *descriptor) normalizeDigest() string {
-	return strings.Replace(d.Digest, ":", "-", -1)
+	return strings.Replace(d.Digest, ":", "/", -1)
 }
 
 func findDescriptor(w walker, name string) (*descriptor, error) {


### PR DESCRIPTION
It is relevant to #232 .
I've run the new code for `create`, `unpack` and `validate`, and they are passed.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>