### PR TITLE
config: Remove redundant OPTIONAL from Labels description

### DIFF
--- a/config.md
+++ b/config.md
@@ -160,7 +160,7 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
    - **Labels** *object*, OPTIONAL
 
      The field contains arbitrary metadata for the container.
-     This OPTIONAL property MUST use the [annotation rules](annotations.md#rules).
+     This property MUST use the [annotation rules](annotations.md#rules).
 
   - **StopSignal** *string*, OPTIONAL
 


### PR DESCRIPTION
While the other annotations references (e.g. [here][1]) use the “This OPTIONAL property…” pattern, `config.md` puts the OPTIONAL/REQUIRED-ness [in the same line as the property name][2] (while [`manifest.md` does not][3]).  My preferred larger fix would be to follow runtime-spec and consistently declare OPTIONAL/REQUIRED-ness in the same line as the property name, but that's a bigger change.  This commit just removes the redundant OPTIONAL from the description body.

Spun off from [here][4].

[1]: https://github.com/opencontainers/image-spec/blame/v1.0.0-rc5/manifest.md#L69
[2]: https://github.com/opencontainers/image-spec/blame/v1.0.0-rc5/config.md#L117
[3]: https://github.com/opencontainers/image-spec/blame/v1.0.0-rc5/manifest.md#L66
[4]: https://github.com/opencontainers/image-spec/pull/639#discussion_r109961266