### PR TITLE
config: change reproducibility "MUST" to "SHOULD"

### DIFF
--- a/config.md
+++ b/config.md
@@ -26,7 +26,7 @@ Changing it means creating a new derived image, instead of changing the existing
 ### Layer DiffID
 
 A layer DiffID is the digest over the layer's uncompressed tar archive and serialized in the descriptor digest format, e.g., `sha256:a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9`.
-Layers must be packed and unpacked reproducibly to avoid changing the layer DiffID, for example by using [tar-split][] to save the tar headers.
+Layers SHOULD be packed and unpacked reproducibly to avoid changing the layer DiffID, for example by using [tar-split][] to save the tar headers.
 
 NOTE: Do not confuse DiffIDs with [layer digests](manifest.md#image-manifest-property-descriptions), often referenced in the manifest, which are digests over compressed or uncompressed content.
 


### PR DESCRIPTION
As noted in
https://github.com/opencontainers/image-spec/pull/608#discussion_r105802346 , we shouldn't be mandating that implementers use something like
tar-split to facilitate reproducible DiffIDs, but rather recommend it.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>