### PR TITLE
specs-go/v1: add annotations field to descriptor

### DIFF
--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -30,4 +30,7 @@ type Descriptor struct {
 
 	// URLs specifies a list of URLs from which this object MAY be downloaded
 	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>

@opencontainers/image-spec-maintainers  PTAL