### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lint:
 	@./.tool/lint
 
 test:
-	go test -race -cover ./...
+	go test -race -cover $(shell go list ./... | grep -v /vendor/)
 
 ## this uses https://github.com/Masterminds/glide and https://github.com/sgotti/glide-vc
 update-deps:

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lint:
 	@./.tool/lint
 
 test:
-	go test -race ./...
+	go test -race -cover ./...
 
 ## this uses https://github.com/Masterminds/glide and https://github.com/sgotti/glide-vc
 update-deps:


### PR DESCRIPTION
The first commit just adds `-cover` to `go test`.

The second one deals with this:
```shell
$ make test
go test -race -cover ./...
?   	github.com/opencontainers/image-spec/cmd/oci-image-tool	[no test files]
ok  	github.com/opencontainers/image-spec/image	1.034s	coverage: 10.2% of statements
ok  	github.com/opencontainers/image-spec/schema	1.175s	coverage: 44.6% of statements
?   	github.com/opencontainers/image-spec/specs-go	[no test files]
?   	github.com/opencontainers/image-spec/specs-go/v1	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/inconshreveable/mousetrap	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/opencontainers/runtime-spec/specs-go	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/pkg/errors	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/russross/blackfriday	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/shurcooL/sanitized_anchor_name	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/spf13/cobra	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/spf13/pflag	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/xeipuuv/gojsonpointer	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/xeipuuv/gojsonreference	[no test files]
?   	github.com/opencontainers/image-spec/vendor/github.com/xeipuuv/gojsonschema	[no test files]
?   	github.com/opencontainers/image-spec/vendor/go4.org/errorutil	[no test files] 
```
You can notice packages under `vendor/` are being tested (even if there are no tests right there because `glide-vc` is pruning them). This issue should be related to https://github.com/golang/go/issues/14417. Anyway, fixed it by removing vendor packages with `go list`.

After:
```shell
$ make test 
go test -race -cover github.com/opencontainers/image-spec/cmd/oci-image-tool github.com/opencontainers/image-spec/image github.com/opencontainers/image-spec/schema github.com/opencontainers/image-spec/specs-go github.com/opencontainers/image-spec/specs-go/v1
?   	github.com/opencontainers/image-spec/cmd/oci-image-tool	[no test files]
ok  	github.com/opencontainers/image-spec/image	1.019s	coverage: 10.2% of statements
ok  	github.com/opencontainers/image-spec/schema	1.161s	coverage: 44.6% of statements
?   	github.com/opencontainers/image-spec/specs-go	[no test files]
?   	github.com/opencontainers/image-spec/specs-go/v1	[no test files]
```