### PR TITLE
Makefile: Add .install.esc and make it part of install.tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ DOC_FILENAME	?= oci-image-spec
 
 EPOCH_TEST_COMMIT ?= v0.2.0
 
+TOOLS := esc gitvalidation glide glide-vc
+
 default: check-license lint test
 
 help:
@@ -111,7 +113,7 @@ else
 	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
 endif
 
-install.tools: .install.esc .install.gitvalidation .install.glide .install.glide-vc
+install.tools: $(TOOLS:%=.install.%)
 
 .install.esc:
 	go get -u github.com/mjibson/esc
@@ -129,6 +131,7 @@ clean:
 	rm -rf *~ $(OUTPUT_DIRNAME) header.html
 
 .PHONY: \
+	$(TOOLS:%=.install.%) \
 	validate-examples \
 	check-license \
 	clean \

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,10 @@ else
 	git-validation -v -run DCO,short-subject,dangling-whitespace -range $(EPOCH_TEST_COMMIT)..HEAD
 endif
 
-install.tools: .install.gitvalidation .install.glide .install.glide-vc
+install.tools: .install.esc .install.gitvalidation .install.glide .install.glide-vc
+
+.install.esc:
+	go get -u github.com/mjibson/esc
 
 .install.gitvalidation:
 	go get -u github.com/vbatts/git-validation


### PR DESCRIPTION
So we can make `schema/fs.go` in Travis.

This pulls a commit out of #530, but we'll want this whether we take the #530 approach or @vbatts approach from #533.  Missing this commit doesn't cause an error in the #533 tests at the moment, because the current tip is [not actually rebuilting `fs.go`][1].

[1]: https://github.com/opencontainers/image-spec/pull/533#discussion_r98332378