### PR TITLE
improper error description

### DIFF
--- a/schema/validator.go
+++ b/schema/validator.go
@@ -41,7 +41,7 @@ func (e ValidationError) Error() string {
 func (v Validator) Validate(src io.Reader) error {
 	buf, err := ioutil.ReadAll(src)
 	if err != nil {
-		return errors.Wrap(err, "unable to read manifest")
+		return errors.Wrap(err, "unable to read the document file")
 	}
 
 	sl := gojsonschema.NewReferenceLoaderFileSystem("file:///"+specs[v], fs)


### PR DESCRIPTION
More types than manifest file is read by `Validator.Validate()`.
Signed-off-by: xiekeyang <xiekeyang@huawei.com>