### PR TITLE
manifest: Explicitly make 'layers' optional

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -41,9 +41,9 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 
 - **`layers`** *array*
 
+    This OPTIONAL property references the [layers](layer.md) defining the container's root filesystem.
     Each item in the array MUST be a [descriptor](descriptor.md).
-    The array MUST have the base image at index 0.
-    Subsequent layers MUST then follow in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
+    Layers MUST be [applied](layer.md#applying) in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
     The final filesystem layout MUST match the result of [applying](layer.md#applying) the layers to an empty directory.
 
     Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:

--- a/schema/image-manifest-schema.json
+++ b/schema/image-manifest-schema.json
@@ -30,7 +30,6 @@
   "required": [
     "schemaVersion",
     "mediaType",
-    "config",
-    "layers"
+    "config"
   ]
 }

--- a/specs-go/v1/manifest.go
+++ b/specs-go/v1/manifest.go
@@ -25,7 +25,7 @@ type Manifest struct {
 	Config Descriptor `json:"config"`
 
 	// Layers is an indexed list of layers referenced by the manifest.
-	Layers []Descriptor `json:"layers"`
+	Layers []Descriptor `json:"layers,omitempty"`
 
 	// Annotations contains arbitrary metadata for the manifest list.
 	Annotations map[string]string `json:"annotations"`


### PR DESCRIPTION
Most folks will distribute images containing layers, but the specified behavior applies cleanly to the layer-less case too.  The unpacked rootfs will just be an empty directory with unspecified attributes.
Folks might want to use that sort of thing for [namespace pinning](https://github.com/opencontainers/runtime-spec/pull/395#issuecomment-213605476), [distributing configs](https://github.com/opencontainers/image-spec/pull/313#issuecomment-247701273), [setting up containers that mount the meat from the host](https://github.com/opencontainers/image-spec/pull/313#issuecomment-247701273), etc.

Spun off from #318 to focus on a single point.
