### PR TITLE
config.md: remove "the ID of its parent image"

### DIFF
--- a/config.md
+++ b/config.md
@@ -18,7 +18,7 @@ Using a layer-based or union filesystem such as AUFS, or by computing the diff f
 
 ### Image JSON
 
-Each image has an associated JSON structure which describes some basic information about the image such as date created, author, and the ID of its parent image as well as execution/runtime configuration like its entrypoint, default arguments, CPU/memory shares, networking, and volumes.
+Each image has an associated JSON structure which describes some basic information about the image such as date created, author, as well as execution/runtime configuration like its entrypoint, default arguments, CPU/memory shares, networking, and volumes.
 The JSON structure also references a cryptographic hash of each layer used by the image, and provides history information for those layers.
 This JSON is considered to be immutable, because changing it would change the computed [ImageID](#imageid).
 Changing it means creating a new derived image, instead of changing the existing image.


### PR DESCRIPTION
we doesn't define parent image in the configuration, we
should remove this sentence.

Signed-off-by: Lei Jitang <leijitang@huawei.com>