### PR TITLE
considerations: DRY extensibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ DOC_FILES := \
 	layer.md \
 	config.md \
 	annotations.md \
-	canonicalization.md
+	considerations.md
 
 FIGURE_FILES := \
 	img/media-types.png

--- a/considerations.md
+++ b/considerations.md
@@ -1,3 +1,8 @@
+# Extensibility
+
+Implementations that are reading/processing [manifests](manifest.md) or [manifest lists](manifest-list.md) MUST NOT generate an error if they encounter an unknown property.
+Instead they MUST ignore unknown properties.
+
 # Canonicalization
 
 OCI Images [are](descriptor.md) [content-addressable](image-layout.md).

--- a/manifest-list.md
+++ b/manifest-list.md
@@ -71,10 +71,6 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     See [Pre-Defined Annotation Keys](annotations.md#pre-defined-annotation-keys).
 
-### Extensibility
-Implementations that are reading/processing manifest lists MUST NOT generate an error if they encounter an unknown property.
-Instead they MUST ignore unknown properties.
-
 ## Example Manifest List
 
 *Example showing a simple manifest list pointing to image manifests for two platforms:*

--- a/manifest.md
+++ b/manifest.md
@@ -66,10 +66,6 @@ Unlike the [Manifest List](manifest-list.md), which contains information about a
 
     See [Pre-Defined Annotation Keys](annotations.md#pre-defined-annotation-keys).
 
-### Extensibility
-Implementations that are reading/processing image manifests MUST NOT generate an error if they encounter an unknown property.
-Instead they MUST ignore unknown properties.
-
 ## Example Image Manifest
 
 *Example showing an image manifest:*

--- a/spec.md
+++ b/spec.md
@@ -18,7 +18,9 @@ The goal of this specification is to enable the creation of interoperable tools 
 - [Filesystem Layers](layer.md)
 - [Image Configuration](config.md)
 - [Annotations](annotations.md)
-- [Canonicalization](canonicalization.md)
+- [Considerations](considerations.md)
+    - [Extensibility](considerations.md#extensibility)
+    - [Canonicalization](considerations.md#canonicalization)
 
 # Notational Conventions
 


### PR DESCRIPTION
[As][1] [I][2] [suggested][3] in #164.

The extensibility requirements might arguably apply to our other JSON types as well (like annotations, which were recently DRYed up in #501).  The new extensibility section sets the stage for that, but I've left the other types off this commit to focus on making the current requirements more DRY without changing the specified behavior.

My personal preference would be to have separate `canonicalization.md` and a (very short) `extensibility.md` file, but @jonboulle [wanted the single file][4].

This PR is a resubmission of #340 after rebasing around the just-landed #501 (as [requested][5] by @stevvooe).

[1]: https://github.com/opencontainers/image-spec/pull/164#issuecomment-243952187
[2]: https://github.com/opencontainers/image-spec/pull/164#issuecomment-244279771
[3]: https://github.com/opencontainers/image-spec/pull/164#r77871859
[4]: https://github.com/opencontainers/image-spec/pull/340#issuecomment-252670278
[5]: https://github.com/opencontainers/image-spec/pull/340#issuecomment-274209846