### PR TITLE
conversion: add platform conversions

### DIFF
--- a/conversion.md
+++ b/conversion.md
@@ -44,15 +44,19 @@ These fields all affect the `annotations` of the runtime configuration, and are 
 
 | Image Field         | Runtime Field   | Notes |
 | ------------------- | --------------- | ----- |
-| `author`            | `annotations`   | 1,2   |
-| `created`           | `annotations`   | 1,3   |
+| `os`                | `annotations`   | 1,2   |
+| `architecture`      | `annotations`   | 1,3   |
+| `author`            | `annotations`   | 1,4   |
+| `created`           | `annotations`   | 1,5   |
 | `Config.Labels`     | `annotations`   |       |
-| `Config.StopSignal` | `annotations`   | 1,4   |
+| `Config.StopSignal` | `annotations`   | 1,6   |
 
 1. If a user has explicitly specified this annotation with `Config.Labels`, then the value specified in this field takes lower [precedence](#annotations) and the converter MUST instead use the value from `Config.Labels`.
-2. The value of this field MUST be set as the value of `org.opencontainers.image.author` in `annotations`.
-3. The value of this field MUST be set as the value of `org.opencontainers.image.created` in `annotations`.
-4. The value of this field MUST be set as the value of `org.opencontainers.image.stopSignal` in `annotations`.
+2. The value of this field MUST be set as the value of `org.opencontainers.image.os` in `annotations`.
+3. The value of this field MUST be set as the value of `org.opencontainers.image.architecture` in `annotations`.
+4. The value of this field MUST be set as the value of `org.opencontainers.image.author` in `annotations`.
+5. The value of this field MUST be set as the value of `org.opencontainers.image.created` in `annotations`.
+6. The value of this field MUST be set as the value of `org.opencontainers.image.stopSignal` in `annotations`.
 
 ## Parsed Fields
 


### PR DESCRIPTION
In b6d5a8cc1562 ("Change platform ref from runtime-spec"), the
conversion to runtime-spec for the "os" and "architecture" fields was
removed (as the fields had also been removed in runtime-spec). Re-add
the conversion as an annotation field rather than a verbatim field.

[Obviously this can't go into `1.0.0` due to the time window, but we can put it in `1.0.1`].

Signed-off-by: Aleksa Sarai <asarai@suse.de>