### PR TITLE
image-layout: use a made-up name/email for author

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -132,7 +132,7 @@ $ cat ./blobs/sha256/afff3924849e458c5ef237db5f89539274d5e609db5db935ed3959c90f1
 $ cat ./blobs/sha256/5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270 | jq
 {
   "architecture": "amd64",
-  "author": "Antonio Murdaca <runcom@redhat.com>",
+  "author": "Alyssa P. Hacker <alyspdev@example.com>",
   "config": {
     "Hostname": "8dfe43d80430",
     "Domainname": "",


### PR DESCRIPTION
The image spec shouldn't reference real names/addresses in example
content. Switch to the same fake one we use elsewhere. It's like
alternative facts.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>