### PR TITLE
*: Replace '*array*' with '*array of {type}*'

### DIFF
--- a/config.md
+++ b/config.md
@@ -139,7 +139,7 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
        MUST be set to `layers`.
        Implementations MUST generate an error if they encounter a unknown value while verifying or unpacking an image.
 
-    - **diff_ids** *array*, REQUIRED
+    - **diff_ids** *array of strings*, REQUIRED
 
        An array of layer content hashes (`DiffIDs`), in order from first to last.
 

--- a/descriptor.md
+++ b/descriptor.md
@@ -34,7 +34,7 @@ The following fields contain the primary properties that constitute a Descriptor
   This property exists so that a client will have an expected size for the content before processing.
   If the length of the retrieved content does not match the specified length, the content SHOULD NOT be trusted.
 
-- **`urls`** *array*
+- **`urls`** *array of strings*
 
   This OPTIONAL property specifies a list of URLs from which this object MAY be downloaded.
 

--- a/manifest-list.md
+++ b/manifest-list.md
@@ -18,7 +18,7 @@ This section defines the `application/vnd.oci.image.manifest.list.v1+json` [medi
   For this version of the specification, this MUST be set to `application/vnd.oci.image.manifest.list.v1+json`.
   For the media type(s) that this is compatible with see the [matrix](media-types.md#compatibility-matrix).
 
-- **`manifests`** *array*
+- **`manifests`** *array of objects*
 
   This REQUIRED property contains a list of manifests for specific platforms.
   While the property MUST be present, the size of the array MAY be zero.
@@ -52,7 +52,7 @@ This section defines the `application/vnd.oci.image.manifest.list.v1+json` [medi
 
         This OPTIONAL property specifies the operating system version, for example `10.0.10586`.
 
-    - **`os.features`** *array*
+    - **`os.features`** *array of strings*
 
         This OPTIONAL property specifies an array of strings, each specifying a mandatory OS feature (for example on Windows `win32k`).
 
@@ -60,7 +60,7 @@ This section defines the `application/vnd.oci.image.manifest.list.v1+json` [medi
 
         This OPTIONAL property specifies the variant of the CPU, for example `armv6l` to specify a particular CPU variant of the ARM CPU.
 
-    - **`features`** *array*
+    - **`features`** *array of strings*
 
         This OPTIONAL property specifies an array of strings, each specifying a mandatory CPU feature (for example `sse4` or `aes`).
 

--- a/manifest.md
+++ b/manifest.md
@@ -39,7 +39,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 
         Manifests concerned with portability SHOULD use one of the above media types.
 
-- **`layers`** *array*
+- **`layers`** *array of objects*
 
     Each item in the array MUST be a [descriptor](descriptor.md).
     The array MUST have the base image at index 0.


### PR DESCRIPTION
Covering all cases turned up by:

    $ git grep '\*array'

runtime-spec does this pretty consistently, and the first such usage appeared in image-spec with f3d0f78 (config: reformat and add optional/required, 2016-09-20, #333).  And before that, c22ca799 (serialization: docker v1 image format media type, 2016-04-04, #6) had landed some:

    <code>array of strings</code>
