### PR TITLE
Add imagelayout validator and ImageLayoutFile const

### DIFF
--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -211,7 +211,7 @@ func TestConfig(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.config)
-		err := schema.MediaTypeImageConfig.Validate(r)
+		err := schema.ValidatorMediaTypeImageConfig.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/descriptor_test.go
+++ b/schema/descriptor_test.go
@@ -204,7 +204,7 @@ func TestDescriptor(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.descriptor)
-		err := schema.MediaTypeDescriptor.Validate(r)
+		err := schema.ValidatorMediaTypeDescriptor.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/manifest_backwards_compatibility_test.go
+++ b/schema/manifest_backwards_compatibility_test.go
@@ -116,7 +116,7 @@ func TestBackwardsCompatibilityManifestList(t *testing.T) {
 
 		manifestlist := convertFormats(tt.manifestlist)
 		r := strings.NewReader(manifestlist)
-		err := schema.MediaTypeManifestList.Validate(r)
+		err := schema.ValidatorMediaTypeManifestList.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
@@ -178,7 +178,7 @@ func TestBackwardsCompatibilityManifest(t *testing.T) {
 
 		manifest := convertFormats(tt.manifest)
 		r := strings.NewReader(manifest)
-		err := schema.MediaTypeManifest.Validate(r)
+		err := schema.ValidatorMediaTypeManifest.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
@@ -217,7 +217,7 @@ func TestBackwardsCompatibilityConfig(t *testing.T) {
 
 		config := convertFormats(tt.config)
 		r := strings.NewReader(config)
-		err := schema.MediaTypeImageConfig.Validate(r)
+		err := schema.ValidatorMediaTypeImageConfig.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -193,7 +193,7 @@ func TestManifest(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.manifest)
-		err := schema.MediaTypeManifest.Validate(r)
+		err := schema.ValidatorMediaTypeManifest.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/manifestlist_test.go
+++ b/schema/manifestlist_test.go
@@ -239,7 +239,7 @@ func TestManifestList(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.manifestList)
-		err := schema.MediaTypeManifestList.Validate(r)
+		err := schema.ValidatorMediaTypeManifestList.Validate(r)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -26,6 +26,7 @@ const (
 	MediaTypeManifest     Validator     = v1.MediaTypeImageManifest
 	MediaTypeManifestList Validator     = v1.MediaTypeImageManifestList
 	MediaTypeImageConfig  Validator     = v1.MediaTypeImageConfig
+	TypeImageLayout       Validator     = v1.ImageLayoutFile
 	MediaTypeImageLayer   unimplemented = v1.MediaTypeImageLayer
 )
 
@@ -40,6 +41,7 @@ var (
 		MediaTypeManifest:     "image-manifest-schema.json",
 		MediaTypeManifestList: "manifest-list-schema.json",
 		MediaTypeImageConfig:  "config-schema.json",
+		TypeImageLayout:       "image-layout-schema.json",
 	}
 )
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -22,12 +22,12 @@ import (
 
 // Media types for the OCI image formats
 const (
-	MediaTypeDescriptor   Validator     = v1.MediaTypeDescriptor
-	MediaTypeManifest     Validator     = v1.MediaTypeImageManifest
-	MediaTypeManifestList Validator     = v1.MediaTypeImageManifestList
-	MediaTypeImageConfig  Validator     = v1.MediaTypeImageConfig
-	TypeImageLayout       Validator     = v1.ImageLayoutFile
-	MediaTypeImageLayer   unimplemented = v1.MediaTypeImageLayer
+	ValidatorMediaTypeDescriptor   Validator     = v1.MediaTypeDescriptor
+	ValidatorMediaTypeManifest     Validator     = v1.MediaTypeImageManifest
+	ValidatorMediaTypeManifestList Validator     = v1.MediaTypeImageManifestList
+	ValidatorMediaTypeImageConfig  Validator     = v1.MediaTypeImageConfig
+	ValidatorTypeImageLayout       Validator     = v1.ImageLayoutFile
+	ValidatorMediaTypeImageLayer   unimplemented = v1.MediaTypeImageLayer
 )
 
 var (
@@ -37,11 +37,11 @@ var (
 
 	// specs maps OCI schema media types to schema files.
 	specs = map[Validator]string{
-		MediaTypeDescriptor:   "content-descriptor.json",
-		MediaTypeManifest:     "image-manifest-schema.json",
-		MediaTypeManifestList: "manifest-list-schema.json",
-		MediaTypeImageConfig:  "config-schema.json",
-		TypeImageLayout:       "image-layout-schema.json",
+		ValidatorMediaTypeDescriptor:   "content-descriptor.json",
+		ValidatorMediaTypeManifest:     "image-manifest-schema.json",
+		ValidatorMediaTypeManifestList: "manifest-list-schema.json",
+		ValidatorMediaTypeImageConfig:  "config-schema.json",
+		ValidatorTypeImageLayout:       "image-layout-schema.json",
 	}
 )
 

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -33,7 +33,7 @@ type Validator string
 type validateDescendantsFunc func(r io.Reader) error
 
 var mapValidateDescendants = map[Validator]validateDescendantsFunc{
-	MediaTypeManifest: validateManifestDescendants,
+	ValidatorMediaTypeManifest: validateManifestDescendants,
 }
 
 // ValidationError contains all the errors that happened during validation.

--- a/specs-go/v1/layout.go
+++ b/specs-go/v1/layout.go
@@ -14,8 +14,12 @@
 
 package v1
 
-// ImageLayoutVersion is the version of ImageLayout
-const ImageLayoutVersion = "1.0.0"
+const (
+	// ImageLayoutFile is the file name of oci image layout file
+	ImageLayoutFile = "oci-layout"
+	// ImageLayoutVersion is the version of ImageLayout
+	ImageLayoutVersion = "1.0.0"
+)
 
 // ImageLayout is the structure in the "oci-layout" file, found in the root
 // of an OCI Image-layout directory.


### PR DESCRIPTION
We had added image layout schema, but didn't add image layout validator.
Add imagelayout validator and ImageLayoutFile const, so image tool and other
tools can use image -spec to validate the layout of the oci image.