### PR TITLE
config: relax specification of Config.Volumes

### DIFF
--- a/config.md
+++ b/config.md
@@ -149,8 +149,6 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
    - **Volumes** *object*, OPTIONAL
 
      A set of directories describing where the process is likely write data specific to a container instance.
-     Implementations SHOULD provide mounts for these locations such that application data is not written to the container's root filesystem.
-     If a _new_ image is created from a container based on the image described by this configuration, data in these paths SHOULD NOT be included in the _new_ image.
      **NOTE:** This JSON structure value is unusual because it is a direct JSON serialization of the Go type `map[string]struct{}` and is represented in JSON as an object mapping its keys to an empty object.
 
    - **WorkingDir** *string*, OPTIONAL

--- a/config.md
+++ b/config.md
@@ -148,8 +148,9 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
 
    - **Volumes** *object*, OPTIONAL
 
-     A set of directories which SHOULD be created as data volumes in a container running this image.
-     If a file or folder exists within the image with the same path as a data volume, that file or folder will be replaced by the data volume and never be merged.
+     A set of directories describing where the process is likely write data specific to a container instance.
+     Implementations SHOULD provide mounts for these locations such that application data is not written to the container's root filesystem.
+     If a _new_ image is created from a container based on the image described by this configuration, data in these paths SHOULD NOT be included in the _new_ image.
      **NOTE:** This JSON structure value is unusual because it is a direct JSON serialization of the Go type `map[string]struct{}` and is represented in JSON as an object mapping its keys to an empty object.
 
    - **WorkingDir** *string*, OPTIONAL

--- a/conversion.md
+++ b/conversion.md
@@ -90,7 +90,10 @@ A compliant configuration converter SHOULD provide a way for users to extract th
 
 1. The runtime configuration does not have a corresponding field for this image field.
    However, converters SHOULD set the [`org.opencontainers.image.exposedPorts` annotation](#config.exposedports).
-2. If a converter implements conversion for this field using mountpoints, it SHOULD set the `destination` of the mountpoint to the value specified in `Config.Volumes`.
+2. Implementations SHOULD provide mounts for these locations such that application data is not written to the container's root filesystem.
+   If a converter implements conversion for this field using mountpoints, it SHOULD set the `destination` of the mountpoint to the value specified in `Config.Volumes`.
+   An implementation MAY seed the contents of the mount with data in the image at the same location.
+   If a _new_ image is created from a container based on the image described by this configuration, data in these paths SHOULD NOT be included in the _new_ image.
    The other `mounts` fields are platform and context dependent, and thus are implementation-defined.
    Note that the implementation of `Config.Volumes` need not use mountpoints, as it is effectively a mask of the filesystem.
 

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -37,7 +37,7 @@ type ImageConfig struct {
 	// Cmd defines the default arguments to the entrypoint of the container.
 	Cmd []string `json:"Cmd,omitempty"`
 
-	// Volumes is a set of directories which should be created as data volumes in a container running this image.
+	// Volumes is a set of directories describing where the process is likely write data specific to a container instance.
 	Volumes map[string]struct{} `json:"Volumes,omitempty"`
 
 	// WorkingDir sets the current working directory of the entrypoint process in the container.


### PR DESCRIPTION
Relaxes the specification of `Config.Volumes` by avoiding references to
the concept of "data volumes". Implementors are merely instructed to
provide mounts outside the container's root filesystem.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #687
Supersedes #504

cc @vbatts @cyphar 