### PR TITLE
README: Link to MeetBot logs for meeting minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When in doubt, start on the [mailing-list](#mailing-list).
 The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
 Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1-415-968-0849 (no PIN needed).
 An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived to the [wiki](https://github.com/opencontainers/runtime-spec/wiki) for those who are unable to join the call.
+Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes].
 
 ## Mailing List
 
@@ -164,3 +164,4 @@ Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git
 
 [UberConference]: https://www.uberconference.com/opencontainers
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/


### PR DESCRIPTION
@RobDolinMS had been keeping the wiki up to date with links to the MeetBot logs, but linking directly to the MeetBot logs gives us one less thing to maintain.  The meetings which are only in the wiki are 2015-07-22, 2015-08-05, 2015-08-12, 2015-08-26, 2015-09-02, 2015-09-09, 2015-09-16, 2015-09-24, 2015-09-30.  The last is in MeetBot, but it was our first MeetBot meeting, so the MeetBot logs are not great.  However, *all* of those meetings predate image-spec ([founded
2016-03-24][1]), so I haven't bothered to link the runtime wiki at all.

This PR cherry-picks and adjusts opencontainers/runtime-spec#739 now that it has landed in runtime-spec.

[1]: https://groups.google.com/a/opencontainers.org/forum/#!topic/tob/KGyPpu8YfNk