### PR TITLE
config: Require RFC 3339's more restricted version of ISO 8601

### DIFF
--- a/config.md
+++ b/config.md
@@ -51,7 +51,7 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
 
 - **created** *string*, OPTIONAL
 
-  An ISO-8601 formatted combined date and time at which the image was created.
+  An combined date and time at which the image was created, formatted as defined by [RFC 3339, section 5.6][rfc3339-s5.6].
 
 - **author** *string*, OPTIONAL
 
@@ -146,7 +146,7 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
 
     - **created** *string*, OPTIONAL
 
-       Creation time, expressed as an ISO-8601 formatted combined date and time.
+       A combined date and time at which the layer was created, formatted as defined by [RFC 3339, section 5.6][rfc3339-s5.6].
 
     - **author** *string*, OPTIONAL
 
@@ -228,4 +228,5 @@ Here is an example image configuration JSON document:
 }
 ```
 
+[rfc3339-s5.6]: https://tools.ietf.org/html/rfc3339#section-5.6
 [runtime-platform]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc2/config.md#platform

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -71,7 +71,7 @@ type History struct {
 // Image is the JSON structure which describes some basic information about the image.
 // This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
 type Image struct {
-	// Created defines an ISO-8601 formatted combined date and time at which the image was created.
+	// Created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
 	Created string `json:"created,omitempty"`
 
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.


### PR DESCRIPTION
This brings us into compliance with JSON Schema, whose [current validation draft requires RFC 3339 for date-times][1].  I've modeled the reference phrasing on the draft JSON Schema's date-time definition.

Fixes #389.
Obsoletes #480 (which still hasn't grown a Signed-off-by).

[1]: https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.3.1