### PR TITLE
specs-go/v1/config.go: Capitalize `Labels`

### DIFF
--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -44,7 +44,7 @@ type ImageConfig struct {
 	WorkingDir string `json:"WorkingDir,omitempty"`
 
 	// Labels contains arbitrary metadata for the container.
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string `json:"Labels,omitempty"`
 
 	// StopSignal contains the system call signal that will be sent to the container to exit.
 	StopSignal string `json:"StopSignal,omitempty"`


### PR DESCRIPTION
This field was not similar to the other fields and causes problems when dealing with using this struct to convert between docker v1 and oci v1 repositories (I cheat a little by doing this, I realize it's not a long term solution).

Still, this seems out of place and I wanted to fix it while I noticed.