### PR TITLE
Add ImageLayoutVersion const

### DIFF
--- a/specs-go/v1/layout.go
+++ b/specs-go/v1/layout.go
@@ -16,6 +16,9 @@ package v1
 
 import "regexp"
 
+// ImageLayoutVersion is the version of ImageLayout
+const ImageLayoutVersion = "1.0.0"
+
 // ImageLayout is the structure in the "oci-layout" file, found in the root
 // of an OCI Image-layout directory.
 type ImageLayout struct {


### PR DESCRIPTION
Add a ImageLayoutVersion = 1.0.0 const so implementation can
refer to rather than hard code in implementation just like
https://github.com/containers/image/blob/master/oci/layout/oci_dest.go#L173

```
if err := ioutil.WriteFile(d.ref.ociLayoutPath(), []byte(`{"imageLayoutVersion": "1.0.0"}`), 0644); err != nil {
        return err
}
```

Signed-off-by: Lei Jitang leijitang@huawei.com

ping @vbatts 
