### PR TITLE
config: forbid snapshotting of data volumes

### DIFF
--- a/config.md
+++ b/config.md
@@ -149,7 +149,8 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
    - **Volumes** *object*, OPTIONAL
 
      A set of directories which SHOULD be created as data volumes in a container running this image.
-     If a file or folder exists within the image with the same path as a data volume, that file or folder will be replaced by the data volume and never be merged.
+     If a file or folder exists within the image with the same path as a data volume, that file or folder MUST be replaced by the data volume and never be merged.
+     When a new layer is created from a container that has data volumes, any data within the data volume SHOULD NOT be included in the changeset layer.
      **NOTE:** This JSON structure value is unusual because it is a direct JSON serialization of the Go type `map[string]struct{}` and is represented in JSON as an object mapping its keys to an empty object.
 
    - **WorkingDir** *string*, OPTIONAL


### PR DESCRIPTION
This is necessary in order to make sure that unpackers all have sane
behaviour when it comes to handling image repacking and layer
generation. Since data volumes are generally bindmounts from sources
external to the image, it is not a good idea to snapshot said data --
and thus we should forbid it.

Closes #496
Signed-off-by: Aleksa Sarai <asarai@suse.de>