### PR TITLE
Fix inconsistent layer media type

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -4,7 +4,7 @@ This document describes how to serialize a filesystem and filesystem changes lik
 One or more layers are applied on top of each other to create a complete filesystem.
 This document will use a concrete example to illustrate how to create and consume these filesystem layers.
 
-This section defines the `application/vnd.oci.image.layer.tar+gzip` and `application/vnd.oci.image.layer.nondistributable.tar+gzip` [media types](media-types.md).
+This section defines the `application/vnd.oci.image.layer.v1.tar+gzip` and `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip` [media types](media-types.md).
 
 ## Distributable Format
 


### PR DESCRIPTION
Change layer media type for consistency with `media-types.md`, add
`.v1` to layer media type.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>

ping @wking , maybe you miss this one? :smile: 