### PR TITLE
descriptor: revamp for readability

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -1,10 +1,9 @@
-# OpenContainers Content Descriptors
+# OCI Content Descriptors
 
-OCI have several components that come to together to describe an image.
-References between components form a [Merkle Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Merkle_tree).
-The references in the _Merkle DAG_ are expressed through _Content Descriptors_.
-A _Content Descriptor_ or _Descriptor_, describes the disposition of targeted content.
-A _Descriptor_ includes the type of content, an independently-verifiable content identifier, known as a "digest" and the byte-size of the raw content.
+An OCI image consists of several different components, arranged in a [Merkle Directed Acyclic Graph (DAG)](https://en.wikipedia.org/wiki/Merkle_tree).
+References between components in the graph are expressed through _Content Descriptors_.
+A Content Descriptor (or simply _Descriptor_) describes the disposition of the targeted content.
+A Content Descriptor includes the type of the content, a content identifier (_digest_), and the byte-size of the raw content.
 
 Descriptors SHOULD be embedded in other formats to securely reference external content.
 
@@ -12,25 +11,30 @@ Other formats SHOULD use descriptors to securely reference external content.
 
 ## Properties
 
-The following describe the primary set of properties that make up a _Descriptor_.
+A descriptor consists of a set of properties encapsulated in key-value fields.
+
+The following fields contain the primary properties that constitute a Descriptor:
 
 - **`mediaType`** *string*
 
-  This REQUIRED property contains the MIME type of the referenced object.
+  This REQUIRED property contains the MIME type of the referenced content.
+
+  The OCI image specification defines [several of its own MIME types](media-types.md) for resources defined in the specification.
 
 - **`digest`** *string*
 
-  This REQUIRED property is the _digest_ of the targeted content, meeting the requirements outlined in [Digests and Verification](#digests-and-verification).
+  This REQUIRED property is the _digest_ of the targeted content, conforming to the requirements outlined in [Digests and Verification](#digests-and-verification).
   Retrieved content SHOULD be verified against this digest when consumed via untrusted sources.
 
 - **`size`** *int64*
-  This REQUIRED property specifies the size in bytes of the blob.
-  This property exists so that a client will have an expected size for the content before validating.
+
+  This REQUIRED property specifies the size, in bytes, of the raw content.
+  This property exists so that a client will have an expected size for the content before processing.
   If the length of the retrieved content does not match the specified length, the content SHOULD NOT be trusted.
 
 ### Reserved
 
-The following are field keys that MUST NOT be used in descriptors specified in other OCI specifications:
+The following field keys MUST NOT be used in descriptors specified in other OCI specifications:
 
 - **`urls`** *array*
 
@@ -38,25 +42,21 @@ The following are field keys that MUST NOT be used in descriptors specified in o
 
 - **`data`** *string*
 
-  This key is RESERVED for futures versions of the specification.
+  This key is RESERVED for future versions of the specification.
 
 All other fields may be included in other OCI specifications.
 Extended _Descriptor_ field additions proposed in other OCI specifications SHOULD first be considered for addition into this specification.
 
 ## Digests and Verification
 
-The _digest_ component of a _Descriptor_ acts as a content identifier, employing [content addressability](http://en.wikipedia.org/wiki/Content-addressable_storage) for the OCI image format.
-It uniquely identifies content by taking a collision-resistant hash of the bytes.
-Such an identifier can be independently calculated and verified by selection of a common _algorithm_.
-If such an identifier can be communicated in a secure manner, one can retrieve the content from an insecure source, calculate it independently and be certain that the correct content was obtained.
-Put simply, the identifier is a property of the content.
+The _digest_ property of a Descriptor acts as a content identifier, enabling [content addressability](http://en.wikipedia.org/wiki/Content-addressable_storage).
+It uniquely identifies content by taking a [collision-resistant hash](https://en.wikipedia.org/wiki/Cryptographic_hash_function) of the bytes.
+If the identifier can be communicated in a secure manner, one can retrieve the content from an insecure source, calculate the digest independently, and be certain that the correct content was obtained.
 
-To disambiguate from other concepts, we call this identifier a _digest_.
-A _digest_ is a serialized hash result, consisting of a _algorithm_ and _hex_ portion.
-The _algorithm_ identifies the methodology used to calculate the digest, which are shared by implementations.
-The _hex_ portion is the hex-encoded result of the hash.
+The value of the digest property, the _digest string_, is a serialized hash result, consisting of an _algorithm_ portion and a _hex_ portion.
+The algorithm identifies the methodology used to calculate the digest; the hex portion is the hex-encoded result of the hash.
 
-We define a _digest_ string to match the following grammar:
+The digest string matches the following grammar:
 
 ```
 digest      := algorithm ":" hex
@@ -64,20 +64,20 @@ algorithm   := /[A-Fa-f0-9_+.-]+/
 hex         := /[A-Fa-f0-9]+/
 ```
 
-Some examples of _digests_ include the following:
+Some example digest strings include the following:
 
 digest                                                                            | description                                   |
 ----------------------------------------------------------------------------------|------------------------------------------------
 sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b           | Common sha256 based digest                    |
 
-Before consuming content targeted by a descriptor from untrusted sources, the byte content SHOULD be verified against the _digest_.
-The size of the content SHOULD be verified to reduce hash collision space.
-Heavy processing of before calculating a hash SHOULD be avoided.
-Implementations MAY employ some canonicalization to ensure stable content identifiers.
+Before consuming content targeted by a descriptor from untrusted sources, the byte content SHOULD be verified against the digest.
+Before calculating the digest, the size of the content SHOULD be verified to reduce hash collision space.
+Heavy processing before calculating a hash SHOULD be avoided.
+Implementations MAY employ some canonicalization of the underlying content to ensure stable content identifiers.
 
 ### Algorithms
 
-While the _algorithm_ does allow one to implement a wide variety of algorithms, compliant implementations SHOULD use [SHA-256](#sha-256).
+While the _algorithm_ component of the digest does allow one to utilize a wide variety of algorithms, compliant implementations SHOULD use [SHA-256](#sha-256).
 
 Let's use a simple example in pseudo-code to demonstrate a digest calculation:
 A _digest_ is calculated by the following pseudo-code, where `H` is the selected hash algorithm, identified by string `<alg>`:


### PR DESCRIPTION
Numerous grammar tweaks, simplifications through removal of some
redundant information, typo fixes, attempts to make the document more
internally consistent.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>