### PR TITLE
descriptor: MUST URIs and SHOULD http(s) for descriptor's 'urls'

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -36,7 +36,9 @@ The following fields contain the primary properties that constitute a Descriptor
 
 - **`urls`** *array*
 
-  This OPTIONAL property specifies a list of URLs from which this object MAY be downloaded.
+  This OPTIONAL property specifies a list of URIs from which this object MAY be downloaded.
+  Each entry MUST conform to [RFC 3986][rfc3986].
+  Entries SHOULD use the `http` and `https` schemes, as defined in [RFC 7230][rfc7230-s2.7].
 
 ### Reserved
 
@@ -117,3 +119,6 @@ The following example describes a [_Manifest_](manifest.md#image-manifest) with 
   "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270"
 }
 ```
+
+[rfc3986]: https://tools.ietf.org/html/rfc3986
+[rfc7230-s2.7]: https://tools.ietf.org/html/rfc7230#section-2.7


### PR DESCRIPTION
The in-flight #431 is using JSON Schema's [`uri` format][1], which requires RFC 3986.  This commit makes that an official spec requirement by adding a MUST to the Markdown.  It also SHOULDs the http(s) schemes, because they're widely supported and are deployed in existing Docker images.  And @vbatts and @runcom both like SHOULDing them ;).

Fixes #436.

[1]: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.6