### PR TITLE
*: consistent media-type indications

### DIFF
--- a/config.md
+++ b/config.md
@@ -3,6 +3,8 @@
 An *Image* is an ordered collection of root filesystem changes and the corresponding execution parameters for use within a container runtime.
 This specification outlines the JSON format describing images for use with a container runtime and execution tool and its relationship to filesystem changesets, described in [Layers](layer.md).
 
+This section defines the `application/vnd.oci.image.config.v1+json` [media type](media-types.md).
+
 ## Terminology
 
 This specification uses the following terms:

--- a/descriptor.md
+++ b/descriptor.md
@@ -9,6 +9,8 @@ Descriptors SHOULD be embedded in other formats to securely reference external c
 
 Other formats SHOULD use descriptors to securely reference external content.
 
+This section defines the `application/vnd.oci.descriptor.v1+json` [media type](media-types.md).
+
 ## Properties
 
 A descriptor consists of a set of properties encapsulated in key-value fields.

--- a/layer.md
+++ b/layer.md
@@ -4,6 +4,8 @@ This document describes how to serialize a filesystem and filesystem changes lik
 One or more layers are ordered on top of each other to create a complete filesystem.
 This document will use a concrete example to illustrate how to create and consume these filesystem layers.
 
+This section defines the `application/vnd.oci.image.layer.tar+gzip` and `application/vnd.oci.image.layer.nondistributable.tar+gzip` [media type](media-types.md).
+
 ## Distributable Format
 
 Layer Changesets for the [mediatype](./media-types.md) `application/vnd.oci.image.layer.tar+gzip` MUST be packaged in [tar archive][tar-archive].

--- a/manifest.md
+++ b/manifest.md
@@ -5,6 +5,7 @@ The first goal is content-addressable images, by supporting an image model where
 The second goal is to allow multi-architecture images, through a "fat manifest" which references image manifests for platform-specific versions of an image.
 The third goal is to be translatable to the [OpenContainers/runtime-spec](https://github.com/opencontainers/runtime-spec)
 
+This section defines the `application/vnd.oci.image.manifest.list.v1+json` and `application/vnd.oci.image.manifest.v1+json` [media type](media-types.md).
 
 # Manifest List
 


### PR DESCRIPTION
Every document that defines a media-type ought to declare the media-type
it is defining.

https://github.com/opencontainers/image-spec/pull/349#discussion_r81339429

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>