### PR TITLE
An image may have empty layers array

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -139,7 +139,7 @@ Unlike the [Manifest List](#manifest-list), which contains information about a s
 
 - **`layers`** *array*
 
-    Each item in the array MUST be a [descriptor](descriptor.md).
+    This property MAY be empty, an image can have an empty layers array. Each item in the array MUST be a [descriptor](descriptor.md).
     The array MUST have the base image at index 0.
     Subsequent layers MUST then follow in the order in which they are to be layered on top of each other.
     The algorithm to create the final unpacked filesystem layout MUST be to first unpack the layer at index 0, then index 1, and so on.


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>
from https://github.com/opencontainers/image-spec/pull/305/files/17c1f00097a716ca369d089159dd9569e7a0e0d0#r78707107

make this clear in manifest.md

