### PR TITLE
cmd/oci-image-tool/man: Document multiple --ref for 'validate'

### DIFF
--- a/cmd/oci-image-tool/man/oci-image-tool-validate.1.md
+++ b/cmd/oci-image-tool/man/oci-image-tool-validate.1.md
@@ -15,8 +15,12 @@ oci-image-tool-validate \- Validate one or more image files
 **--help**
   Print usage statement
 
-**--ref**
-  The ref pointing to the manifest to be validated. This must be present in the "refs" subdirectory of the image. Only applicable if type is image or imageLayout. (default "v1.0")
+**--ref** NAME
+  The reference to validate (should point to a manifest).
+  Can be specified multiple times to validate multiple references.
+  `NAME` must be present in the `refs` subdirectory of the image.
+  Defaults to `v1.0`.
+  Only applicable if type is image or imageLayout.
 
 **--type**
   Type of the file to validate. If unset, oci-image-tool will try to auto-detect the type. One of "imageLayout,image,manifest,manifestList,config"


### PR DESCRIPTION
Catch up with 6ca74be5 (cmd/oci-image-tool: support multiple --ref, 2016-09-06, #265).

While I'm touching it, reformat this entry to one line per sentance per the README's [Markdown style section][1].

[1]: https://github.com/opencontainers/image-spec/tree/v0.4.0#markdown-style