### PR TITLE
Makefile: use make builtin rather than shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,13 @@ else
 $(OUTPUT_DIRNAME)/$(DOC_FILENAME).pdf: $(DOC_FILES) $(FIGURE_FILES)
 	@mkdir -p $(OUTPUT_DIRNAME)/ && \
 	$(PANDOC) -f markdown_github -t latex --latex-engine=xelatex -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
-	ls -sh $(shell readlink -f $@)
+	ls -sh $(realpath $@)
 
 $(OUTPUT_DIRNAME)/$(DOC_FILENAME).html: header.html $(DOC_FILES) $(FIGURE_FILES)
 	@mkdir -p $(OUTPUT_DIRNAME)/ && \
 	cp -ap img/ $(shell pwd)/$(OUTPUT_DIRNAME)/&& \
 	$(PANDOC) -f markdown_github -t html5 -H $(PANDOC_SRC)header.html --standalone -o $(PANDOC_DST)$@ $(patsubst %,$(PANDOC_SRC)%,$(DOC_FILES))
-	ls -sh $(shell readlink -f $@)
+	ls -sh $(realpath $@)
 endif
 
 header.html: .tool/genheader.go specs-go/version.go


### PR DESCRIPTION
Since READLINK(1) varies across platforms, namely darwin version does
not have the `-f` flag, then don't rely on the shell. Especially since
gnu make already has this as a builtin function.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>