### PR TITLE
image-index: define platform.variant for arm

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -63,7 +63,16 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     - **`variant`** *string*
 
-        This OPTIONAL property specifies the variant of the CPU, for example `armv6l` to specify a particular CPU variant of the ARM CPU.
+        This OPTIONAL property specifies the variant of the CPU.
+        Image indexes SHOULD use, and implementations SHOULD understand, values listed in the following table.
+        When the variant of the CPU is not listed in the table, values are implementation-defined and SHOULD be submitted to this specification for standardization.
+
+        | ISA/ABI         | `architecture` | `variant`   |
+        |-----------------|----------------|-------------|
+        | ARM 32-bit, v6  | `arm`          | `v6`        |
+        | ARM 32-bit, v7  | `arm`          | `v7`        |
+        | ARM 32-bit, v8  | `arm`          | `v8`        |
+        | ARM 64-bit, v8  | `arm64`        | `v8`        |
 
     - **`features`** *array of strings*
 

--- a/schema/backwards_compatibility_test.go
+++ b/schema/backwards_compatibility_test.go
@@ -49,7 +49,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
 		fail       bool
 	}{
 		{
-			digest: "sha256:219f4b61132fe9d09b0ec5c15517be2ca712e4744b0e0cc3be71295b35b2a467",
+			digest: "sha256:d0ed7cfe33821cb6a15624486e650149e92fff3192ff2014bda0c4b0206c1aa2",
 			imageIndex: `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
@@ -91,7 +91,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
          "platform": {
             "architecture": "arm",
             "os": "linux",
-            "variant": "armv7"
+            "variant": "v7"
          }
       },
       {
@@ -101,7 +101,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
          "platform": {
             "architecture": "arm64",
             "os": "linux",
-            "variant": "armv8"
+            "variant": "v8"
          }
       }
    ]

--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -59,7 +59,7 @@ type Platform struct {
 	OSFeatures []string `json:"os.features,omitempty"`
 
 	// Variant is an optional field specifying a variant of the CPU, for
-	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	// example `v7` to specify ARMv7 when architecture is `arm`.
 	Variant string `json:"variant,omitempty"`
 
 	// Features is an optional field specifying an array of strings, each


### PR DESCRIPTION
Please refer to https://github.com/opencontainers/image-spec/pull/632 for previous discussion.

In this PR, I avoided to use Linux-specific uname values for ease of porting to non-Linux.
https://github.com/opencontainers/image-spec/pull/632#discussion_r109226040

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>