### PR TITLE
fix repeated content address example

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -38,8 +38,8 @@ $ find .
 ./blobs
 ./blobs/sha256/e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f
 ./blobs/sha256/afff3924849e458c5ef237db5f89539274d5e609db5db935ed3959c90f1f2d51
+./blobs/sha256/9b97579de92b1c195b85bb42a11011378ee549b02d7fe9c17bf2a6b35d5cb079
 ./blobs/sha256/5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270
-./blobs/sha256/e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f
 ./oci-layout
 ./refs
 ./refs/v1.0
@@ -94,7 +94,7 @@ The blobs directory MAY be missing referenced blobs, in which case the missing b
 ### Example Blobs
 
 ```
-$ cat ./blobs/sha256/e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f | jq
+$ cat ./blobs/sha256/9b97579de92b1c195b85bb42a11011378ee549b02d7fe9c17bf2a6b35d5cb079 | jq
 {
   "schemaVersion": 2,
   "manifests": [


### PR DESCRIPTION
should not be present 2 identicial cas file under a dir.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>