### PR TITLE
Makefile: Use 'ifdef TRAVIS_COMMIT_RANGE' for git-validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 install: true
 
 script:
+  - env | grep TRAVIS_
   - make .gitvalidation
   - make lint
   - make check-license

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ img/%.png: img/%.dot
 # When this is running in travis, it will only check the travis commit range
 .gitvalidation:
 	@which git-validation > /dev/null 2>/dev/null || (echo "ERROR: git-validation not found. Consider 'make install.tools' target" && false)
-ifeq ($(TRAVIS),true)
+ifdef TRAVIS_COMMIT_RANGE
 	git-validation -q -run DCO,short-subject,dangling-whitespace
 else
 	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD


### PR DESCRIPTION
Only use the auto-ranging when Travis tells us what the range is.  Use our `EPOCH_TEST_COMMIT`-based range in all other cases.

This may fix the issue we've been having with #514.