### PR TITLE
Use 'Image config JSON' instead of `Container config JSON`

### DIFF
--- a/media-types.md
+++ b/media-types.md
@@ -5,7 +5,7 @@ The following media types identify the formats described here and their referenc
 - `application/vnd.oci.descriptor.v1+json`: [Content Descriptor](descriptor.md)
 - `application/vnd.oci.image.manifest.list.v1+json`: [Manifest list](manifest.md#manifest-list)
 - `application/vnd.oci.image.manifest.v1+json`: [Image manifest format](manifest.md#image-manifest)
-- `application/vnd.oci.image.config.v1+json`: [Container config JSON](config.md)
+- `application/vnd.oci.image.config.v1+json`: [Image config JSON](config.md)
 - `application/vnd.oci.image.layer.tar+gzip`: ["Layer", as a gzipped tar archive](layer.md)
 - `application/vnd.oci.image.layer.nondistributable.tar+gzip`: ["Layer", as a gzipped tar that has distribution restrictions](layer.md#non-distributable-layers)
 


### PR DESCRIPTION
config.md is describe the image config json, it's not
container config JSON.

Signed-off-by: Lei Jitang <leijitang@huawei.com>