### PR TITLE
fix json format of example in config.md

### DIFF
--- a/config.md
+++ b/config.md
@@ -223,7 +223,7 @@ Here is an example image configuration JSON document:
         "Labels": {
             "com.example.project.git.url": "https://example.com/project.git",
             "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b"
-	}
+        }
     },
     "rootfs": {
       "diff_ids": [


### PR DESCRIPTION
replace `tab` with 8 space
Signed-off-by: Lei Jitang <leijitang@huawei.com>