### PR TITLE
.pullapprove.yml: Switch to v2 and other project-template updates

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,12 +1,27 @@
-approve_by_comment: true
-approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
-reject_regex: ^Rejected
-reset_on_push: true
-author_approval: ignored
-signed_off_by:
-  required: true
-reviewers:
-  teams:
-  - image-spec-maintainers
-  name: default
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+group_defaults:
   required: 2
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(Approved|lgtm|LGTM|:shipit:|:star:|:\+1:|:ship:)'
+    reject_regex: ^Rejected
+  reset_on_push:
+    enabled: true
+  author_approval:
+    ignored: true
+  always_pending:
+    title_regex: ^WIP
+    explanation: 'Work in progress...'
+  conditions:
+    branches:
+      - master
+
+groups:
+  image-spec:
+    teams:
+      - image-spec-maintainers


### PR DESCRIPTION
Pull in changes from opencontainers/project-template#29.  The only changes vs. the upstream version are:

* Kept the image-spec-specific `approve_regexp`.
* Removed all the groups except for the image-spec group.

After this PR lands, PullApprove will start treating @jbouzane's [review][1]-[approvals][2] as LGTM votes.

[1]: https://github.com/opencontainers/image-spec/pull/567#pullrequestreview-25901352
[2]: https://github.com/opencontainers/image-spec/pull/609#pullrequestreview-27199819