### PR TITLE
validate media type of manifest descendants

### DIFF
--- a/schema/validator.go
+++ b/schema/validator.go
@@ -16,10 +16,12 @@ package schema
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 
+	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -27,6 +29,12 @@ import (
 // Validator wraps a media type string identifier
 // and implements validation against a JSON schema.
 type Validator string
+
+type validateDescendantsFunc func(r io.Reader) error
+
+var mapValidateDescendants = map[Validator]validateDescendantsFunc{
+	MediaTypeManifest: validateManifestDescendants,
+}
 
 // ValidationError contains all the errors that happened during validation.
 type ValidationError struct {
@@ -42,6 +50,16 @@ func (v Validator) Validate(src io.Reader) error {
 	buf, err := ioutil.ReadAll(src)
 	if err != nil {
 		return errors.Wrap(err, "unable to read the document file")
+	}
+
+	if f, ok := mapValidateDescendants[v]; ok {
+		if f == nil {
+			return fmt.Errorf("internal error: mapValidateDescendents[%q] is nil", v)
+		}
+		err = f(bytes.NewReader(buf))
+		if err != nil {
+			return err
+		}
 	}
 
 	sl := gojsonschema.NewReferenceLoaderFileSystem("file:///"+specs[v], fs)
@@ -72,4 +90,30 @@ type unimplemented string
 
 func (v unimplemented) Validate(src io.Reader) error {
 	return fmt.Errorf("%s: unimplemented", v)
+}
+
+func validateManifestDescendants(r io.Reader) error {
+	header := v1.Manifest{}
+
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return errors.Wrapf(err, "error reading the io stream")
+	}
+
+	err = json.Unmarshal(buf, &header)
+	if err != nil {
+		return errors.Wrap(err, "manifest format mismatch")
+	}
+
+	if header.Config.MediaType != string(v1.MediaTypeImageConfig) {
+		fmt.Printf("warning: config %s has an unknown media type: %s\n", header.Config.Digest, header.Config.MediaType)
+	}
+
+	for _, layer := range header.Layers {
+		if layer.MediaType != string(v1.MediaTypeImageLayer) &&
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) {
+			fmt.Printf("warning: layer %s has an unknown media type: %s\n", layer.Digest, layer.MediaType)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This PR is alternate of https://github.com/opencontainers/image-tools/pull/10.
As we have some suggestion that descendants media type should be checked by JSON schema, I put up this PR.
JSON schema constrains config and layer fields type in manifest file. If this is acceptable, we should then update the vendor to this in #image-tools.

Signed-off-by: xiekeyang xiekeyang@huawei.com
