### PR TITLE
manifest-list.md: fix example

### DIFF
--- a/manifest-list.md
+++ b/manifest-list.md
@@ -105,7 +105,7 @@ Instead they MUST ignore unknown properties.
       "platform": {
         "architecture": "amd64",
         "os": "linux",
-        "features": [
+        "os.features": [
           "sse4"
         ]
       }


### PR DESCRIPTION
The json tag define in
https://github.com/opencontainers/image-spec/blob/master/specs-go/v1/manifest_list.go#L34
for os.features is `os.features`, we should use
`os.features` in the example of manifest list.

Signed-off-by: Lei Jitang <leijitang@huawei.com>