### PR TITLE
validator.go: add the layers of the judgment

### DIFF
--- a/schema/validator.go
+++ b/schema/validator.go
@@ -105,6 +105,10 @@ func validateManifestDescendants(r io.Reader) error {
 		return errors.Wrap(err, "manifest format mismatch")
 	}
 
+	if len(header.Layers) == 0 {
+		return fmt.Errorf("no layers found")
+	}
+
 	if header.Config.MediaType != string(v1.MediaTypeImageConfig) {
 		fmt.Printf("warning: config %s has an unknown media type: %s\n", header.Config.Digest, header.Config.MediaType)
 	}


### PR DESCRIPTION
Since the following use of ` range header.Layers`, so in the previous layer should increase the judge.
Signed-off-by: zhouhao <zhouhao@cn.fujitsu.com>