### PR TITLE
fix error valid target in image-layout

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -134,7 +134,7 @@ The `imageLayoutVersion` value will align with the OCI Image Specification versi
 
 ### oci-layout Example
 
-```json
+```json,title=OCI%20Layout&mediatype=oci%2Dlayout
 {
     "imageLayoutVersion": "1.0.0"
 }


### PR DESCRIPTION
In layout.md, The validated target should be image layout itself, not only image index.

I'd like to extract and land this firstly, while #452 is in WIP. 

Signed-off-by: xiekeyang <xiekeyang@huawei.com>