### PR TITLE
image-layout: make index.json refnames unique

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -147,7 +147,8 @@ The [image index](image-index.md) is a multi-descriptor entry point.
 
 This index provides an established path (`/index.json`) to have an entry point for an image-layout and to discover auxiliary descriptors.
 
-No semantic restriction is given for the "org.opencontainers.ref.name" annotation of descriptors.
+If set, the value of the `org.opencontainers.ref.name` annotation in each descriptor MUST be unique to the `index.json`.
+No semantic restriction is given for the `org.opencontainers.ref.name` annotation of descriptors.
 In general the `mediaType` of each [descriptor][descriptors] object in the `manifests` field will be either `application/vnd.oci.image.index.v1+json` or `application/vnd.oci.image.manifest.v1+json`.
 Future versions of the spec MAY use a different mediatype (i.e. a new versioned format).
 An encountered `mediaType` that is unknown SHOULD be safely ignored.

--- a/image-layout.md
+++ b/image-layout.md
@@ -149,9 +149,9 @@ This index provides an established path (`/index.json`) to have an entry point f
 
 If set, the value of the `org.opencontainers.ref.name` annotation in each descriptor MUST be unique to the `index.json`.
 No semantic restriction is given for the `org.opencontainers.ref.name` annotation of descriptors.
-In general the `mediaType` of each [descriptor][descriptors] object in the `manifests` field will be either `application/vnd.oci.image.index.v1+json` or `application/vnd.oci.image.manifest.v1+json`.
+In general, the `mediaType` of each [descriptor][descriptors] object in the `manifests` field SHOULD be either `application/vnd.oci.image.index.v1+json` or `application/vnd.oci.image.manifest.v1+json`.
 Future versions of the spec MAY use a different mediatype (i.e. a new versioned format).
-An encountered `mediaType` that is unknown SHOULD be safely ignored.
+An encountered `mediaType` that is unknown SHOULD be ignored.
 
 
 **Implementor's Note:**


### PR DESCRIPTION
Without this change, a generic image handling tool would not be able to
handle all cases with duplicate org.opencontainers.ref.name annotations,
due to ambiguity about which descriptor is the "best match".

While it has been floated that since the annotation is not actually
mandatory implementations should have alternative methods of referencing
entries in an image-index, this is quite a frustrating issue for
implementations that just want to use org.opencontainers.ref.name in the
"common" case.

Fixes #581 
Signed-off-by: Aleksa Sarai <asarai@suse.de>