### PR TITLE
Bump version to v1.0.0-rc1

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -18,14 +18,14 @@ import "fmt"
 
 const (
 	// VersionMajor is for an API incompatible changes
-	VersionMajor = 0
+	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 5
+	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = "-rc1"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc1"
+	VersionDev = "-rc1-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
https://github.com/opencontainers/image-spec/milestone/8 has been cleared out.

This would be such that b472d5f is tagged as v1.0.0-rc1