### PR TITLE
Error out if no validate layers found during unpacking

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -117,7 +117,7 @@ func (m *manifest) unpack(w walker, dest string) error {
 			return err
 		}
 	}
-	return nil
+	return fmt.Errorf("%s: layer not found", dest)
 }
 
 func unpackLayer(dest string, r io.Reader) error {


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

Instead of silently finished when `oci-image-tool create-runtime-bundle` unpack a oci-layout to a runtime bundle but there is no valid layer(for example the media type of layer is not correct), it's better error out.