### PR TITLE
descriptor: Replace "supported" with "registered"

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -78,18 +78,18 @@ encoded               := /[a-zA-Z0-9=_-]+/
 
 Some example digest strings include the following:
 
-digest                                                                    | algorithm           | Supported |
---------------------------------------------------------------------------|---------------------|-----------|
-`sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b` | [SHA-256](#sha-256) | Yes       |
-`sha512:401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b372742...`   | [SHA-512](#sha-512) | Yes       |
-`multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8`         | Multihash           | No        |
-`sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564`                 | SHA-256 with urlsafe base64 | No|
+digest                                                                    | algorithm           | Registered |
+--------------------------------------------------------------------------|---------------------|------------|
+`sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b` | [SHA-256](#sha-256) | Yes        |
+`sha512:401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b372742...`   | [SHA-512](#sha-512) | Yes        |
+`multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8`         | Multihash           | No         |
+`sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564`                 | SHA-256 with urlsafe base64 | No |
 
-Please see [Registered Algorithms](#registered-algorithms) for a list of supported algorithms.
+Please see [Registered Algorithms](#registered-algorithms) for a list of registered algorithms.
 
-Implementations SHOULD allow digests that are unsupported to pass validation if they comply with the above grammar.
-While `sha256` will only use hex encoded digests, support for separators in _algorithm_ and alpha numeric in _encoded_ is included to allow for future extension of digest support.
-As an example, we can paramterize the encoding and algorithm as `multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8`, which would be considered valid but unsupported by this specification.
+Implementations SHOULD allow digests with unrecognized algorithms to pass validation if they comply with the above grammar.
+While `sha256` will only use hex encoded digests, separators in _algorithm_ and alphanumerics in _encoded_ are included to allow for extensions.
+As an example, we can parameterize the encoding and algorithm as `multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8`, which would be considered valid but unregistered by this specification.
 
 ### Verification
 


### PR DESCRIPTION
Avoid adding a second word meaning the same thing (spun off from [here][1]).  I've consolidated around “registered” because it matches the existing “Registered algorithms” header.

Also some copy-edits for the sentences I've touched:

* “alpha numeric” -> “alphanumerics” (matching [Wikipedia][2]).
* “paramterize” -> “parameterize”
* “future extension of digest support” -> “extensions”, because folks may be taking advantage of the extended grammar *now*, without waiting for the image-spec to take advantage of the extended grammar.

[1]: https://github.com/opencontainers/image-spec/pull/654#discussion_r114640550
[2]: https://en.wikipedia.org/wiki/Alphanumeric