### PR TITLE
manifest: Require support for runtime-spec configurations

### DIFF
--- a/config.md
+++ b/config.md
@@ -4,6 +4,7 @@ An OCI *Image* is an ordered collection of root filesystem changes and the corre
 This specification outlines the JSON format describing images for use with a container runtime and execution tool and its relationship to filesystem changesets, described in [Layers](layer.md).
 
 This section defines the `application/vnd.oci.image.config.v1+json` [media type](media-types.md).
+Implementations unpacking this type MUST generate a [version 1.0.0-rc2 runtime-spec configuration][runtime-config].
 
 ## Terminology
 
@@ -232,4 +233,5 @@ Here is an example image configuration JSON document:
 }
 ```
 
+[runtime-config]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md
 [runtime-platform]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md#platform

--- a/manifest.md
+++ b/manifest.md
@@ -37,6 +37,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
         Implementations MUST support at least the following media types:
 
         - [`application/vnd.oci.image.config.v1+json`](config.md)
+        - [`application/vnd.oci.runtime.config.v1+json`](https://github.com/opencontainers/runtime-spec/blob/master/config.md), which MUST be unpacked to `config.json` without alteration.
 
         Manifests concerned with portability SHOULD use one of the above media types.
 

--- a/manifest.md
+++ b/manifest.md
@@ -28,6 +28,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 - **`config`** *[descriptor](descriptor.md)*
 
     This REQUIRED property references a configuration object for a container, by digest.
+    Implementations unpacking manifests MUST generate a [`config.json`][bundle-format] from the referenced configuration.
     Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:
 
     - **`mediaType`** *string*
@@ -118,3 +119,5 @@ This specification defines the following annotation keys, which MAY be used by m
 * **org.opencontainers.authors** contact details of the people or organization responsible for the image (freeform string)
 * **org.opencontainers.homepage** URL to find more information on the image (string, must be a URL with scheme HTTP or HTTPS)
 * **org.opencontainers.documentation** URL to get documentation on the image (string, must be a URL with scheme HTTP or HTTPS)
+
+[bundle-format]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/bundle.md#container-format


### PR DESCRIPTION
We probably need to keep `application/vnd.oci.image.config.v1+json` untouched, since #145 and other maintainer activity suggest a goal of bit-for-bit compatibility with the current Docker schemas (excepting media types).  However, requiring Docker support doesn't mean we can't *also* require support for configuration formats that are easier for image authors to use.

Of course, with the (greatly) increased flexibility comes a lot more risk.  Image consumers in general, and runtime-spec-based-image consumers in particular, should use a sanitization tool like the one I've floated in opencontainers/runtime-tools#219.

The runtime-spec config also lacks support for diffIDs, but local image tooling is still welcome to record the digests of uncompressed layers and use that for local optimizations.  You have to fetch the compressed layer at least once to perform the uncompression, but you'd have to do that to verify the old diffID anyway.

This PR requires opencontainers/runtime-spec#611 for typing the runtime-spec config.