### PR TITLE
image manifest: add back 'source' annotation key

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -118,3 +118,4 @@ This specification defines the following annotation keys, which MAY be used by m
 * **org.opencontainers.authors** contact details of the people or organization responsible for the image (freeform string)
 * **org.opencontainers.homepage** URL to find more information on the image (string, must be a URL with scheme HTTP or HTTPS)
 * **org.opencontainers.documentation** URL to get documentation on the image (string, must be a URL with scheme HTTP or HTTPS)
+* **org.opencontainers.source** URL to get source code for the binary files in the image (string, must be a URL with scheme HTTP or HTTPS)


### PR DESCRIPTION
This got dropped somehow in commit 873b9b64fda6eed when things were
moved around in the file, so add it back.

Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>