### PR TITLE
Support different levels validation for JSON reader stream

### DIFF
--- a/schema/backwards_compatibility_test.go
+++ b/schema/backwards_compatibility_test.go
@@ -116,7 +116,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
 
 		imageIndex := convertFormats(tt.imageIndex)
 		r := strings.NewReader(imageIndex)
-		err := schema.ValidatorMediaTypeImageIndex.Validate(r)
+		err := schema.ValidatorMediaTypeImageIndex.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
@@ -178,7 +178,7 @@ func TestBackwardsCompatibilityManifest(t *testing.T) {
 
 		manifest := convertFormats(tt.manifest)
 		r := strings.NewReader(manifest)
-		err := schema.ValidatorMediaTypeManifest.Validate(r)
+		err := schema.ValidatorMediaTypeManifest.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
@@ -217,7 +217,7 @@ func TestBackwardsCompatibilityConfig(t *testing.T) {
 
 		config := convertFormats(tt.config)
 		r := strings.NewReader(config)
-		err := schema.ValidatorMediaTypeImageConfig.Validate(r)
+		err := schema.ValidatorMediaTypeImageConfig.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -212,7 +212,7 @@ func TestConfig(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.config)
-		err := schema.ValidatorMediaTypeImageConfig.Validate(r)
+		err := schema.ValidatorMediaTypeImageConfig.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/descriptor_test.go
+++ b/schema/descriptor_test.go
@@ -204,7 +204,7 @@ func TestDescriptor(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.descriptor)
-		err := schema.ValidatorMediaTypeDescriptor.Validate(r)
+		err := schema.ValidatorMediaTypeDescriptor.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/imageindex_test.go
+++ b/schema/imageindex_test.go
@@ -239,7 +239,7 @@ func TestImageIndex(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.imageIndex)
-		err := schema.ValidatorMediaTypeImageIndex.Validate(r)
+		err := schema.ValidatorMediaTypeImageIndex.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -193,7 +193,7 @@ func TestManifest(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.manifest)
-		err := schema.ValidatorMediaTypeManifest.Validate(r)
+		err := schema.ValidatorMediaTypeManifest.Validate(r, []schema.ValidateFunc{schema.ValidateSchema})
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/spec_test.go
+++ b/schema/spec_test.go
@@ -77,7 +77,8 @@ func validate(t *testing.T, name string) {
 			continue
 		}
 
-		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body))
+		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body),
+			[]schema.ValidateFunc{schema.ValidateSchema})
 		if err == nil {
 			printFields(t, "ok", example.Mediatype, example.Title)
 			t.Log(example.Body, "---")


### PR DESCRIPTION
As previous discussion among developers, to use selectable strict mode, for validating media type of referenced objects.  After enabling strict media types unmatched to OCI will be expected failure.
* each object media type in manifest and manifest list should be validated.
* add unit test cases for un/strict mode, with expected result.
* image-tool repo should introduce the new flag if this PR be landed.
* rename previous functions from xxDescendants to xxMediaType, because functions validate all objects media type, not only descendants.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>