### PR TITLE
config: DRY up labels with annotations reference

### DIFF
--- a/config.md
+++ b/config.md
@@ -160,12 +160,7 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
    - **Labels** *object*, OPTIONAL
 
      The field contains arbitrary metadata for the container.
-     Labels MUST be a key-value map where both the key and value MUST be strings.
-     Keys MUST be unique within this map, and best practice is to namespace the keys.
-     Keys SHOULD be named using a reverse domain notation - e.g. `com.example.myKey`.
-     Keys using the `org.opencontainers.image` namespace are reserved and MUST NOT be used by subsequent specifications.
-     If there are no labels then this property MAY either be absent or an empty map.
-     Implementations that are reading/processing this configuration file MUST NOT generate an error if they encounter an unknown labels key.
+     This OPTIONAL property MUST use the [annotation rules](annotations.md#rules).
 
   - **StopSignal** *string*, OPTIONAL
 


### PR DESCRIPTION
from
https://github.com/opencontainers/image-spec/pull/635#issuecomment-291634824
it was clear that all the rules for `Labels` are the same as
annotations, so let's DRY that up a bit.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>