### PR TITLE
Add regular expression for object names in 'refs'

### DIFF
--- a/specs-go/v1/layout.go
+++ b/specs-go/v1/layout.go
@@ -14,8 +14,15 @@
 
 package v1
 
+import "regexp"
+
 // ImageLayout is the structure in the "oci-layout" file, found in the root
 // of an OCI Image-layout directory.
 type ImageLayout struct {
 	Version string `json:"imageLayoutVersion"`
 }
+
+var (
+	// RefsRegexp matches requirement of image-layout 'refs' charset.
+	RefsRegexp = regexp.MustCompile(`^[a-zA-Z0-9-._]+$`)
+)


### PR DESCRIPTION
it will be used in 'image-tools' or other project for checking regular
expression of 'refs', which writes as "Object names in the refs
subdirectories MUST NOT include characters outside of the set of "A" to
"Z", "a" to "z", "0" to "9", the hyphen -, the dot ., and the underscore
_." at https://github.com/opencontainers/image-spec/blob/master/image-layout.md

Signed-off-by: Ling FaKe lingfake@huawei.com
