### PR TITLE
*: update runtime-spec links to v1.0.0

### DIFF
--- a/conversion.md
+++ b/conversion.md
@@ -19,8 +19,8 @@ Externally provided inputs are considered to be a modification of the `applicati
 For example, externally provided inputs MAY cause an environment variable to be added, removed or changed.
 However an implementation-defined default SHOULD NOT result in an environment variable being removed or changed.
 
-[oci-runtime-bundle]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/bundle.md
-[oci-runtime-config]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc5/config.md
+[oci-runtime-bundle]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/bundle.md
+[oci-runtime-config]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/config.md
 
 ## Verbatim Fields
 

--- a/image-layout.md
+++ b/image-layout.md
@@ -3,11 +3,11 @@
 * The OCI Image Layout is a slash separated layout of OCI content-addressable blobs and [location-addressable](https://en.wikipedia.org/wiki/Content-addressable_storage#Content-addressed_vs._location-addressed) references (refs).
 * This layout MAY be used in a variety of different transport mechanisms: archive formats (e.g. tar, zip), shared filesystem environments (e.g. nfs), or networked file fetching (e.g. http, ftp, rsync).
 
-Given an image layout and a ref, a tool can create an [OCI Runtime Specification bundle](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/bundle.md) by:
+Given an image layout and a ref, a tool can create an [OCI Runtime Specification bundle](https://github.com/opencontainers/runtime-spec/blob/v1.0.0/bundle.md) by:
 
 * Following the ref to find a [manifest](manifest.md#image-manifest), possibly via an [image index](image-index.md)
 * [Applying the filesystem layers](layer.md#applying) in the specified order
-* Converting the [image configuration](config.md) into an [OCI Runtime Specification `config.json`](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc3/config.md)
+* Converting the [image configuration](config.md) into an [OCI Runtime Specification `config.json`](https://github.com/opencontainers/runtime-spec/blob/v1.0.0/config.md)
 
 # Content
 


### PR DESCRIPTION
Despite this not being a valid link, until the runtime spec has its
v1.0.0 release, these URLs need to be accurate for once the this spec is
tagged v1.0.0

Part of #615 

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>