### PR TITLE
Fix media type on unpacking layer

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -89,7 +89,7 @@ func (m *manifest) validate(w walker) error {
 
 func (m *manifest) unpack(w walker, dest string) error {
 	for _, d := range m.Layers {
-		if d.MediaType != string(schema.MediaTypeImageConfig) {
+		if d.MediaType != string(schema.MediaTypeImageLayer) {
 			continue
 		}
 

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -46,5 +48,63 @@ func TestUnpackLayerDuplicateEntries(t *testing.T) {
 	defer os.RemoveAll(tmp2)
 	if err := unpackLayer(tmp2, r); err != nil && !strings.Contains(err.Error(), "duplicate entry for") {
 		t.Fatalf("Expected to fail with duplicate entry, got %v", err)
+	}
+}
+
+func TestUnpackLayer(t *testing.T) {
+	tmp1, err := ioutil.TempDir("", "test-layer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp1)
+	err = os.MkdirAll(filepath.Join(tmp1, "blobs", "sha256"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tarfile := filepath.Join(tmp1, "blobs", "sha256", "test.tar")
+	f, err := os.Create(tarfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	tw.WriteHeader(&tar.Header{Name: "test", Size: 4, Mode: 0600})
+	io.Copy(tw, bytes.NewReader([]byte("test")))
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	// generate sha256 hash
+	h := sha256.New()
+	file, err := os.Open(tarfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	_, err = io.Copy(h, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Rename(tarfile, filepath.Join(tmp1, "blobs", "sha256", fmt.Sprintf("%x", h.Sum(nil))))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testManifest := manifest{
+		Layers: []descriptor{descriptor{
+			MediaType: "application/vnd.oci.image.layer.tar+gzip",
+			Digest:    fmt.Sprintf("sha256:%s", fmt.Sprintf("%x", h.Sum(nil))),
+		}},
+	}
+	err = testManifest.unpack(newPathWalker(tmp1), filepath.Join(tmp1, "rootfs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(filepath.Join(tmp1, "rootfs", "test"))
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package image
 
 import (


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

The media type on unpacking layer should be `MediaTypeImageLayer`