### PR TITLE
README: Document the alternate-week meeting times

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# https://tools.ietf.org/html/rfc5545#section-3.1
+*.ics text eol=crlf

--- a/README.md
+++ b/README.md
@@ -73,10 +73,16 @@ When in doubt, start on the [mailing-list](#mailing-list).
 
 ## Weekly Call
 
-The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
+The contributors and maintainers of all OCI projects have a weekly meeting on Wednesdays at:
+
+* 8:00 AM (USA Pacific), during [odd weeks][iso-week].
+* 5:00 PM (USA Pacific), during [even weeks][iso-week].
+
+There is an [iCalendar][rfc5545] format for the meetings [here](meeting.ics).
+
 Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1-415-968-0849 (no PIN needed).
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/runtime-spec/wiki) for those who are unable to join the call.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki][runtime-wiki] for those who are unable to join the call.
 
 ## Mailing List
 
@@ -164,3 +170,6 @@ Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git
 
 [UberConference]: https://www.uberconference.com/opencontainers
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[iso-week]: https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_of_a_given_date
+[rfc5545]: https://tools.ietf.org/html/rfc5545
+[runtime-wiki]: https://github.com/opencontainers/runtime-spec/wiki

--- a/meeting.ics
+++ b/meeting.ics
@@ -1,0 +1,44 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Open Containers Initiative//Developer Meeting//EN
+BEGIN:VTIMEZONE
+TZID:America/Los_Angeles
+LAST-MODIFIED:20050809T050000Z
+BEGIN:STANDARD
+DTSTART:20071104T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+TZOFFSETFROM:-0700
+TZOFFSETTO:-0800
+TZNAME:PST
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+TZOFFSETFROM:-0800
+TZOFFSETTO:-0700
+TZNAME:PDT
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:tdc-meeting-1@opencontainers.org
+DTSTAMP:20170322T223000Z
+DTSTART;TZID=America/Los_Angeles:20170329T080000
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
+DURATION:PT1H
+SUMMARY:OCI TDC Meeting
+DESCRIPTION;ALTREP="https://github.com/opencontainers/image-spec#
+ weekly-call":Open Containers Initiative Developer Meeting
+URL:https://github.com/opencontainers/image-spec/blob/master/meeting.ics
+END:VEVENT
+BEGIN:VEVENT
+UID:tdc-meeting-2@opencontainers.org
+DTSTAMP:20170322T223000Z
+DTSTART;TZID=America/Los_Angeles:20170405T170000
+RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=WE
+DURATION:PT1H
+SUMMARY:OCI TDC Meeting
+DESCRIPTION;ALTREP="https://github.com/opencontainers/image-spec#
+ weekly-call":Open Containers Initiative Developer Meeting
+URL:https://github.com/opencontainers/image-spec/blob/master/meeting.ics
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
Cherry-pick opencontainers/runtime-spec#740 over now that it has landed (and still ~45 minutes before today's meeting starts ;).