### PR TITLE
annotations: restrict character set of ref.name values

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -28,7 +28,16 @@ This specification defines the following annotation keys, intended for but not l
 * **org.opencontainers.image.revision** Source control revision identifier for the packaged software.
 * **org.opencontainers.image.vendor** Name of the distributing entity, organization or individual.
 * **org.opencontainers.image.licenses** License(s) under which contained software is distributed as an [SPDX License Expression][spdx-license-expression].
-* **org.opencontainers.image.ref.name** Name of the reference for a target (string). SHOULD only be considered valid when on descriptors on `index.json` within [image layout](image-layout.md).
+* **org.opencontainers.image.ref.name** Name of the reference for a target (string).
+  * SHOULD only be considered valid when on descriptors on `index.json` within [image layout](image-layout.md).
+  * Character set of the value SHOULD conform to alphanum of `A-Za-z0-9` and separator set of `-._:@/+`
+  * An EBNF'esque grammar + regular expression like:
+    ```
+    ref := component ["/" component]*
+    component := alphanum [separator alphanum]*
+    alphanum := /[A-Za-z0-9]+/
+    separator := /[-._:@+]/ | "--"
+    ```
 * **org.opencontainers.image.title** Human-readable title of the image (string)
 * **org.opencontainers.image.description** Human-readable description of the software packaged in the image (string)
 


### PR DESCRIPTION
Started from the URI charset, and ended up with a broader set and pattern from the docker tag. While not strictly the same, it's closer to the ideal set for containerd, flatpak and others.

Fixes #599

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>