### PR TITLE
Fix prerequisites in HACKING

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,7 @@ This guide contains instructions for building artifacts contained in this reposi
 This spec includes several Go packages, and a command line tool considered to be a reference implementation of the OCI image specification.
 
 Prerequisites:
-* Go >=1.5
+* Go - current release only, earlier releases are not supported
 * make
 
 The following make targets are relevant for any work involving the Go packages.


### PR DESCRIPTION
Updating Go version dependency

The prerequisites in HACKING.md states Go >= 1.5 is supported. 
However, the tests will not pass in 1.5 or 1.6, nor will the linting as
testing.T.Run() which is used was added in Go 1.7. 

This patch updates the prerequisite to the latest Go version. A  
specific version is not specified as this will likely have to be 
changed repeatedly in the future. But it does remove the incorrect
version with some guidance to upgrade.

Fix #535 

Signed-off-by: David Lyle david.lyle@intel.com