### PR TITLE
specs-go/v1: use digest type on descriptor

### DIFF
--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -14,13 +14,15 @@
 
 package v1
 
+import digest "github.com/opencontainers/go-digest"
+
 // Descriptor describes the disposition of targeted content.
 type Descriptor struct {
 	// MediaType contains the MIME type of the referenced object.
 	MediaType string `json:"mediaType"`
 
 	// Digest is the digest of the targeted content.
-	Digest string `json:"digest"`
+	Digest digest.Digest `json:"digest"`
 
 	// Size specifies the size in bytes of the blob.
 	Size int64 `json:"size"`


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @opencontainers/image-spec-maintainers