### PR TITLE
fixes broken links to oci-scope-table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Additional documentation about how this group operates:
 - [Releases](RELEASES.md)
 - [Project Documentation](project.md)
 
-The _optional_ and _base_ layers of all OCI projects are tracked in the [OCI Scope Table](https://www.opencontainers.org/governance/oci-scope-table).
+The _optional_ and _base_ layers of all OCI projects are tracked in the [OCI Scope Table](https://www.opencontainers.org/about/oci-scope-table).
 
 ## Running an OCI Image
 
@@ -39,7 +39,7 @@ To support this UX the OCI Image Format contains sufficient information to launc
 
 **Q: Why doesn't this project mention distribution?**
 
-A: Distribution, for example using HTTP as both Docker v2.2 and AppC do today, is currently out of scope on the [OCI Scope Table](https://www.opencontainers.org/governance/oci-scope-table).
+A: Distribution, for example using HTTP as both Docker v2.2 and AppC do today, is currently out of scope on the [OCI Scope Table](https://www.opencontainers.org/about/oci-scope-table).
 There has been [some discussion on the TOB mailing list](https://groups.google.com/a/opencontainers.org/d/msg/tob/A3JnmI-D-6Y/tLuptPDHAgAJ) to make distribution an optional layer, but this topic is a work in progress.
 
 **Q: Why a new project?**


### PR DESCRIPTION
The oci-scope-table moved from governance/ to about/

Signed-off-by: Mike Brown <brownwm@us.ibm.com>