### PR TITLE
fix bug: media types mismatch in manifest

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -22,11 +22,13 @@ import (
 
 // Media types for the OCI image formats
 const (
-	MediaTypeDescriptor   Validator     = v1.MediaTypeDescriptor
-	MediaTypeManifest     Validator     = v1.MediaTypeImageManifest
-	MediaTypeManifestList Validator     = v1.MediaTypeImageManifestList
-	MediaTypeImageConfig  Validator     = v1.MediaTypeImageConfig
-	MediaTypeImageLayer   unimplemented = v1.MediaTypeImageLayer
+	MediaTypeDescriptor        Validator     = v1.MediaTypeDescriptor
+	MediaTypeManifest          Validator     = v1.MediaTypeImageManifest
+	MediaTypeManifestList      Validator     = v1.MediaTypeImageManifestList
+	MediaTypeImageConfig       Validator     = v1.MediaTypeImageConfig
+	MediaTypeImageLayer        unimplemented = v1.MediaTypeImageLayer
+	MediaTypeDockerImageConfig Validator     = "application/vnd.docker.container.image.v1+json"
+	MediaTypeDockerImageLayer  unimplemented = "application/vnd.docker.image.rootfs.diff.tar.gzip"
 )
 
 var (


### PR DESCRIPTION
It is passed validation on manifest part, even the config mediatype and layer mediatype inside is mismatch.
It had better to add media type item(config and layer) checking on manifest Validate.
bug case:
```json
{
    "annotations": null,
    "config": {
        "digest": "sha256:2b8fd9751c4c0f5dd266fcae00707e67a2545ef34f9a29354585f93dac906749",
        "mediaType": "application/vnd.oci.image.serialization.config.v1+json",
        "size": 1459
    },  
    "layers": [
        {   
            "digest": "sha256:8ddc19f16526912237dd8af81971d5e4dd0587907234be2b83e249518d5b673f",
            "mediaType": "application/vnd.oci.image.serialization.rootfs.tar.gzip",
            "size": 667590
        }   
    ],  
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "schemaVersion": 2
}
```

validate result is OK. But  "mediaType": "application/vnd.oci.image.serialization.rootfs.tar.gzip" and "mediaType": "application/vnd.oci.image.serialization.config.v1+json" have been unsupported.


Signed-off-by: xiekeyang <xiekeyang@huawei.com>