### PR TITLE
specs-go/v1: unify the descriptor type

### DIFF
--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -17,7 +17,8 @@ package v1
 import digest "github.com/opencontainers/go-digest"
 
 // Descriptor describes the disposition of targeted content.
-// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype when marshalled to JSON
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
+// when marshalled to JSON.
 type Descriptor struct {
 	// MediaType is the media type of the object this schema refers to.
 	MediaType string `json:"mediaType,omitempty"`
@@ -33,4 +34,35 @@ type Descriptor struct {
 
 	// Annotations contains arbitrary metadata relating to the targeted content.
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Platform describes the platform which the image in the manifest runs on.
+	//
+	// This should only be used when referring to a manifest.
+	Platform *Platform `json:"platform,omitempty"`
+}
+
+// Platform describes the platform which the image in the manifest runs on.
+type Platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings, each
+	// listing a required CPU feature (for example `sse4` or `aes`).
+	Features []string `json:"features,omitempty"`
 }

--- a/specs-go/v1/index.go
+++ b/specs-go/v1/index.go
@@ -16,47 +16,13 @@ package v1
 
 import "github.com/opencontainers/image-spec/specs-go"
 
-// Platform describes the platform which the image in the manifest runs on.
-type Platform struct {
-	// Architecture field specifies the CPU architecture, for example
-	// `amd64` or `ppc64`.
-	Architecture string `json:"architecture"`
-
-	// OS specifies the operating system, for example `linux` or `windows`.
-	OS string `json:"os"`
-
-	// OSVersion is an optional field specifying the operating system
-	// version, for example `10.0.10586`.
-	OSVersion string `json:"os.version,omitempty"`
-
-	// OSFeatures is an optional field specifying an array of strings,
-	// each listing a required OS feature (for example on Windows `win32k`).
-	OSFeatures []string `json:"os.features,omitempty"`
-
-	// Variant is an optional field specifying a variant of the CPU, for
-	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
-	Variant string `json:"variant,omitempty"`
-
-	// Features is an optional field specifying an array of strings, each
-	// listing a required CPU feature (for example `sse4` or `aes`).
-	Features []string `json:"features,omitempty"`
-}
-
-// ManifestDescriptor describes a platform specific manifest.
-type ManifestDescriptor struct {
-	Descriptor
-
-	// Platform describes the platform which the image in the manifest runs on.
-	Platform *Platform `json:"platform,omitempty"`
-}
-
 // Index references manifests for various platforms.
 // This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
 type Index struct {
 	specs.Versioned
 
 	// Manifests references platform specific manifests.
-	Manifests []ManifestDescriptor `json:"manifests"`
+	Manifests []Descriptor `json:"manifests"`
 
 	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`


### PR DESCRIPTION
Unifying the descriptor type makes it much easier to handler descriptors
in generic manner. This change ensures that a single deserialization can
be done a descriptor that may be processed in separate contexts.

It is unclear whether or not the specification should be pedantic about
this, as well. As it is written, these fields are only valid when being
referred through a manifest, but this distinction is only required
during validation. It may be possible to lift the platform definition to
the descriptor type, but this isn't strictly necessary.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Addresses #588.
Closes #618.