### PR TITLE
README: Link to specs-go and schema and declare Go-compat policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The OCI Image Format project creates and maintains the software shipping contain
 
 The specification can be found [here](spec.md).
 
+This repository also provides [Go types](specs-go), [intra-blob validation tooling, and JSON Schema](schema).
+The Go types and validation should be compatible with the current Go release; earlier Go releases are not supported.
+
 Additional documentation about how this group operates:
 
 - [Code of Conduct](https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md)


### PR DESCRIPTION
The links help with discoverability, otherwise folks reading the README might not notice that we provided these resources in addition to the spec itself.

The Go-compat policy formalizes the rough sketch [here][1].  By declaring a Go-compat policy, folks who have Go troubles can tell without testing whether the image-spec tooling *should* work for their Go environment.  And if/when it does not, they can see whether image-spec is interested in patches or not.  For example, if the tooling breaks on Go 1.5, we don't care or want some awkward workaround.  But if it breaks on Go 1.6 we do care and want a patch.   And if someone wants to genericize our test suite to run on both 1.6 and 1.7, we want a patch for that too.

And I'm just guessing at 1.6.  Maybe the repo-policy is to support 1.5+?  Something else?

[1]: https://github.com/opencontainers/image-spec/pull/487#issuecomment-265876398