### PR TITLE
specs-go: Image.Created uses a string type

### DIFF
--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -14,6 +14,8 @@
 
 package v1
 
+import "time"
+
 // ImageConfig defines the execution parameters which should be used as a base when running a container using an image.
 type ImageConfig struct {
 	// User defines the username or UID which the process in the container should run as.
@@ -52,8 +54,8 @@ type RootFS struct {
 
 // History describes the history of a layer.
 type History struct {
-	// Created is the creation time.
-	Created string `json:"created,omitempty"`
+	// Created is the combined date and time at which the layer was created, formatted as defined by RFC 3339, section 5.6.
+	Created time.Time `json:"created,omitempty"`
 
 	// CreatedBy is the command which created the layer.
 	CreatedBy string `json:"created_by,omitempty"`
@@ -72,7 +74,7 @@ type History struct {
 // This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
 type Image struct {
 	// Created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
-	Created string `json:"created,omitempty"`
+	Created time.Time `json:"created,omitempty"`
 
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
 	Author string `json:"author,omitempty"`


### PR DESCRIPTION
Modify History.Created and Image.Created to be of type time.Time so that creation times may be validated, compared, etc.