### PR TITLE
specs-go: adding structure of `oci-layout` file

### DIFF
--- a/specs-go/v1/layout.go
+++ b/specs-go/v1/layout.go
@@ -1,0 +1,7 @@
+package v1
+
+// ImageLayout is the structure in the "oci-layout" file, found in the root
+// of an OCI Image-layout directory.
+type ImageLayout struct {
+	Version string `json:"imageLayoutVersion"`
+}


### PR DESCRIPTION
This file found in an image-layout only had a described content, but not
a referenced structure.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>