### PR TITLE
.tool/lint: increase deadline

### DIFF
--- a/.tool/lint
+++ b/.tool/lint
@@ -20,5 +20,5 @@ for d in $(find . -type d -not -iwholename '*.git*' -a -not -iname '.tool' -a -n
 		--disable=gas \
 		--cyclo-over=35 \
 		--tests \
-		--deadline=15s "${d}"
+		--deadline=60s "${d}"
 done


### PR DESCRIPTION
CI has been flaky for the too short deadline (https://github.com/opencontainers/image-spec/pull/650#issuecomment-296584432)

60s might be extremely long, but I think it does not hurt.


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>