### PR TITLE
fix bug: config test cases MUST include all required fields

### DIFF
--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -31,7 +31,13 @@ func TestConfig(t *testing.T) {
 			config: `
 {
     "architecture": "amd64",
-    "os": 123
+    "os": 123,
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
+    }
 }
 `,
 			fail: true,
@@ -47,6 +53,12 @@ func TestConfig(t *testing.T) {
     "os": "linux",
     "config": {
         "User": 1234
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
     }
 }
 `,
@@ -57,7 +69,15 @@ func TestConfig(t *testing.T) {
 		{
 			config: `
 {
-    "history": "should be an array"
+    "history": "should be an array",
+    "architecture": "amd64",
+    "os": 123,
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
+    }
 }
 `,
 			fail: true,
@@ -67,10 +87,18 @@ func TestConfig(t *testing.T) {
 		{
 			config: `
 {
+    "architecture": "amd64",
+    "os": 123,
     "config": {
         "Env": [
             7353
         ]
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
     }
 }
 `,
@@ -81,11 +109,19 @@ func TestConfig(t *testing.T) {
 		{
 			config: `
 {
+    "architecture": "amd64",
+    "os": 123,
     "config": {
         "Volumes": [
             "/var/job-result-data",
             "/var/log/my-app-logs"
         ]
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
     }
 }
 `,
@@ -98,6 +134,7 @@ func TestConfig(t *testing.T) {
 			fail:   true,
 		},
 
+		// valid config with optional fields
 		{
 			config: `
 {
@@ -150,6 +187,23 @@ func TestConfig(t *testing.T) {
         "empty_layer": true
       }
     ]
+}
+`,
+			fail: false,
+		},
+
+		// valid config with only required fields
+		{
+			config: `
+{
+    "architecture": "amd64",
+    "os": "linux",
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
+    }
 }
 `,
 			fail: false,


### PR DESCRIPTION
Test cases should contain required fields, otherwise result will be always failure whether the validated field be legal or not. That is not our expection.
And add a new test case for only required fields, to check the `optional` and `required` fields in spec.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>