### PR TITLE
Use `REQUIRED properties` instead of `base properties`

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -25,7 +25,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
   This REQUIRED property contains a list of [manifests](manifest.md) for specific platforms.
   While this property MUST be present, the size of the array MAY be zero.
 
-  Each object in `manifests` has the base properties of [descriptor](descriptor.md) with the following additional properties and restrictions:
+  Each object in `manifests` has the REQUIRED properties of [descriptor](descriptor.md) with the following additional properties and restrictions:
 
   - **`mediaType`** *string*
 

--- a/image-layout.md
+++ b/image-layout.md
@@ -26,8 +26,7 @@ The image layout is as follows:
     - It MAY include additional fields
 - `index.json` file
     - It MUST exist
-    - It MUST be a JSON object
-    - It MUST have the base properties of an [image index](image-index.md).
+    - It MUST be an [image index](image-index.md) JSON object.
     - See [index.json](#indexjson-file) section
 
 ## Example Layout


### PR DESCRIPTION
`base properties` is not quite clear because we don't
define which property is the base properties and which
is not the base properties. Use `REQUIRED properties`
to make it more clear.

Signed-off-by: Lei Jitang <leijitang@huawei.com>