### PR TITLE
panic fix

### DIFF
--- a/image/walker.go
+++ b/image/walker.go
@@ -92,6 +92,12 @@ func newPathWalker(root string) walker {
 
 func (w *pathWalker) walk(f walkFunc) error {
 	return filepath.Walk(w.root, func(path string, info os.FileInfo, err error) error {
+		// MUST check error value, to make sure the `os.FileInfo` is available.
+		// Otherwise panic risk will exist.
+		if err != nil {
+			return errors.Wrap(err, "error walking path")
+		}
+
 		rel, err := filepath.Rel(w.root, path)
 		if err != nil {
 			return errors.Wrap(err, "error walking path") // err from filepath.Walk includes path name


### PR DESCRIPTION
Here the program will happen panic if the target path not found. So, it had better to add a condition to avoid that. I check the other `info` point which should be safe.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>