### PR TITLE
manifest-list: Drop HTTP Content-Type sentence

### DIFF
--- a/manifest-list.md
+++ b/manifest-list.md
@@ -2,7 +2,6 @@
 
 The manifest list is a higher-level manifest which points to specific [image manifests](manifest.md) for one or more platforms.
 While the use of a manifest list is OPTIONAL for image providers, image consumers SHOULD be prepared to process them.
-A client will distinguish a manifest list from an image manifest based on the Content-Type returned in the HTTP response.
 
 This section defines the `application/vnd.oci.image.manifest.list.v1+json` [media type](media-types.md).
 


### PR DESCRIPTION
As Adrian Colley points out in #390, clients may not be aquiring the manifest over HTTP.  In most cases, folks will know (from a Content-Type header, a descriptor media type, or other means) what type of blob they're dealing with before they look at the blob.  I expect client behavior [like][2]:

> If you can verify the digest, ignore Content-Type. If you can't verify the digest,   respect the Content-Type and require it to match your expected media type (if any).

But in the absence of an HTTP-API spec I don't think we need to talk about this at all.

Fixes #390.

[1]: https://github.com/opencontainers/image-spec/issues/390
[2]: https://github.com/opencontainers/image-spec/issues/390#issuecomment-254029311