### PR TITLE
README: Define "unspecified", "undefined", and "implementation-defined"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The combination of the image manifest, image configuration, and one or more file
 
 The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119) (Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997).
 
+The keywords "unspecified", "undefined", and "implementation-defined" are to be interpreted as described in the [rationale for the C99 standard][c99-unspecified].
+
 ![](img/build-diagram.png)
 
 Once built the OCI Image can then be discovered by name, downloaded, verified by hash, trusted through a signature, and unpacked into an [OCI Runtime Bundle](https://github.com/opencontainers/runtime-spec/blob/master/bundle.md).
@@ -174,5 +176,6 @@ Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git
 8. When possible, one keyword to scope the change in the subject (i.e. "README: ...", "runtime: ...")
 
 
+[c99-unspecified]: http://www.open-std.org/jtc1/sc22/wg14/www/C99RationaleV5.10.pdf#page=18
 [UberConference]: https://www.uberconference.com/opencontainers
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/

--- a/layer.md
+++ b/layer.md
@@ -277,6 +277,6 @@ Typically, such layers are downloaded directly from a distributor but are never 
 
 Layers that have these restrictions SHOULD be tagged with an alternative mediatype of `application/vnd.oci.image.layer.nondistributable.tar+gzip`.
 [Descriptors](descriptor.md) referencing these layers MAY include `urls` for downloading these layers.
-It is implementation defined whether or not implementations upload layers tagged with this media type.
+It is implementation-defined whether or not implementations upload layers tagged with this media type.
 
 [tar-archive]: https://en.wikipedia.org/wiki/Tar_(computing)


### PR DESCRIPTION
I had been unaware of formal distinctions between these terms until @stephenrwalli [called it out][1] in the context of his [suggestion to use “implementation defined” for uploading `application/vnd.oci.image.layer.nondistributable.tar+gzip`][2].  I couldn't find anything as compact as RFC 2119 around this idea, but linking to a section of the C99 rationale seems reasonable enough.  The PDF I'm linking is “Rationale for International Standard - Programming Languages - C Revision 5.10 April-2003” and the referenced content appears in section 3.

The “rationale for the C99 standard” link text seems pretty informal, but that's [what WG14 uses to refer to the document][3].

[1]: https://github.com/opencontainers/image-spec/pull/233#issuecomment-245416276
[2]: https://github.com/opencontainers/image-spec/pull/233#issuecomment-245354663
[3]: http://www.open-std.org/jtc1/sc22/wg14/