### PR TITLE
image-layout.md, annotations.md: restrict scope of ref.name

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -26,4 +26,4 @@ This specification defines the following annotation keys, intended for but not l
 * **org.opencontainers.image.revision** Source control revision identifier for packaged software.
 * **org.opencontainers.image.vendor** Name of the distributing entity, organization or individual.
 * **org.opencontainers.image.licenses** Comma-separated list of licenses under which contained software is distributed, in [SPDX Short identifier]https://spdx.org/licenses/] form.
-* **org.opencontainers.image.ref.name** Name of the reference (string)
+* **org.opencontainers.image.ref.name** Name of the reference for a target (string). SHOULD only be considered valid when on descriptors on `index.json` within [image layout](image-layout.md).


### PR DESCRIPTION
By restricting the scope of the annotation
`org.opencontainers.image.ref.name` to only image indexes appearing in
the context of an image layout, we can greatly simplify processing and
selection of target content. While other properties may apply down, we
ensure that naming is restricted to a single "entity", the `index.json`,
ambiguity for a given reference is reduced.

This does not apply to other annotations, which may "apply downward" to
other resources referenced. The application of annotation downward is
specific to a particular annotation.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Related to #588.