### PR TITLE
Replace 'base image' with 'base layer'

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -140,7 +140,7 @@ Unlike the [Manifest List](#manifest-list), which contains information about a s
 - **`layers`** *array*
 
     Each item in the array MUST be a [descriptor](descriptor.md).
-    The array MUST have the base image at index 0.
+    The array MUST have the base layer at index 0.
     Subsequent layers MUST then follow in the order in which they are to be layered on top of each other.
     The algorithm to create the final unpacked filesystem layout MUST be to first unpack the layer at index 0, then index 1, and so on.
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

`base image` here is misleading, we should use `base layer`