### PR TITLE
image-index: mark os.version, os.features and variant as "reserved"

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -55,15 +55,15 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     - **`os.version`** *string*
 
-        This OPTIONAL property specifies the operating system version, for example `10.0.10586`.
+        This OPTIONAL property is *reserved* for future versions of the specification and hence SHOULD NOT be used.
 
     - **`os.features`** *array of strings*
 
-        This OPTIONAL property specifies an array of strings, each specifying a mandatory OS feature (for example on Windows `win32k`).
+        This OPTIONAL property is *reserved* for future versions of the specification and hence SHOULD NOT be used.
 
     - **`variant`** *string*
 
-        This OPTIONAL property specifies the variant of the CPU, for example `armv6l` to specify a particular CPU variant of the ARM CPU.
+        This OPTIONAL property is *reserved* for future versions of the specification and hence SHOULD NOT be used.
 
     - **`features`** *array of strings*
 

--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -51,15 +51,16 @@ type Platform struct {
 	OS string `json:"os"`
 
 	// OSVersion is an optional field specifying the operating system
-	// version, for example `10.0.10586`.
+	// version. This property is reserved and SHOULD NOT be used.
 	OSVersion string `json:"os.version,omitempty"`
 
 	// OSFeatures is an optional field specifying an array of strings,
-	// each listing a required OS feature (for example on Windows `win32k`).
+	// each listing a required OS feature. This property is reserved and
+	// SHOULD NOT be used.
 	OSFeatures []string `json:"os.features,omitempty"`
 
-	// Variant is an optional field specifying a variant of the CPU, for
-	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	// Variant is an optional field specifying a variant of the CPU.
+	// This property is reserved and SHOULD NOT be used.
 	Variant string `json:"variant,omitempty"`
 
 	// Features is an optional field specifying an array of strings, each


### PR DESCRIPTION
Updates #622.

Previous version of this PR as follows: https://github.com/AkihiroSuda/image-spec/commit/24b83323f6f87e207b7b099d83e60f67d044ebd9
```
 - os.version:  speculated Windows-specific convention from the example
   - I think this property can be marked as "reserved, SHOULD NOT be used" unless someone is already using https://github.com/opencontainers/image-spec/pull/632#discussion_r109088972
 - os.features: still unclear. should be clearly standardized in post-v1.0.0
   - ditto
 - variant:     speculated arm-specific convention from the example
   - ditto
 - features:    speculated x86-specific convention from the example, and put little modification
   - this should be standardized in v1.0.0 for x86, because runtime-spec has already some Xeon-specific spec: https://github.com/opencontainers/runtime-spec/commit/73a6002bf3a2fc80b4aad706b7271993b9989404
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>