### PR TITLE
manifest: List media types supported by descriptor references

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -30,7 +30,16 @@ A client will distinguish a manifest list from an image manifest based on the Co
   This REQUIRED property contains a list of manifests for specific platforms.
   While the property MUST be present, the size of the array MAY be zero.
 
-  Each object in the manifest is a [descriptor](descriptor.md) with the following additional properties:
+  Each object in the manifest is a [descriptor](descriptor.md) with the following additional properties and restrictions:
+
+  - **`mediaType`** *object*
+
+    This [descriptor property](descriptor.md#properties) has additional restrictions for `manifests`.
+    Implementations MUST support at least the following media types:
+
+    - [`application/vnd.oci.image.manifest.v1+json`](#image-manifest)
+
+    Manifest lists concerned with portability SHOULD use one of the above media types.
 
   - **`platform`** *object*
 
@@ -135,7 +144,16 @@ Unlike the [Manifest List](#manifest-list), which contains information about a s
 - **`config`** *[descriptor](descriptor.md)*
 
     This REQUIRED property references a configuration object for a container, by digest.
-    The referenced configuration object is a JSON blob that the runtime uses to set up the container, see [Image JSON Description](config.md).
+    Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:
+
+    - **`mediaType`** *object*
+
+        This [descriptor property](descriptor.md#properties) has additional restrictions for `config`.
+        Implementations MUST support at least the following media types:
+
+        - [`application/vnd.oci.image.config.v1+json`](config.md)
+
+        Manifests concerned with portability SHOULD use one of the above media types.
 
 - **`layers`** *array*
 
@@ -143,6 +161,18 @@ Unlike the [Manifest List](#manifest-list), which contains information about a s
     The array MUST have the base image at index 0.
     Subsequent layers MUST then follow in the order in which they are to be layered on top of each other.
     The algorithm to create the final unpacked filesystem layout MUST be to first unpack the layer at index 0, then index 1, and so on.
+
+    Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:
+
+    - **`mediaType`** *object*
+
+        This [descriptor property](descriptor.md#properties) has additional restrictions for `layers[]`.
+        Implementations MUST support at least the following media types:
+
+        - [`application/vnd.oci.image.layer.tar+gzip`](layer.md)
+        - [`application/vnd.oci.image.layer.nondistributable.tar+gzip`](layer.md#non-distributable-layers)
+
+        Manifests concerned with portability SHOULD use one of the above media types.
 
 - **`annotations`** *string-string map*
 


### PR DESCRIPTION
Require implementations to support these media types (although an implementation which also supports additional media types is still compliant).  Suggest portable manifests and manifest lists stick to these types so the can rely on implementation support.

A manifest(-list) can safely use a type from outside the list if the author expects the implementation to support the extension type (e.g. application/vnd.docker.image.rootfs.diff.tar.gzip).  But how that out-of-band expectation is setup is beyond the scope of this specification.

Previous discussion in #286 and a few other one-off comments ;).