### PR TITLE
README: Consolidate "OCI Image" definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ The goal of this specification is to enable the creation of interoperable tools 
 
 ## Overview
 
-This specification defines how to create an OCI Image, which will generally be done by a build system, and output an [image manifest](manifest.md), a set of [filesystem layers](layer.md), and an [image configuration](config.md).
+This specification defines an OCI Image, consisting of a [manifest](manifest.md), a set of [filesystem layers](layer.md), and a [configuration](config.md).
 At a high level the image manifest contains metadata about the contents and dependencies of the image including the content-addressable identity of one or more [filesystem layer changeset](layer.md) archives that will be unpacked to make up the final runnable filesystem.
 The image configuration includes information such as application arguments, environments, etc.
-The combination of the image manifest, image configuration, and one or more filesystem layers is called the "OCI Image".
 
 The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as described in [RFC 2119](http://tools.ietf.org/html/rfc2119) (Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997).
 


### PR DESCRIPTION
These two sentences had been saying pretty much the same thing.  The first had previously scoped the spec to image creation, but the spec covers the format itself, creation, and unpacking.  Listing the constituent components seemed like enough for one sentence, so the new sentence stays away from format/creation/unpacking distinctions.

I've also left manifest lists out for now, since adding a reference too them seemed orthogonal do consolidating these sentences.  Adding manifest-list references is covered in #455.