### PR TITLE
Makefile: suitable "default" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DOC_FILENAME	?= oci-image-spec
 
 EPOCH_TEST_COMMIT ?= v0.2.0
 
-default: help
+default: check-license lint test
 
 help:
 	@echo "Usage: make <target>"


### PR DESCRIPTION
I like that there is a "help" target, but the default ought to do
sensible things. :-)

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>