### PR TITLE
manifest.md: use `base layer` instead of `base image`

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -42,7 +42,7 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 - **`layers`** *array*
 
     Each item in the array MUST be a [descriptor](descriptor.md).
-    The array MUST have the base image at index 0.
+    The array MUST have the base layer at index 0.
     Subsequent layers MUST then follow in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).
     The final filesystem layout MUST match the result of [applying](layer.md#applying) the layers to an empty directory.
     The [ownership, mode, and other attributes](layer.md#file-attributes) of the initial empty directory are unspecified.


### PR DESCRIPTION
We doesn't define a `base image`, use `base layer` is
correct. This issue first being addressed in pr #312,
and then being addressed in pr #318, and then in pr #407,
but landing #407 has a long way to go. We could address
this first to avoid confusing.

Signed-off-by: Lei Jitang <leijitang@huawei.com>