### PR TITLE
spec-go: Add "Annotations" field to Descriptor.

### DIFF
--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -30,4 +30,7 @@ type Descriptor struct {
 
 	// URLs specifies a list of URLs from which this object MAY be downloaded
 	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata for the descriptor.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }


### PR DESCRIPTION
[84b6a28](https://github.com/opencontainers/image-spec/commit/84b6a2856480590f79ecd09244504bb935f8ebbe) added annotations to [descriptor.md](https://github.com/opencontainers/image-spec/blob/master/descriptor.md), we need to add it to spec-go accordingly as well.

Signed-off-by: Qian Zhang <zhq527725@gmail.com>