### PR TITLE
image-layout: Drop manifest ref example description

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -78,8 +78,6 @@ $ cat ./refs/v1.0 | jq
 }
 ```
 
-This illustrates the expected contents of a given ref, the manifest list it points to and the blobs the manifest references.
-
 ## Blobs
 
 Object names in the `blobs` subdirectories are composed of a directory for each hash algorithm, the children of which will contain the actual content.

--- a/image-layout.md
+++ b/image-layout.md
@@ -69,6 +69,8 @@ Those tags will often be represented in an image-layout repository with matching
 
 ### Example Ref
 
+This is an example `v1.0` ref with a manifest-list descriptor:
+
 ```
 $ cat ./refs/v1.0 | jq
 {


### PR DESCRIPTION
A ref → descriptor example caption gained “blobs the manifest references” wording with 2f24791, #136, but I don't see a direct relationship between descriptors and those deeper-ancestor blobs.  I think we either want to revert the changes 2f24791 made to this line or drop the line.  In this commit I drop the line, because the other points covered by the sentence are already covered in other descriptor docs.  And it's pretty clear just from the example command and output that this is showing the content of a ref pointing at a manifest list.

Fixes #427.