### PR TITLE
Add MUST NOT and SHALL NOT to conventions

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -29,8 +29,8 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 The key words "unspecified", "undefined", and "implementation-defined" are to be interpreted as described in the [rationale for the C99 standard][c99-unspecified].
 
-An implementation is not compliant if it fails to satisfy one or more of the MUST, REQUIRED, or SHALL requirements for the protocols it implements.
-An implementation is compliant if it satisfies all the MUST, REQUIRED, and SHALL requirements for the protocols it implements.
+An implementation is not compliant if it fails to satisfy one or more of the MUST, MUST NOT, REQUIRED, SHALL, or SHALL NOT requirements for the protocols it implements.
+An implementation is compliant if it satisfies all the MUST, MUST NOT, REQUIRED, SHALL, and SHALL NOT requirements for the protocols it implements.
 
 ## Overview
 


### PR DESCRIPTION
MUST NOT and SHALL NOT means an absolute prohibition of the spec. They should be one of requirements to judge one implementation if it is compliant.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>