### PR TITLE
schema: Use Validators map and prepare to extend beyond JSON Schema

### DIFF
--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -18,7 +18,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/schema"
+	"github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestConfig(t *testing.T) {
@@ -210,9 +212,14 @@ func TestConfig(t *testing.T) {
 			fail: false,
 		},
 	} {
-		r := strings.NewReader(tt.config)
-		err := schema.MediaTypeImageConfig.Validate(r)
-
+		configBytes := []byte(tt.config)
+		reader := strings.NewReader(tt.config)
+		descriptor := v1.Descriptor{
+			MediaType: v1.MediaTypeImageConfig,
+			Digest:    digest.FromBytes(configBytes).String(),
+			Size:      int64(len(configBytes)),
+		}
+		err := schema.Validate(reader, &descriptor, true)
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
 		}

--- a/schema/manifest.go
+++ b/schema/manifest.go
@@ -1,0 +1,72 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// ValidateManifest validates the given CAS blob as
+// application/vnd.oci.image.manifest.v1+json.  Calls
+// ValidateJSONSchema as well.
+func ValidateManifest(blob io.Reader, descriptor *v1.Descriptor, strict bool) (err error) {
+	if descriptor.MediaType != v1.MediaTypeImageManifest {
+		return fmt.Errorf("unexpected descriptor media type: %q", descriptor.MediaType)
+	}
+
+	buffer, err := ioutil.ReadAll(blob)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read %s", descriptor.Digest)
+	}
+
+	err = ValidateJSONSchema(bytes.NewReader(buffer), descriptor, strict)
+	if err != nil {
+		return err
+	}
+
+	header := v1.Manifest{}
+	err = json.Unmarshal(buffer, &header)
+	if err != nil {
+		return errors.Wrap(err, "manifest format mismatch")
+	}
+
+	if header.Config.MediaType != v1.MediaTypeImageConfig {
+		error := fmt.Errorf("warning: config %s has an unknown media type: %s\n", header.Config.Digest, header.Config.MediaType)
+		if strict {
+			return error
+		}
+		fmt.Println(error)
+	}
+
+	for _, layer := range header.Layers {
+		if layer.MediaType != v1.MediaTypeImageLayer &&
+			layer.MediaType != v1.MediaTypeImageLayerNonDistributable {
+			error := fmt.Errorf("warning: layer %s has an unknown media type: %s\n", layer.Digest, layer.MediaType)
+			if strict {
+				return error
+			}
+			fmt.Println(error)
+		}
+	}
+
+	return nil
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -20,26 +20,17 @@ import (
 	"github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// Media types for the OCI image formats
-const (
-	MediaTypeDescriptor   Validator     = v1.MediaTypeDescriptor
-	MediaTypeManifest     Validator     = v1.MediaTypeImageManifest
-	MediaTypeManifestList Validator     = v1.MediaTypeImageManifestList
-	MediaTypeImageConfig  Validator     = v1.MediaTypeImageConfig
-	MediaTypeImageLayer   unimplemented = v1.MediaTypeImageLayer
-)
-
 var (
 	// fs stores the embedded http.FileSystem
 	// having the OCI JSON schema files in root "/".
 	fs = _escFS(false)
 
-	// specs maps OCI schema media types to schema files.
-	specs = map[Validator]string{
-		MediaTypeDescriptor:   "content-descriptor.json",
-		MediaTypeManifest:     "image-manifest-schema.json",
-		MediaTypeManifestList: "manifest-list-schema.json",
-		MediaTypeImageConfig:  "config-schema.json",
+	// Schemas maps OCI media types to JSON Schema files.
+	Schemas = map[string]string{
+		v1.MediaTypeDescriptor:        "content-descriptor.json",
+		v1.MediaTypeImageManifest:     "image-manifest-schema.json",
+		v1.MediaTypeImageManifestList: "manifest-list-schema.json",
+		v1.MediaTypeImageConfig:       "config-schema.json",
 	}
 )
 

--- a/schema/spec_test.go
+++ b/schema/spec_test.go
@@ -24,7 +24,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/schema"
+	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/russross/blackfriday"
 )
@@ -73,7 +75,15 @@ func validate(t *testing.T, name string) {
 			continue
 		}
 
-		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body))
+		bodyBytes := []byte(example.Body)
+		bodyDigest := digest.FromBytes(bodyBytes).String()
+		reader := strings.NewReader(example.Body)
+		descriptor := v1.Descriptor{
+			MediaType: example.Mediatype,
+			Digest:    bodyDigest,
+			Size:      int64(len(bodyBytes)),
+		}
+		err = schema.Validate(reader, &descriptor, true)
 		if err == nil {
 			printFields(t, "ok", example.Mediatype, example.Title)
 			t.Log(example.Body, "---")


### PR DESCRIPTION
With image-tools split off into its own repository, the plan seems to be to [keep all intra-blob JSON validation in this repository](http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/2016/opencontainers.2016-10-12-21.01.log.html#l-71) and to move all other validation (e.g. for layers or for walking Merkle trees) in image-tools.  All the non-validation logic currently in `image/` is [moving into image-tools as well](https://github.com/opencontainers/image-spec/pull/337).

Some requirements (e.g. multi-parameter checks like [allowed OS/arch pairs](https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.5)) are difficult to handle in JSON Schema but easy to handle in Go.  And callers won't care if we're using JSON Schema or not; they just want to know if their blob is valid.

This commit restructures intra-blob validation to ease the path going forward (although it doesn't actually change the current validation significantly).  The old method:

```
func (v Validator) Validate(src io.Reader) error
```

is now a new Validator type:

```
type Validator(blob io.Reader, descriptor *v1.Descriptor, strict bool) (err error)
```

and instead of instantiating an old `Validator` instance:

```
schema.MediaTypeImageConfig.Validate(reader)
```

there's a `Validators` registry mapping from the media type strings to the appropriate Validator instance (which may or may not use JSON Schema under the hood).  And there's a Validate function (with the same Validator interface) that looks up the appropriate entry in Validators for you so you have:

```
schema.Validate(reader, descriptor, true)
```

By using a `Validators` map, we make it easy for library consumers to register (or override) intra-blob validators for a particular type.  Locations that call `Validate(…)` will automatically pick up the new validators without needing local changes.

All of the old validation was based on JSON Schema, so currently all `Validators` values are `ValidateJSONSchema`.  As the `schema` package grows non-JSON-Schema validation, entries will start to look like:

```
var Validators = map[string]Validator{
  v1.MediaTypeImageConfig: ValidateConfig,
  …
}
```

although `ValidateConfig` will probably use `ValidateJSONSchema` internally.

By passing through a descriptor, we get a chance to validate the digest and size (which we were not doing before).  Digest and size validation for a byte array are also exposed directly (as `ValidateByteDigest` and `ValidateByteSize`) for use in validators that are not based on `ValidateJSONSchema`.  Access to the digest also gives us a way to print specific error messages on failures.  In situations where you don't know the blob digest, the new `DigestByte` will help you calculate it (for a byte array).

There is also a new `strict` parameter to distinguish between compliant images (which should only pass when strict is false) and images that only use features which the spec requires implementations to support (which should pass regardless of strict).  The current JSON Schemas are not strict, and I expect we'll soon gain Go code to handle the distinction (e.g. #341).  So the presence of `strict` in the Validator type is future-proofing our API and not exposing a currently-implemented feature.

I've made the minimal sane changes to `cmd/` and `image/`, because we're [dropping them from this repository](https://github.com/opencontainers/image-spec/pull/337) (and continuing them in runtime-tools).
