### PR TITLE
Clarify 'platform' identifies the image runtime requirements.

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -40,7 +40,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
   - **`platform`** *object*
 
-    This OPTIONAL property describes the platform which the image in the manifest runs on.
+    This OPTIONAL property describes the minimum runtime requirements of the image.
     This property SHOULD be present if its target is platform-specific.
 
     - **`architecture`** *string*


### PR DESCRIPTION
It needs to be clarified that the manifest is describing what is 'in the image', not what 'it will run on'.

Signed-off-by: Matt Spencer <matt.spencer@arm.com>