### PR TITLE
considerations.md: use clearer links to describe concepts

### DIFF
--- a/considerations.md
+++ b/considerations.md
@@ -5,7 +5,7 @@ Instead they MUST ignore unknown properties.
 
 # Canonicalization
 
-* OCI Images [are](descriptor.md) [content-addressable](image-layout.md).
+* OCI Images are [content-addressable](https://en.wikipedia.org/wiki/Content-addressable_storage). See [descriptors](descriptor.md) for more.
 * One benefit of content-addressable storage is easy deduplication.
 * Many images might depend on a particular [layer](layer.md), but there will only be one blob in the [store](image-layout.md).
 * With a different serialization, that same semantic layer would have a different hash, and if both versions of the layer are referenced there will be two blobs with the same semantic content.


### PR DESCRIPTION
I felt the linking of the word `are` and `content-addressible` to foreign topics unrelated to the words needed to be changed to be more explicit. I hope you agree.

Thanks!