### PR TITLE
Fix unpack multiple layers

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -112,7 +112,6 @@ func (m *manifest) unpack(w walker, dest string) error {
 		case nil:
 			return fmt.Errorf("%s: layer not found", dest)
 		case errEOW:
-			return nil
 		default:
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

If there are multiple layers, it will only unpack a layer and then return.
This pr fix this.