### PR TITLE
descriptor: Require lowercase hex

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -54,14 +54,14 @@ It uniquely identifies content by taking a [collision-resistant hash](https://en
 If the identifier can be communicated in a secure manner, one can retrieve the content from an insecure source, calculate the digest independently, and be certain that the correct content was obtained.
 
 The value of the digest property, the _digest string_, is a serialized hash result, consisting of an _algorithm_ portion and a _hex_ portion.
-The algorithm identifies the methodology used to calculate the digest; the hex portion is the hex-encoded result of the hash.
+The algorithm identifies the methodology used to calculate the digest; the hex portion is the lowercase hex-encoded result of the hash.
 
-The digest string matches the following grammar:
+The digest string MUST match the following grammar:
 
 ```
 digest      := algorithm ":" hex
 algorithm   := /[a-z0-9_+.-]+/
-hex         := /[A-Fa-f0-9]+/
+hex         := /[a-f0-9]+/
 ```
 
 Some example digest strings include the following:

--- a/schema/defs-image.json
+++ b/schema/defs-image.json
@@ -9,7 +9,7 @@
     "digest": {
       "description": "the cryptographic checksum digest of the object, in the pattern '<hash>:<hexadecimal digest>'",
       "type": "string",
-      "pattern": "^[a-z0-9_+.-]+:[a-fA-F0-9]+$"
+      "pattern": "^[a-z0-9_+.-]+:[a-f0-9]+$"
     },
     "manifestDescriptor": {
       "id": "https://opencontainers.org/schema/image/manifestDescriptor",


### PR DESCRIPTION
Now that 75a51ed (fix regular expression of algorithim, 2016-08-30, #221) has made the Markdown and JSON Schema consistent (and required lowercase algorithms), make digest comparisons easier by also requiring lowercase hex.

This also:

* Makes it easier to serve blobs out of a case-insensitive filesystem
  store.
* Avoids having two otherwise-identical descriptor (or
  descriptor-containing) blobs with different hashes because they
  picked differend hex-casing.