### PR TITLE
serialization: Remove "changeset" from terminology

### DIFF
--- a/serialization.md
+++ b/serialization.md
@@ -9,11 +9,11 @@ This specification uses the following terms:
 
 <dl>
     <dt>
-        Layer
+        [Layer](layer.md)
     </dt>
     <dd>
-        Images are composed of <i>layers</i>.
-	Each layer is a set of filesystem changes.
+        Image filesystems are composed of <i>layers</i>.
+        Each layer represents a set of filesystem changes in a tar-based [layer format](layer.md), recording files to be added, changed, or deleted relative to its parent layer.
 	Layers do not have configuration metadata such as environment variables or default arguments - these are properties of the image as a whole rather than any particular layer.
     </dd>
     <dt>
@@ -24,13 +24,6 @@ This specification uses the following terms:
 	The JSON structure also references a cryptographic hash of each layer used by the image, and provides history information for those layers.
 	This JSON is considered to be immutable, because changing it would change the computed ImageID.
 	Changing it means creating a new derived image, instead of changing the existing image.
-    </dd>
-    <dt>
-        Image Filesystem Changeset
-    </dt>
-    <dd>
-        Each layer has an archive of the files which have been added, changed, or deleted relative to its parent layer.
-	Using a layer-based or union filesystem such as AUFS, or by computing the diff from filesystem snapshots, the filesystem changeset can be used to present a series of image layers as if they were one cohesive filesystem.
     </dd>
     <dt>
         Layer DiffID

--- a/serialization.md
+++ b/serialization.md
@@ -15,6 +15,7 @@ This specification uses the following terms:
         Image filesystems are composed of <i>layers</i>.
         Each layer represents a set of filesystem changes in a tar-based [layer format](layer.md), recording files to be added, changed, or deleted relative to its parent layer.
 	Layers do not have configuration metadata such as environment variables or default arguments - these are properties of the image as a whole rather than any particular layer.
+        Using a layer-based or union filesystem such as AUFS, or by computing the diff from filesystem snapshots, the filesystem changeset can be used to present a series of image layers as if they were one cohesive filesystem.
     </dd>
     <dt>
         Image JSON


### PR DESCRIPTION
On Wed, Aug 31, 2016 at 06:53:45PM -0700, Brandon Philips [wrote][1]:
> @wking I think changeset is the logical concept, layer is the
> serialization of that changeset into a tar. I really don't have a
> strong opnion about having different nouns for these things but
> @stevvooe seems to.

On Thu, Sep 01, 2016 at 10:29:16AM -0700, Stephen Day [wrote][2]:
> A "changeset" is just an english word for a set of changes. We
> represent a set of changes with a layer.

I also removed the "Image" prefix, since all of these terms are image-specific.

[1]: https://github.com/opencontainers/image-spec/pull/231#issuecomment-243954395
[2]: https://github.com/opencontainers/image-spec/pull/231#issuecomment-244151555