### PR TITLE
schema/config_test.go: add a test for an env var without `=value`

### DIFF
--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -210,6 +210,27 @@ func TestConfig(t *testing.T) {
 `,
 			fail: false,
 		},
+		// expected failure: Env is invalid
+		{
+			config: `
+{
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "Env": [
+            "foo"
+        ]
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
+      ],
+      "type": "layers"
+    }
+}
+`,
+			fail: true,
+		},
 	} {
 		r := strings.NewReader(tt.config)
 		err := schema.ValidatorMediaTypeImageConfig.Validate(r)

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
 
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -138,7 +139,7 @@ func validateDescriptor(r io.Reader) error {
 	}
 
 	err = header.Digest.Validate()
-	if  err == digest.ErrDigestUnsupported {
+	if err == digest.ErrDigestUnsupported {
 		// we ignore unsupported algorithms
 		fmt.Printf("warning: unsupported digest: %q: %v\n", header.Digest, err)
 		return nil
@@ -183,6 +184,13 @@ func validateConfig(r io.Reader) error {
 	}
 
 	checkPlatform(header.OS, header.Architecture)
+
+	envRegexp := regexp.MustCompile(`^[^=]+=.*$`)
+	for _, e := range header.Config.Env {
+		if !envRegexp.MatchString(e) {
+			return errors.Errorf("unexpected env: %q", e)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Related: https://github.com/moby/moby/pull/33557

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>