### PR TITLE
descriptor: Rephrase reserved wording

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -38,7 +38,7 @@ The following fields contain the primary properties that constitute a Descriptor
 
 ### Reserved
 
-The following field keys MUST NOT be used in descriptors specified in other OCI specifications:
+The following field keys are reserved and MUST NOT be used by other specifications.
 
 - **`data`** *string*
 


### PR DESCRIPTION
We're [not][1] [forbidding][2] other OCI specs from using these fields, we're forbidding all specs (except for future versions of image-spec) from using these fields.  The wording I'm bringing in here matches what #164 landed for the `org.opencontainers.*` annotation namespace.

My personal preference would be to [use JSON-LD][3] to assign explicit semantics to every field (after which you don't have to worry about namespacing the fields themselves), but that would be a larger change ;).

Fixes #125.

[1]: https://github.com/opencontainers/image-spec/pull/111#r65460193
[2]: https://github.com/opencontainers/image-spec/pull/111#r65659259
[3]: https://github.com/opencontainers/image-spec/pull/111#r65468737