### PR TITLE
Remove Memory MemorySwap CpuShares from config

### DIFF
--- a/config.md
+++ b/config.md
@@ -18,7 +18,7 @@ Using a layer-based or union filesystem such as AUFS, or by computing the diff f
 
 ### Image JSON
 
-Each image has an associated JSON structure which describes some basic information about the image such as date created, author, as well as execution/runtime configuration like its entrypoint, default arguments, CPU/memory shares, networking, and volumes.
+Each image has an associated JSON structure which describes some basic information about the image such as date created, author, as well as execution/runtime configuration like its entrypoint, default arguments, networking, and volumes.
 The JSON structure also references a cryptographic hash of each layer used by the image, and provides history information for those layers.
 This JSON is considered to be immutable, because changing it would change the computed [ImageID](#imageid).
 Changing it means creating a new derived image, instead of changing the existing image.
@@ -78,21 +78,6 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
      This acts as a default value to use when the value is not specified when creating a container.
      For Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.
      If `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` from the container are applied.
-
-   - **Memory** *integer*, OPTIONAL
-
-     Memory limit (in bytes).
-     This acts as a default value to use when the value is not specified when creating a container.
-
-   - **MemorySwap** *integer*, OPTIONAL
-
-     MemorySwap is a platform-specific field to set total memory usage (memory + swap) for Linux based systems; set to `-1` to disable swap.
-     This acts as a default value to use when the value is not specified when creating a container.
-
-   - **CpuShares** *integer*, OPTIONAL
-
-     CPU shares (relative weight vs. other containers).
-     This acts as a default value to use when the value is not specified when creating a container.
 
    - **ExposedPorts** *object*, OPTIONAL
 
@@ -196,9 +181,6 @@ Here is an example image configuration JSON document:
     "os": "linux",
     "config": {
         "User": "alice",
-        "Memory": 2048,
-        "MemorySwap": 4096,
-        "CpuShares": 8,
         "ExposedPorts": {
             "8080/tcp": {}
         },

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -144,9 +144,6 @@ func TestConfig(t *testing.T) {
     "os": "linux",
     "config": {
         "User": "1:1",
-        "Memory": 2048,
-        "MemorySwap": 4096,
-        "CpuShares": 8,
         "ExposedPorts": {
             "8080/tcp": {}
         },

--- a/schema/defs-config.json
+++ b/schema/defs-config.json
@@ -7,15 +7,6 @@
         "User": {
           "type": "string"
         },
-        "Memory": {
-          "$ref": "defs.json#/definitions/int64"
-        },
-        "MemorySwap": {
-          "$ref": "defs.json#/definitions/int64"
-        },
-        "CpuShares": {
-          "$ref": "defs.json#/definitions/int64"
-        },
         "ExposedPorts": {
           "$ref": "defs.json#/definitions/mapStringObject"
         },

--- a/schema/fs.go
+++ b/schema/fs.go
@@ -233,24 +233,24 @@ DLQ9RAMAAA==
 
 	"/defs-config.json": {
 		local:   "defs-config.json",
-		size:    2483,
-		modtime: 1480556605,
+		size:    2236,
+		modtime: 1481704571,
 		compressed: `
-H4sIAAAJbogA/+RWzY7TMBC+5ykiw7GwF8SB6y43UJEi4IBQ5SaT7Syxx4wnQIT23XGypRsnrel2tycO
-VRvH389845/+zvJcVeBLRidIVr3J1RXUaLF/8rnTLFi2jeZcKF86sJdkRaMFzsOvGq/zwkGJNZZ6wC/u
-CHcMgbDXCIPlMH33HEakc9AL0voGShmgw7hjchB0wY9mh/GPHjgaGXF4YbTXavfqdnGPew+GuJsinzPU
-PTKY9S9vPNlnFyPfF2jl9asUX/FTu6fjvHRtsdE8KflRlG9/OfJQfSCWh7Ia7Yoh0OVda/bz2x+HuqGZ
-dacW41coYKY2Ev0LUgdEhTtHoeypNllY9jV9iQRiuaTFhM1/WI3tTiwnXdi2aWKmMc/X/UvFVP9t7Z+o
-ac18kxxZ/6mr/txVfSb+FmSv8KTj7Z1eQ3PuSIo9jX/ySLLx95ZdMZHU/jH3RoV1vcJqFtH5T6vt/FRL
-I1mwrZn1TDW6A/YqndkuBYbvLTJUEc99BlN32Zjxb+Yb9BJfmQ8OvWTQArOTKlV9TWy0DKsxQF8IGti/
-4nUrGzppr2xdrdazvwNHockYmN88x0DBOOlWQycPwddEDWirDu2HrP/cZn8CAAD//0zDaxqzCQAA
+H4sIAAAJbogA/+RVzY7TMBC+5yksw7Gwd6673JCKVAEHhCo3Ge/OEnvMeIKI0L47TrZ0888qpac9VG0m
+/n7m89j9nSmlC4g5YxAkr98pfQMWPTZPUQXDgnlVGlZCahvAX5MXgx5YpV8Wb9UuQI4Wc9PiN4+EJ4ZE
+2GikYt4uPz2nitQBGkE63EMuLbStB6YASRdiZ3Wqf4rAvUqHIwqjv9WnVw+bJ9z7X4EiFB+JJQ7xrxls
+g0+W49v7SP7VVcf9lTNh1zJvHz1O8/ufc7YMs6n1pvsKBdzQxkIjSWpGVLgOhF6G2uRh2/T0tSfQl1u0
+uGDzH1b7dgeWF134qiz7TF2eb5MRXLvixfb+mcrKwWicn9n/2qm/dFdfiL8n2Rtcdc4/mAOUl45kN7Hx
+/z2SrPt9ZNdMJDaec4EWaO0ei1FEl7+tjuuXtrQnC75yoz3TpamBo17O7JQCw48KGYoez1MGQ3dZl/Fv
+5ncYhbg+J/ScwQiMbqql7i2xM9JOY4K+EXQwPfGmkjtadVaOrvaHehWanIPxP89zoOCC1Pt2J+fgB6IS
+jNdz5yFrPg/ZnwAAAP//3oH4m7wIAAA=
 `,
 	},
 
 	"/defs-image.json": {
 		local:   "defs-image.json",
 		size:    2736,
-		modtime: 1480556516,
+		modtime: 1481704392,
 		compressed: `
 H4sIAAAJbogA/7yWy27bOhCG934KQgmQhS86i4MCNYIARbPpKot01cAtJtTImlQiVZJO6gR+95K6UrcE
 boyuEg7Jn/83nBH9MmMsiFBzRbkhKYI1C64xJkFupFkOyhDfpaCYkewmR/FZCgMkULEvGWyR3ebIKSYO
@@ -289,7 +289,7 @@ MrVJbn8cB+ZnN/gbAAD//0JyEpx5DAAA
 	"/image-manifest-schema.json": {
 		local:   "image-manifest-schema.json",
 		size:    1139,
-		modtime: 1480556516,
+		modtime: 1481704392,
 		compressed: `
 H4sIAAAJbogA/6RSO4/UMBDu8ytGvuu4xByiupbqCkTBiQZRmHiSzCl+YPtWrFb73/Ej3mx2KRBb5ou/
 18wcGgAm0feObCCj2ROwLxb1J6ODII0OnpUYET4LTQP6AF8t9jRQL/Lrh0S/9/2ESiTqFIJ94vzVG90W

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -19,15 +19,6 @@ type ImageConfig struct {
 	// User defines the username or UID which the process in the container should run as.
 	User string `json:"User,omitempty"`
 
-	// Memory defines the memory limit.
-	Memory int64 `json:"Memory,omitempty"`
-
-	// MemorySwap defines the total memory usage limit (memory + swap).
-	MemorySwap int64 `json:"MemorySwap,omitempty"`
-
-	// CPUShares is the CPU shares (relative weight vs. other containers).
-	CPUShares int64 `json:"CpuShares,omitempty"`
-
 	// ExposedPorts a set of ports to expose from a container running this image.
 	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
 


### PR DESCRIPTION
As I said in https://github.com/opencontainers/image-spec/pull/371#issuecomment-252411562,
I'd like to remove these resource limit from image-spec.

On the on hand, if we have this, we should have limit
the min and max size of these value. For example, in
docker, there are some min and max limit for some
resource, see https://github.com/docker/docker/blob/master/daemon/daemon_unix.go#L48

ping @vbatts  @stevvooe 


Signed-off-by: Lei Jitang <leijitang@huawei.com>