### PR TITLE
[Spec.md] Split title onto two lines

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,5 @@
-# Open Container Initiative Image Format Specification
+# Open Container Initiative
+# Image Format Specification
 
 This specification defines an OCI Image, consisting of a [manifest](manifest.md), a set of [filesystem layers](layer.md), and a [configuration](config.md).
 


### PR DESCRIPTION
This should fix the hyphenation of the word "Specification" in the PDF version.

Signed-off-by: Rob Dolin <robdolin@microsoft.com>