### PR TITLE
Makefile: update the version of pandoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifeq "$(strip $(PANDOC))" ''
 			-v $(shell pwd)/$(OUTPUT_DIRNAME)/:/$(OUTPUT_DIRNAME)/ \
 			-u $(shell id -u) \
 			--workdir /input \
-			vbatts/pandoc
+			docker.io/vbatts/pandoc:1.16.0.2-1.fc24
 		PANDOC_SRC := /input/
 		PANDOC_DST := /
 	endif


### PR DESCRIPTION
Before it was just using the latest image build, which was
1.13.2-4.fc23. With this change it will more explicitly use a tagged
version.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>