### PR TITLE
image-index: remove platform.features field

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -76,7 +76,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     - **`features`** *array of strings*
 
-        This OPTIONAL property specifies an array of strings, each specifying a mandatory CPU feature (for example `sse4` or `aes`).
+        This property is RESERVED for future versions of the specification.
 
 - **`annotations`** *string-string map*
 
@@ -107,10 +107,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {
         "architecture": "amd64",
-        "os": "linux",
-        "os.features": [
-          "sse4"
-        ]
+        "os": "linux"
       }
     }
   ],

--- a/schema/backwards_compatibility_test.go
+++ b/schema/backwards_compatibility_test.go
@@ -49,7 +49,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
 		fail       bool
 	}{
 		{
-			digest: "sha256:d0ed7cfe33821cb6a15624486e650149e92fff3192ff2014bda0c4b0206c1aa2",
+			digest: "sha256:4ffd0883f25635999f04ea543240a27c9a4341979ff7d46a9774f71512eebb1f",
 			imageIndex: `{
    "schemaVersion": 2,
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
@@ -69,10 +69,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
          "digest": "sha256:ae1b0e06e8ade3a11267564a26e750585ba2259c0ecab59ab165ad1af41d1bdd",
          "platform": {
             "architecture": "amd64",
-            "os": "linux",
-            "features": [
-               "sse"
-            ]
+            "os": "linux"
          }
       },
       {

--- a/schema/fs.go
+++ b/schema/fs.go
@@ -223,7 +223,7 @@ b1D07fCyW0vviMlWxN4UcYpZ/Enjdtf+RQ3SGiZ/vj8oANpKu/UTMV9kR1SDMjPzGZ6y5MQwnZvwWfX7
 	"/content-descriptor.json": {
 		local:   "content-descriptor.json",
 		size:    1085,
-		modtime: 1493147571,
+		modtime: 1494380450,
 		compressed: `
 H4sIAAAAAAAA/5yTwW7UMBCG73mKUVqpl27NoeIQVb3AnQPcEAevPY6nbGwznlW1oL47mniXJoAo3Vsy
 +r+Zz8n4RwfQe6yOqQjl1A/QfyiY3uUklhIy6BMmgffHUGb4WNBRIGdn4lpbXFYXcbKKR5EyGPNQc9q0
@@ -238,7 +238,7 @@ ERcrb5b9zhBc4s2zO7r2jN/2xKhin3+/McttXS9NB/Cle+p+BgAA///HjexwPQQAAA==
 	"/defs-descriptor.json": {
 		local:   "defs-descriptor.json",
 		size:    922,
-		modtime: 1493750367,
+		modtime: 1494380450,
 		compressed: `
 H4sIAAAAAAAA/6STX2/TMBTF3/spLl7FgDZN4QFp0Ria2DsP42lTV93ZN/Ed8R/ZrqYy9bsjJ1naFYFA
 PCSyj67Pub8b52kCIBRFGdgndlZUIK6oZst5F8FjSCw3LQZIDr56sl+cTciWAlwNx1yAa0+Sa5bYecx7
@@ -268,21 +268,21 @@ fIvD7in0ryMEy+fK1G6UfmdTE+tvpoL+1wV/AgAA//96IpqyhgYAAA==
 
 	"/image-index-schema.json": {
 		local:   "image-index-schema.json",
-		size:    3151,
-		modtime: 1493147606,
+		size:    3009,
+		modtime: 1495059260,
 		compressed: `
-H4sIAAAAAAAA/7yWP2/bPBDGd3+KgxIgSxK+eBF0MIIs7ZKpQ4MuRQaGPFmXWqR6pJO4hb97QTKyJVF2
-E9XoZh95z/2eE//9mgEUGp1iajxZU8yh+Nyg+WiNl2SQ4baWC4Rbo/EFvjSoqCQl49TzkHvqVIW1DHmV
-981ciEdnzUWKXlpeCM2y9Bf/XYkUO0l5pNsUNxfCNmhUW9LFtDRbUCgvKJRPiX7dYEi1D4+ofIo1bBtk
-T+iKOQRLAEXK/4rskq0Uzt3eVeSgJFxqcMkeOvAVQqwMsTIkMXhKaiAdSANkPC6QI0JUnuBJ9DG3Uq3L
-rEZNhupVXczh/11MvrSxGNqkkaKWhkp03nXtt8qSWa477B7r7rx322mLfXptr91Bj3+11xHGHytiDLW+
-baMBHjXJu5B23g07+jmIaFqg88U2dN8RH1kYmXx/IF8gYS3E2cED2DIuDsYSGY1CDZmlKHLKWIZsjaW7
-0NueXIbdcSI0lmQoVHBiR9JR2OSm38IZJgIZeFh7dJNYRwDJ+A9X++Fe+/8WPMXrxtsFy6YiBapC9d2t
-akgKLW5iPA82wt9Geo9s4OxaLheWyVf1zfw6rEWN+uZset+H62boa8XL4arJXUlYUkIP06FkW8NzRaoC
-H86V5AVquYYHBG2fzdJKjXo6daTay9wspS8t1zn3+zbzVmfAuXcbw4GtHMckq4o8Kr9iHOQBFLbnqbeH
-4eA+zrXz8cnuxUHoTjucZzKLYjBhM2bzmHjWHQfq8im7JY8Bt5U9DmSJMnyHY7dwp3sAs39Zdstm1+ab
-TQJs/mj7STJJkx+uk3p4uIH/2Ops37/+gSaNsT4+N0fO4vd9892xKrqqk0/irshszEv7a9N7lI07mvR2
-HLPxNwYCaMTMT/Ji7J3aeWDOAO5nm9nvAAAA//8Mp+UwTwwAAA==
+H4sIAAAAAAAA/6yWv27bMBDGdz/FQQmQJYmKIuhgBFnaJVOHBl2KDAx5ki61SPVIJ3ELvXtBMrJlUXZt
+1Zt95H33+07892cGkCm0kqlxZHQ2h+xrg/qz0U6QRob7WpQI91rhG3xrUFJBUoSplz733MoKa+HzKuea
+eZ4/W6OvYvTacJkrFoW7+nCTx9hZzCPVpdh5npsGtexK2pAWZ+fky+fky8dEt2rQp5qnZ5Quxho2DbIj
+tNkcvCWALOZ/R7bRVgynbh8qslAQLhTYaA8tuAohVIZQGaIYvEQ1EBaEBtIOS+SAEJQneMq3MddSncuk
+Rk2a6mWdzeHjJibeulgItXEkq4WmAq2zffudsmAWqx67w7o/72g7XbEv7+01G+jxr/Y+wvhrSYy+1o91
+1MOjIvHg0y77YUu/BxFFJVqXrUOPPfGRhZHIbw+kC8SvhTDbewBThMXBWCCjlqggsRREzhkLn62wsFdq
+3ZNrvzvOcoUFafIVbL4h6Sm0qelDOP1EIA1PK4d2EusIIGn36WY33Hv/D8GTvGqcKVk0FUmQFcqfdllD
+VOhwI+Olt+H/NsI5ZA0Xt2JRGiZX1XfzW78WFaq7i+l9H66boa8lL4arJnUlYEER3U+Hgk0NrxXJCpw/
+V6IXqMUKnhCUedULIxSq6dSBaidzsxCuMFyn3Mdt5rXOgHPnNoY9WzmMCZYVOZRuyTjIA8jMlqetPQx7
+93GqnY5Pdp/vhe61wzomXWaDCe2YzVPiGXsaqOuX5JY8Bdxa9jSQBQr/HU7dwo3uHszty7JfNrk2DzYJ
+0P7T9otgEjo9XA/p4d7/7c4jRGhtXHjgjZx+x3V5c5DlfdXJZ19fZDbmpfvVbj2Dxh1Neq2N2fgfAx40
+YKZnZzb2Muw96WYAj7N29jcAAP//8RsPuMELAAA=
 `,
 	},
 

--- a/schema/image-index-schema.json
+++ b/schema/image-index-schema.json
@@ -67,12 +67,7 @@
               },
               "variant": {
                 "type": "string"
-              },
-              "features": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
+              }
               }
             }
           },

--- a/schema/imageindex_test.go
+++ b/schema/imageindex_test.go
@@ -59,11 +59,8 @@ func TestImageIndex(t *testing.T) {
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {
         "architecture": "amd64",
-        "os": "linux",
-        "features": [
-          "sse4"
-        ]
-      }
+        "os": "linux"
+	  }
     }
   ]
 }
@@ -82,10 +79,7 @@ func TestImageIndex(t *testing.T) {
       "size": 7682,
       "platform": {
         "architecture": "amd64",
-        "os": "linux",
-        "features": [
-          "sse4"
-        ]
+        "os": "linux"
       }
     }
   ]
@@ -126,10 +120,7 @@ func TestImageIndex(t *testing.T) {
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {
         "architecture": "amd64",
-        "os": "linux",
-        "features": [
-          "sse4"
-        ]
+        "os": "linux"
       }
     }
   ]
@@ -150,10 +141,7 @@ func TestImageIndex(t *testing.T) {
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {
         "architecture": "amd64",
-        "os": "linux",
-        "features": [
-          "sse4"
-        ]
+        "os": "linux"
       }
     }
   ]
@@ -183,10 +171,7 @@ func TestImageIndex(t *testing.T) {
       "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
       "platform": {
         "architecture": "amd64",
-        "os": "linux",
-        "features": [
-          "sse4"
-        ]
+        "os": "linux"
       }
     }
   ],

--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -61,8 +61,4 @@ type Platform struct {
 	// Variant is an optional field specifying a variant of the CPU, for
 	// example `v7` to specify ARMv7 when architecture is `arm`.
 	Variant string `json:"variant,omitempty"`
-
-	// Features is an optional field specifying an array of strings, each
-	// listing a required CPU feature (for example `sse4` or `aes`).
-	Features []string `json:"features,omitempty"`
 }


### PR DESCRIPTION
While the intended use of the `platform.features` field was to express
the availability of hardware instructions on CPUs, the practicality of
expressing and implementing such a standard has been called into
question. Much of the functionality is usually hidden deep within kernel
code or is defined by hardware vendors in ways that will make the field
unusable without future additions. Applications that can make use of such
field will likely have other requirements on top of this field that are
specific to a deployment.

In that regard, it is best to remove this field and defer to hardware to
make the decision about what can be run.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #622