### PR TITLE
config: s/annotations/labels/

### DIFF
--- a/config.md
+++ b/config.md
@@ -136,8 +136,8 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
      Keys MUST be unique within this map, and best practice is to namespace the keys.
      Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
      Keys using the `org.opencontainers` namespace are reserved and MUST NOT be used by subsequent specifications.
-     If there are no annotations then this property MAY either be absent or an empty map.
-     Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown annotation key.
+     If there are no labels then this property MAY either be absent or an empty map.
+     Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown label key.
 
 - **rootfs** *object*, REQUIRED
 


### PR DESCRIPTION
Let's consistently refer to labels as labels so as not to confuse them
with the other kinds of annotations.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>