### PR TITLE
annotations: Use SPDX License Expressions for licenses

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -25,7 +25,7 @@ This specification defines the following annotation keys, intended for but not l
 * **org.opencontainers.image.version** [Semantic versioning-compatible](http://semver.org/) version of the packaged software. The version MAY match a label or tag in the source code repository.
 * **org.opencontainers.image.revision** Source control revision identifier for the packaged software.
 * **org.opencontainers.image.vendor** Name of the distributing entity, organization or individual.
-* **org.opencontainers.image.licenses** Comma-separated list of licenses under which contained software is distributed, in [SPDX Short identifier](https://spdx.org/licenses/) form.
+* **org.opencontainers.image.licenses** License(s) under which contained software is distributed as a [SPDX License Expression][spdx-license-expression].
 * **org.opencontainers.image.ref.name** Name of the reference for a target (string). SHOULD only be considered valid when on descriptors on `index.json` within [image layout](image-layout.md).
 * **org.opencontainers.image.name** Human-readable name of the software packaged in the image (string)
 * **org.opencontainers.image.description** Human-readable description of the software packaged in the image (string)
@@ -52,3 +52,5 @@ While users are encouraged to use the **org.opencontainers.image** keys, tools M
 | `ref.name` | | No equivalent in Label Schema |
 | | `schema-version`| No equivalent in the OCI Image Spec |
 | | `docker.*`, `rkt.*` | No equivalent in the OCI Image Spec |
+
+[spdx-license-expression]: https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60


### PR DESCRIPTION
Instead of comma-separated short identifiers, which have unclear semantics (are the delimiters `AND` or `OR`?).  I don't see any discussion of the syntax for this field in #636 (which landed it), but I'd floaded license expressions before in the sub-thread starting [here][2].  @gregkh had pushed back against my earlier proposal (licensing information on descriptors) [with][3]:

> No, that's not going to work at all, you can't properly describe the license for a whole layer in any form of a string that could be standardized or parsed. SPDX is great for describing the individual licenses of things, but not for a collection of things, which almost always has an arbitrary license (example, what's the license, in a simple string, for a Ubuntu base layer?)

But SPDX License Expressions are both more expressive and better defined than the current comma delimiters.  Everything you could have said with the comma-delimited string you can say more clearly with a SPDX License Expression.  And because the syntax is not OCI-specific, you're more likely to be able to find tooling that handles these values out of the box.

There are other annotation adjustments in flight with #678, but that's not currently touching the `licenses` entry.

[2]: https://github.com/opencontainers/image-spec/pull/501#discussion_r96761939
[3]: https://github.com/opencontainers/image-spec/pull/501#discussion_r97056075