### PR TITLE
manifest: Explicitly unspecified attributes for the initial layer directory

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -45,6 +45,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
     The array MUST have the base image at index 0.
     Subsequent layers MUST then follow in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
     The final filesystem layout MUST match the result of [applying](layer.md#applying) the layers to an empty directory.
+    The [ownership, mode, and other attributes](layer.md#file-attributes) of the initial empty directory are unspecified.
 
     Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:
 


### PR DESCRIPTION
Point out that the layer's initial empty directory has unspecified attributes.  Layer authors interested in the ownership and other attributes of the unpacked root directory should explicitly set an entry for it.

Spun off from #318 to focus on a single point.