### PR TITLE
manifest: Explicitly base manifest.layers on an empty directory

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -45,6 +45,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
     The array MUST have the base image at index 0.
     Subsequent layers MUST then follow in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
     The final filesystem layout MUST match the result of [applying](layer.md#applying) the layers to an empty directory.
+    The [ownership, mode, and other attributes](layer.md#file-attributes) of the initial empty directory are unspecified.
 
     Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:
 

--- a/manifest.md
+++ b/manifest.md
@@ -41,9 +41,9 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 
 - **`layers`** *array*
 
+    This OPTIONAL property references the [layers](layer.md) defining the container's root filesystem.
     Each item in the array MUST be a [descriptor](descriptor.md).
-    The array MUST have the base image at index 0.
-    Subsequent layers MUST then follow in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
+    Layers MUST be [applied](layer.md#applying) in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
     The final filesystem layout MUST match the result of [applying](layer.md#applying) the layers to an empty directory.
     The [ownership, mode, and other attributes](layer.md#file-attributes) of the initial empty directory are unspecified.
 

--- a/schema/image-manifest-schema.json
+++ b/schema/image-manifest-schema.json
@@ -30,7 +30,6 @@
   "required": [
     "schemaVersion",
     "mediaType",
-    "config",
-    "layers"
+    "config"
   ]
 }

--- a/specs-go/v1/manifest.go
+++ b/specs-go/v1/manifest.go
@@ -25,7 +25,7 @@ type Manifest struct {
 	Config Descriptor `json:"config"`
 
 	// Layers is an indexed list of layers referenced by the manifest.
-	Layers []Descriptor `json:"layers"`
+	Layers []Descriptor `json:"layers,omitempty"`
 
 	// Annotations contains arbitrary metadata for the manifest list.
 	Annotations map[string]string `json:"annotations"`


### PR DESCRIPTION
And point out that layer authors interested in the ownership and other attributes of the unpacked root directory should explicitly set an entry for it.  I expect folks will mostly use `./`, but have made that an example in case they want to use other spellings (which unpackers should respect).

I've used "match"” instead of "be" to allow folks to apply via a union filesystem or whatever. As long as the finished product is right, compliance testers and users should be satisfied.

Spun off from [this comment][1] to answer [this request][2], cc @jonboulle.

[1]: https://github.com/opencontainers/image-spec/pull/313#r78716777
[2]: https://github.com/opencontainers/image-spec/pull/312#issuecomment-247647193