### PR TITLE
manifest: Require unpackers to create a config.json from the referenced config

### DIFF
--- a/config.md
+++ b/config.md
@@ -4,6 +4,7 @@ An OCI *Image* is an ordered collection of root filesystem changes and the corre
 This specification outlines the JSON format describing images for use with a container runtime and execution tool and its relationship to filesystem changesets, described in [Layers](layer.md).
 
 This section defines the `application/vnd.oci.image.config.v1+json` [media type](media-types.md).
+Implementations unpacking this type MUST generate a [version 1.0.0-rc2 runtime-spec configuration][runtime-config].
 
 ## Terminology
 
@@ -232,4 +233,5 @@ Here is an example image configuration JSON document:
 }
 ```
 
+[runtime-config]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md
 [runtime-platform]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md#platform

--- a/manifest.md
+++ b/manifest.md
@@ -28,6 +28,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 - **`config`** *[descriptor](descriptor.md)*
 
     This REQUIRED property references a configuration object for a container, by digest.
+    Implementations unpacking manifests MUST generate a [`config.json`][bundle-format] from the referenced configuration.
     Beyond the [descriptor requirements](descriptor.md#properties), the value has the following additional restrictions:
 
     - **`mediaType`** *string*
@@ -118,3 +119,5 @@ This specification defines the following annotation keys, which MAY be used by m
 * **org.opencontainers.authors** contact details of the people or organization responsible for the image (freeform string)
 * **org.opencontainers.homepage** URL to find more information on the image (string, must be a URL with scheme HTTP or HTTPS)
 * **org.opencontainers.documentation** URL to get documentation on the image (string, must be a URL with scheme HTTP or HTTPS)
+
+[bundle-format]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/bundle.md#container-format


### PR DESCRIPTION
The image-tools framework has attempted this since #114, but we didn't specify whether the translation was required or what the output of the translation should be.  That means downstream consumers of an unpacked image couldn't be sure if they'd find a `config.json` or (if they found one) which runtime-spec versions it would be compatible with.  With this commit, the config output becomes specified, so consumers can post-process their `config.json` and/or invoke a runtime-spec 1.0.0-rc2-compatible runtime on it without worrying about the presence or version of the unpacked `config.json`.

I've picked 1.0.0-rc2 as the most recent runtime-spec commit.  As the runtime-spec moves forward with more RCs, I expect we'll want to bump this to keep up.  Once runtime-spec hits 1.0, we can probably freeze the target, since post 1.0 releases in runtime-spec's 1.x line are unlikely to make translation from the config format easier, and any 1.x-compatible runtime will be able to handle 1.0 configs.