### PR TITLE
schema/gen: Include .json instead of excluding .go

### DIFF
--- a/schema/gen.go
+++ b/schema/gen.go
@@ -18,4 +18,4 @@ package schema
 // using esc (https://github.com/mjibson/esc).
 
 // This should generally be invoked with `make schema-fs`
-//go:generate esc -private -pkg=schema -ignore=.*go -ignore=.*swp .
+//go:generate esc -private -pkg=schema -include=.*\.json$ .


### PR DESCRIPTION
To avoid accidentally including [`.swp`, `.un~`, etc.][1]  Test with:

    $ touch schema/.defs-image.json.swp
    $ touch schema/.content-descriptor.json.un~
    $ touch schema/foojson
    $ make schema-fs
    $ grep '"/' schema/fs.go
            "/config-schema.json": {
            "/content-descriptor.json": {
            "/defs-config.json": {
            "/defs-image.json": {
            "/defs.json": {
            "/image-layout-schema.json": {
            "/image-manifest-schema.json": {
            "/manifest-list-schema.json": {
            "/": {
                    local: "/",

CC @vbatts.

[1]: https://github.com/opencontainers/image-spec/pull/533#discussion_r98296739