### PR TITLE
specs-go/v1/config: pointer-ify optional "Created" field

### DIFF
--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -62,7 +62,7 @@ type RootFS struct {
 // History describes the history of a layer.
 type History struct {
 	// Created is the combined date and time at which the layer was created, formatted as defined by RFC 3339, section 5.6.
-	Created time.Time `json:"created,omitempty"`
+	Created *time.Time `json:"created,omitempty"`
 
 	// CreatedBy is the command which created the layer.
 	CreatedBy string `json:"created_by,omitempty"`
@@ -81,7 +81,7 @@ type History struct {
 // This provides the `application/vnd.oci.image.config.v1+json` mediatype when marshalled to JSON.
 type Image struct {
 	// Created is the combined date and time at which the image was created, formatted as defined by RFC 3339, section 5.6.
-	Created time.Time `json:"created,omitempty"`
+	Created *time.Time `json:"created,omitempty"`
 
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
 	Author string `json:"author,omitempty"`


### PR DESCRIPTION
PR #534 changed Created from string to time.Time field.
This neutered the `omitempty` property on it, as a missing
field is now populated as the default time.Time value.

This commit turns the field into a pointer, in order to keep
the empty-value semantic for `omitempty`.

Fixes https://github.com/opencontainers/image-spec/issues/626

Signed-off-by: Luca Bruno <luca.bruno@coreos.com>