### PR TITLE
Make the Platform field actually optional.

### DIFF
--- a/specs-go/v1/index.go
+++ b/specs-go/v1/index.go
@@ -47,7 +47,7 @@ type ManifestDescriptor struct {
 	Descriptor
 
 	// Platform describes the platform which the image in the manifest runs on.
-	Platform Platform `json:"platform,omitempty"`
+	Platform *Platform `json:"platform,omitempty"`
 }
 
 // Index references manifests for various platforms.


### PR DESCRIPTION
The spec states that platform is an optional field for the items in the
image index. Pull request #607 added omitempty to the field, but
omitempty only works for types with a zero value. Because Platform is a
struct, it will never be omitted. The platform field should instead be a
pointer so that it can be properly omitted when it has no value.
Currently, serializing an index.json without populating platform leads to
something like the following:
```
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest":
"sha256:d73e0d70cb05a373b5a666ba608139624d90a88d0155d2ade06a6001a27cd8d5",
      "size": 348,
      "platform": {
        "architecture": "",
        "os": ""
      }
    }
  ]
}
```
With the change in this patch, leaving platform as nil will cause it to
be omitted as expected.

Signed-off-by: Vishvananda Ishaya Abrams <vishvananda@gmail.com>