### PR TITLE
travis: fix gometalinter

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -6,7 +6,7 @@ set -o pipefail
 
 if [ ! $(command -v gometalinter) ]; then
 	go get -u github.com/alecthomas/gometalinter
-	gometalinter --update --install
+	gometalinter --install
 fi
 
 for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -not -iwholename '*vendor*'); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - docker pull vbatts/pandoc
   - make install.tools
   - go get -u github.com/alecthomas/gometalinter
-  - gometalinter --install --update
+  - gometalinter --install
   - go get -t -d ./...
 
 install: true


### PR DESCRIPTION
Apparently --update doesn't play nicely anymore, and has been removed
from the guidance for gometalinter usage. Let's get rid of it since it's
breaking every travis build and appears to be redundant anyway.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>