### PR TITLE
address duplicate REQUIREMENT

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -25,7 +25,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
   This REQUIRED property contains a list of [manifests](manifest.md) for specific platforms.
   While this property MUST be present, the size of the array MAY be zero.
 
-  Each object in `manifests` has the REQUIRED properties of [descriptor](descriptor.md) with the following additional properties and restrictions:
+  Each object in `manifests` includes a set of [descriptor properties](descriptor.md#properties) with the following additional properties and restrictions:
 
   - **`mediaType`** *string*
 


### PR DESCRIPTION
We are repeating the REQUIRED statement here in image-index.md which is properly located in the forward reference document descriptor.md. All upper case terms hold special meaning see  https://tools.ietf.org/html/rfc2119

Additionally as @wking points out, we're also including OPTIONAL descriptor properties in the extension, not just the REQUIRED properties.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>