### PR TITLE
schema: validation: correctly validate gzip layer mediatypes

### DIFF
--- a/schema/validator.go
+++ b/schema/validator.go
@@ -111,7 +111,9 @@ func validateManifestDescendants(r io.Reader) error {
 
 	for _, layer := range header.Layers {
 		if layer.MediaType != string(v1.MediaTypeImageLayer) &&
-			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) {
+			layer.MediaType != string(v1.MediaTypeImageLayerGzip) &&
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) &&
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableGzip) {
 			fmt.Printf("warning: layer %s has an unknown media type: %s\n", layer.Digest, layer.MediaType)
 		}
 	}


### PR DESCRIPTION
When the change was made to make gzip optional for layers, the validator
was not updated -- causing completely valid layers to cause warnings
during validation.

Fixes: aad7f240f0c54 ("media-types: Define layer media types with and without '+gzip'")
Signed-off-by: Aleksa Sarai <asarai@suse.de>