### PR TITLE
image: manifest.go: remove empty layers check

### DIFF
--- a/image/manifest.go
+++ b/image/manifest.go
@@ -59,10 +59,6 @@ func findManifest(w walker, d *descriptor) (*manifest, error) {
 			return err
 		}
 
-		if len(m.Layers) == 0 {
-			return fmt.Errorf("%s: no layers found", path)
-		}
-
 		return errEOW
 	}); err {
 	case nil:


### PR DESCRIPTION
There's a discrepancy between `oci-image-tool`, internal schema tests (https://github.com/opencontainers/image-spec/blob/master/schema/manifest_test.go#L51) and the spec itself (https://github.com/opencontainers/image-spec/blob/master/manifest.md#image-manifest-property-descriptions). Schema tests and the spec don't require a _not_ empty layers array while `oci-image-tool` is erroring out on an empty layers array.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>