### PR TITLE
define media type for oci-layout

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -20,5 +20,5 @@ for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -n
 		--disable=gas \
 		--cyclo-over=35 \
 		--tests \
-		--deadline=10s "${d}"
+		--deadline=15s "${d}"
 done

--- a/image-layout.md
+++ b/image-layout.md
@@ -133,7 +133,7 @@ This section defines the `application/vnd.oci.layout.header.v1+json` [media type
 
 ### oci-layout Example
 
-```json,title=OCI%20Layout&mediatype=oci%2Dlayout
+```json,title=OCI%20Layout&mediatype=application/vnd.oci.layout.header.v1%2Bjson
 {
     "imageLayoutVersion": "1.0.0"
 }

--- a/image-layout.md
+++ b/image-layout.md
@@ -129,6 +129,7 @@ $ cat ./blobs/sha256/e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7f
 
 This JSON object serves as a marker for the base of an Open Container Image Layout and to provide the version of the image-layout in use.
 The `imageLayoutVersion` value will align with the OCI Image Specification version at the time changes to the layout are made, and will pin a given version until changes to the image layout are required.
+This section defines the `application/vnd.oci.layout.header.v1+json` [media type](media-types.md).
 
 ### oci-layout Example
 

--- a/media-types.md
+++ b/media-types.md
@@ -3,6 +3,7 @@
 The following media types identify the formats described here and their referenced resources:
 
 - `application/vnd.oci.descriptor.v1+json`: [Content Descriptor](descriptor.md)
+- `application/vnd.oci.layout.header.v1+json`: [OCI Layout](image-layout.md#oci-layout-file)
 - `application/vnd.oci.image.index.v1+json`: [Image Index](image-index.md)
 - `application/vnd.oci.image.manifest.v1+json`: [Image manifest](manifest.md#image-manifest)
 - `application/vnd.oci.image.config.v1+json`: [Image config](config.md)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -22,12 +22,12 @@ import (
 
 // Media types for the OCI image formats
 const (
-	ValidatorMediaTypeDescriptor  Validator     = v1.MediaTypeDescriptor
-	ValidatorMediaTypeManifest    Validator     = v1.MediaTypeImageManifest
-	ValidatorMediaTypeImageIndex  Validator     = v1.MediaTypeImageIndex
-	ValidatorMediaTypeImageConfig Validator     = v1.MediaTypeImageConfig
-	ValidatorTypeImageLayout      Validator     = v1.ImageLayoutFile
-	ValidatorMediaTypeImageLayer  unimplemented = v1.MediaTypeImageLayer
+	ValidatorMediaTypeDescriptor   Validator     = v1.MediaTypeDescriptor
+	ValidatorMediaTypeLayoutHeader Validator     = v1.MediaTypeLayoutHeader
+	ValidatorMediaTypeManifest     Validator     = v1.MediaTypeImageManifest
+	ValidatorMediaTypeImageIndex   Validator     = v1.MediaTypeImageIndex
+	ValidatorMediaTypeImageConfig  Validator     = v1.MediaTypeImageConfig
+	ValidatorMediaTypeImageLayer   unimplemented = v1.MediaTypeImageLayer
 )
 
 var (
@@ -37,11 +37,11 @@ var (
 
 	// specs maps OCI schema media types to schema files.
 	specs = map[Validator]string{
-		ValidatorMediaTypeDescriptor:  "content-descriptor.json",
-		ValidatorMediaTypeManifest:    "image-manifest-schema.json",
-		ValidatorMediaTypeImageIndex:  "image-index-schema.json",
-		ValidatorMediaTypeImageConfig: "config-schema.json",
-		ValidatorTypeImageLayout:      "image-layout-schema.json",
+		ValidatorMediaTypeDescriptor:   "content-descriptor.json",
+		ValidatorMediaTypeLayoutHeader: "image-layout-schema.json",
+		ValidatorMediaTypeManifest:     "image-manifest-schema.json",
+		ValidatorMediaTypeImageIndex:   "image-index-schema.json",
+		ValidatorMediaTypeImageConfig:  "config-schema.json",
 	}
 )
 

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -18,6 +18,9 @@ const (
 	// MediaTypeDescriptor specifies the media type for a content descriptor.
 	MediaTypeDescriptor = "application/vnd.oci.descriptor.v1+json"
 
+	// MediaTypeLayoutHeader specifies the media type for the oci-layout.
+	MediaTypeLayoutHeader = "application/vnd.oci.layout.header.v1+json"
+
 	// MediaTypeImageManifest specifies the media type for an image manifest.
 	MediaTypeImageManifest = "application/vnd.oci.image.manifest.v1+json"
 


### PR DESCRIPTION
Following #579.

To add a new specific media type for oci-layout, serving over its transportation.

Signed-off-by: xiekeyang <xiekeyang@huawei.com>