### PR TITLE
spec: Drop "one or more" from index description

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -52,7 +52,7 @@ The [OCI Image Media Types](media-types.md) document is a starting point to unde
 The high-level components of the spec include:
 
 * [Image Manifest](manifest.md) - a document describing the components that make up a container image
-* [Image Index](image-index.md) - an annotated index of one or more image manifests
+* [Image Index](image-index.md) - an annotated index of image manifests
 * [Image Layout](image-layout.md) - a filesystem layout representing the contents of an image
 * [Filesystem Layer](layer.md) - a changeset that describes a container's filesystem
 * [Image Configuration](config.md) - a document determining layer ordering and configuration of the image suitable for translation into a [runtime bundle][runtime-spec]


### PR DESCRIPTION
Fixing overly-strict wording from #641 (see [this comment][1]).  We [explicitly allow `manifests` to be empty][2], which allows you to do things like distribute an image-layout which only provides CAS blobs.

[1]: https://github.com/opencontainers/image-spec/pull/641#discussion_r110429162
[2]: https://github.com/opencontainers/image-spec/blame/eb02c88ef382324a1572fa8c66f836a00d865a3f/image-index.md#L26