### PR TITLE
remove temporary directory for unit test with TestUnpackLayerDuplicateEntries

### DIFF
--- a/image/manifest_test.go
+++ b/image/manifest_test.go
@@ -23,7 +23,7 @@ func TestUnpackLayerDuplicateEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer f.Close()
-	defer os.RemoveAll(tarfile)
+	defer os.RemoveAll(tmp1)
 	gw := gzip.NewWriter(f)
 	tw := tar.NewWriter(gw)
 


### PR DESCRIPTION

Signed-off-by: Ling FaKe <lingfake@huawei.com>