### PR TITLE
config|manifest-list: Punt to runtime-spec for platform OS/arch

### DIFF
--- a/config.md
+++ b/config.md
@@ -60,16 +60,12 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
 - **architecture** *string*, REQUIRED
 
   The CPU architecture which the binaries in this image are built to run on.
-  Possible values include: `386`, `amd64`, `arm`, `arm64`.
-  More values may be supported in the future and any of these may or may not be supported by a given container runtime implementation.
-  New entries SHOULD be submitted to this specification for standardization and be inspired by the [Go language documentation for $GOOS and $GOARCH](https://golang.org/doc/install/source#environment).
+  Configurations SHOULD use, and implementations SHOULD understand, values [supported by runtime-spec's `platform.arch`][runtime-platform].
 
 - **os** *string*, REQUIRED
 
   The name of the operating system which the image is built to run on.
-  Possible values include: `darwin`, `freebsd`, `linux`.
-  More values may be supported in the future and any of these may or may not be supported by a given container runtime implementation.
-  New entries SHOULD be submitted to this specification for standardization and be inspired by the [Go language documentation for $GOOS and $GOARCH](https://golang.org/doc/install/source#environment).
+  Configurations SHOULD use, and implementations SHOULD understand, values [supported by runtime-spec's `platform.os`][runtime-platform].
 
 - **config** *object*, OPTIONAL
 
@@ -235,3 +231,5 @@ Here is an example image configuration JSON document:
     ]
 }
 ```
+
+[runtime-platform]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md#platform

--- a/manifest-list.md
+++ b/manifest-list.md
@@ -38,15 +38,16 @@ This section defines the `application/vnd.oci.image.manifest.list.v1+json` [medi
   - **`platform`** *object*
 
     This REQUIRED property describes the platform which the image in the manifest runs on.
-    A full list of valid operating system and architecture values are listed in the [Go language documentation for `$GOOS` and `$GOARCH`](https://golang.org/doc/install/source#environment)
 
     - **`architecture`** *string*
 
-        This REQUIRED property specified the CPU architecture, for example `amd64` or `ppc64le`.
+        This REQUIRED property specified the CPU architecture.
+        Manifest lists SHOULD use, and implementations SHOULD understand, values [supported by runtime-spec's `platform.arch`][runtime-platform].
 
     - **`os`** *string*
 
-        This REQUIRED property specifies the operating system, for example `linux` or `windows`.
+        This REQUIRED property specifies the operating system.
+        Manifest lists SHOULD use, and implementations SHOULD understand, values [supported by runtime-spec's `platform.os`][runtime-platform].
 
     - **`os.version`** *string*
 
@@ -117,3 +118,5 @@ Instead they MUST ignore unknown properties.
   }
 }
 ```
+
+[runtime-platform]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md#platform


### PR DESCRIPTION
The new wording makes it clear that implementations are free to support only a subset of OSes or architectures, and both implementations and blobs are free to support/use OSes and architectures not listed in runtime-spec.  Leaning on runtime-spec here lets us consolidate any OCI `GOOS`/`GOARCH` extension in a single location (runtime-spec).

Spun off from [this comment][1] in #385.

[1]: https://github.com/opencontainers/image-spec/pull/385#issuecomment-253640211