### PR TITLE
layer: clarify that not all file types need be supported

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -30,7 +30,7 @@ Removals are represented using "[whiteout](#whiteouts)" file entries (See [Repre
 
 ### File Types
 
-Throughout this document section, the use of word "files" or "entries" includes:
+Throughout this document section, the use of word "files" or "entries" includes the following, where supported:
 
 * regular files
 * directories


### PR DESCRIPTION
As I mentioned in #415, some file types (sockets, block devices, character devices, FIFOs) are not currently supported on Windows. This change intends to clarify that not all file types are supported on all platforms without being too prescriptive.