### PR TITLE
cmd/oci-image-tool: validate all refs by default

### DIFF
--- a/cmd/oci-image-tool/validate.go
+++ b/cmd/oci-image-tool/validate.go
@@ -63,7 +63,7 @@ func newValidateCmd(stdout, stderr *log.Logger) *cobra.Command {
 	)
 
 	cmd.Flags().StringSliceVar(
-		&v.refs, "ref", []string{"v1.0"},
+		&v.refs, "ref", nil,
 		`A set of refs pointing to the manifests to be validated. Each reference must be present in the "refs" subdirectory of the image. Only applicable if type is image or imageLayout.`,
 	)
 

--- a/image/descriptor.go
+++ b/image/descriptor.go
@@ -49,6 +49,27 @@ func (d *descriptor) hash() string {
 	return pts[1]
 }
 
+func listReferences(w walker) (map[string]*descriptor, error) {
+	refs := make(map[string]*descriptor)
+
+	if err := w.walk(func(path string, info os.FileInfo, r io.Reader) error {
+		if info.IsDir() || !strings.HasPrefix(path, "refs") {
+			return nil
+		}
+
+		var d descriptor
+		if err := json.NewDecoder(r).Decode(&d); err != nil {
+			return err
+		}
+		refs[info.Name()] = &d
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return refs, nil
+}
+
 func findDescriptor(w walker, name string) (*descriptor, error) {
 	var d descriptor
 	dpath := filepath.Join("refs", name)


### PR DESCRIPTION
This is taking care of https://github.com/opencontainers/image-spec/issues/271#issuecomment-245325132 (left a TODO/FIXME for later in case).

I'll adapt everything to be same as per https://github.com/opencontainers/image-spec/issues/266 later

```shell
$ oci-image-tool validate /home/amurdaca/src/github.com/projectatomic/skopeo/busybox-oci2
reference "12.04": OK
reference "3.1": OK
reference "a59906e33509d14c036c8678d687bd4eec81ed7c4b8ce907b888c607f6a1e0e6": OK
reference "latest": OK
reference "notlatest": OK
reference "tag": OK
/home/amurdaca/src/github.com/projectatomic/skopeo/busybox-oci2: OK
```

/cc @wking @vbatts @philips @stevvooe 

Signed-off-by: Antonio Murdaca <runcom@redhat.com>