### PR TITLE
schema/defs-image: Remove 'null' from valid annotations

### DIFF
--- a/schema/defs-image.json
+++ b/schema/defs-image.json
@@ -83,14 +83,7 @@
     },
     "annotations": {
       "id": "https://opencontainers.org/schema/image/annotations",
-      "oneOf": [
-        {
-          "$ref": "defs.json#/definitions/mapStringString"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "defs.json#/definitions/mapStringString"
     }
   }
 }


### PR DESCRIPTION
The `null` option has been in the JSON Schema since #44, although I expect it was accidental.  The spec has clearly not allowed:

    "annotations": null

since #164 landed with the following (still current) requirements:

> Annotations MUST be a key-value map where both the key and value MUST be strings.

and:

> If there are no annotations then this property MUST either be absent or be an empty map.

Folks without annotations should not set the property at all, or they should set it to:

    "annotations": {}