### PR TITLE
specs-go/v1: remove stutter in name of index

### DIFF
--- a/specs-go/v1/index.go
+++ b/specs-go/v1/index.go
@@ -50,9 +50,9 @@ type ManifestDescriptor struct {
 	Platform Platform `json:"platform"`
 }
 
-// ImageIndex references manifests for various platforms.
+// Index references manifests for various platforms.
 // This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
-type ImageIndex struct {
+type Index struct {
 	specs.Versioned
 
 	// Manifests references platform specific manifests.


### PR DESCRIPTION
We are already working with images, so we don't need to repeat
ourselves. Changing `ImageIndex` to `Index.

Signed-off-by: Stephen J Day <stephen.day@docker.com>