### PR TITLE
media-types: Replace Docker link with internal descriptor link

### DIFF
--- a/media-types.md
+++ b/media-types.md
@@ -45,5 +45,5 @@ The following figure shows how the above media types reference each other:
 
 ![](img/media-types.png)
 
-A reference is defined as the target content digest, as defined by the [Registry V2 HTTP API Specificiation](https://docs.docker.com/registry/spec/api/#digest-parameter).
+[Descriptors](descriptor.md) are used for all references.
 The manifest list being a "fat manifest" references one or more image manifests per target platform. An image manifest references exactly one target configuration and possibly many layers.


### PR DESCRIPTION
The Docker link landed in #55, but we've had a descriptor definition locally since #111.