### PR TITLE
layer: Use rfc1952_2 as a link reference

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -9,7 +9,7 @@ This section defines the `application/vnd.oci.image.layer.v1.tar`, `application/
 ## `+gzip` Media Types
 
 The media type `application/vnd.oci.image.layer.v1.tar+gzip` represents an `application/vnd.oci.image.layer.v1.tar` payload which has been compressed with [gzip][rfc1952].
-The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload which has been compressed with [gzip][rfc1952].
+The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload which has been compressed with [gzip][rfc1952_2].
 
 ## Distributable Format
 
@@ -323,5 +323,5 @@ Implementations SHOULD NOT upload layers tagged with this media type; however, s
 
 [libarchive-tar]: https://github.com/libarchive/libarchive/wiki/ManPageTar5#POSIX_ustar_Archives
 [gnu-tar-standard]: http://www.gnu.org/software/tar/manual/html_node/Standard.html
-[rfc1952]: https://tools.ietf.org/html/rfc1952
+[rfc1952_2]: https://tools.ietf.org/html/rfc1952
 [tar-archive]: https://en.wikipedia.org/wiki/Tar_(computing)


### PR DESCRIPTION
Avoiding [this][1]:

    pandoc: Duplicate link reference `[rfc1952]' "source" (line 1044, column 1)

which is breaking current master builds.  More on this (and the solution I'm using here) [here][2].

[1]: https://travis-ci.org/opencontainers/image-spec/builds/209076959#L363
[2]: https://github.com/opencontainers/runtime-spec/blob/dd41d8ffd6dd29fc0be1f3197519f11727cb19d3/style.md#links