### PR TITLE
descriptor: sha{256,512}: disallow /[A-F]/ characters

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -76,6 +76,9 @@ algorithm-separator   := /[+._-]/
 encoded               := /[a-zA-Z0-9=_-]+/
 ```
 
+Note that _algorithm_ MAY impose algorithm-specific restriction on the grammar of the _encoded_ portion.
+See also [Registered Algorithms](#registered-identifiers).
+
 Some example digest strings include the following:
 
 digest                                                                    | algorithm           | Supported |
@@ -137,10 +140,16 @@ If a useful algorithm is not included in the above table, it SHOULD be submitted
 [SHA-256][rfc4634-s4.1] is a collision-resistant hash function, chosen for ubiquity, reasonable size and secure characteristics.
 Implementations MUST implement SHA-256 digest verification for use in descriptors.
 
+When the _algorithm identifier_ is `sha256`, the _encoded_ portion MUST match `/[a-f0-9]{64}/`.
+Note that `[A-F]` MUST NOT be used here.
+
 #### SHA-512
 
 [SHA-512][rfc4634-s4.2] is a collision-resistant hash function which [may be more perfomant][sha256-vs-sha512] than [SHA-256](#sha-256) on some CPUs.
 Implementations MAY implement SHA-512 digest verification for use in descriptors.
+
+When the _algorithm identifier_ is `sha512`, the _encoded_ portion MUST match `/[a-f0-9]{128}/`.
+Note that `[A-F]` MUST NOT be used here.
 
 ## Examples
 

--- a/schema/descriptor_test.go
+++ b/schema/descriptor_test.go
@@ -191,7 +191,7 @@ func TestDescriptor(t *testing.T) {
 			fail: true,
 		},
 
-		// expected failure: digest does not match pattern (invalid hash characters)
+		// expected failure: digest does not match pattern (characters needs to be lower for sha256)
 		{
 			descriptor: `
 {
@@ -200,6 +200,7 @@ func TestDescriptor(t *testing.T) {
   "digest": "sha256:5B0BCABD1ED22E9FB1310CF6C2DEC7CDEF19F0AD69EFA1F392E94A4333501270"
 }
 `,
+			fail: true,
 		},
 
 		// expected success: valid URL entry

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
 
+	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
@@ -33,7 +35,8 @@ type Validator string
 type validateDescendantsFunc func(r io.Reader) error
 
 var mapValidateDescendants = map[Validator]validateDescendantsFunc{
-	ValidatorMediaTypeManifest: validateManifestDescendants,
+	ValidatorMediaTypeManifest:   validateManifestDescendants,
+	ValidatorMediaTypeDescriptor: validateDescriptorDescendants,
 }
 
 // ValidationError contains all the errors that happened during validation.
@@ -115,6 +118,42 @@ func validateManifestDescendants(r io.Reader) error {
 			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) &&
 			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableGzip) {
 			fmt.Printf("warning: layer %s has an unknown media type: %s\n", layer.Digest, layer.MediaType)
+		}
+	}
+	return nil
+}
+
+var (
+	sha256EncodedRegexp = regexp.MustCompile(`^[a-f0-9]{64}$`)
+	sha512EncodedRegexp = regexp.MustCompile(`^[a-f0-9]{128}$`)
+)
+
+func validateDescriptorDescendants(r io.Reader) error {
+	header := v1.Descriptor{}
+
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return errors.Wrapf(err, "error reading the io stream")
+	}
+
+	err = json.Unmarshal(buf, &header)
+	if err != nil {
+		return errors.Wrap(err, "descriptor format mismatch")
+	}
+
+	if header.Digest.Validate() != nil {
+		// we ignore unsupported algorithms
+		fmt.Printf("warning: unsupported digest: %q: %v\n", header.Digest, err)
+		return nil
+	}
+	switch header.Digest.Algorithm() {
+	case digest.SHA256:
+		if !sha256EncodedRegexp.MatchString(header.Digest.Hex()) {
+			return errors.Errorf("unexpected sha256 digest: %q", header.Digest)
+		}
+	case digest.SHA512:
+		if !sha512EncodedRegexp.MatchString(header.Digest.Hex()) {
+			return errors.Errorf("unexpected sha512 digest: %q", header.Digest)
 		}
 	}
 	return nil


### PR DESCRIPTION
Disallowing upper characters will be useful for avoiding implementation bugs

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>