### PR TITLE
Add audit interface for validation API

### DIFF
--- a/schema/backwards_compatibility_test.go
+++ b/schema/backwards_compatibility_test.go
@@ -113,7 +113,7 @@ func TestBackwardsCompatibilityImageIndex(t *testing.T) {
 
 		imageIndex := convertFormats(tt.imageIndex)
 		r := strings.NewReader(imageIndex)
-		err := schema.ValidatorMediaTypeImageIndex.Validate(r)
+		err := schema.ValidatorMediaTypeImageIndex.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
@@ -175,7 +175,7 @@ func TestBackwardsCompatibilityManifest(t *testing.T) {
 
 		manifest := convertFormats(tt.manifest)
 		r := strings.NewReader(manifest)
-		err := schema.ValidatorMediaTypeManifest.Validate(r)
+		err := schema.ValidatorMediaTypeManifest.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)
@@ -214,7 +214,7 @@ func TestBackwardsCompatibilityConfig(t *testing.T) {
 
 		config := convertFormats(tt.config)
 		r := strings.NewReader(config)
-		err := schema.ValidatorMediaTypeImageConfig.Validate(r)
+		err := schema.ValidatorMediaTypeImageConfig.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/config_test.go
+++ b/schema/config_test.go
@@ -233,7 +233,7 @@ func TestConfig(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.config)
-		err := schema.ValidatorMediaTypeImageConfig.Validate(r)
+		err := schema.ValidatorMediaTypeImageConfig.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/descriptor_test.go
+++ b/schema/descriptor_test.go
@@ -294,7 +294,7 @@ func TestDescriptor(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.descriptor)
-		err := schema.ValidatorMediaTypeDescriptor.Validate(r)
+		err := schema.ValidatorMediaTypeDescriptor.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/imageindex_test.go
+++ b/schema/imageindex_test.go
@@ -223,7 +223,7 @@ func TestImageIndex(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.imageIndex)
-		err := schema.ValidatorMediaTypeImageIndex.Validate(r)
+		err := schema.ValidatorMediaTypeImageIndex.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/imagelayout_test.go
+++ b/schema/imagelayout_test.go
@@ -47,7 +47,7 @@ func TestImageLayout(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.imageLayout)
-		err := schema.ValidatorMediaTypeLayoutHeader.Validate(r)
+		err := schema.ValidatorMediaTypeLayoutHeader.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -230,7 +230,7 @@ func TestManifest(t *testing.T) {
 		},
 	} {
 		r := strings.NewReader(tt.manifest)
-		err := schema.ValidatorMediaTypeManifest.Validate(r)
+		err := schema.ValidatorMediaTypeManifest.Validate(r, nil)
 
 		if got := err != nil; tt.fail != got {
 			t.Errorf("test %d: expected validation failure %t but got %t, err %v", i, tt.fail, got, err)

--- a/schema/spec_test.go
+++ b/schema/spec_test.go
@@ -77,7 +77,7 @@ func validate(t *testing.T, name string) {
 			continue
 		}
 
-		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body))
+		err = schema.Validator(example.Mediatype).Validate(strings.NewReader(example.Body), nil)
 		if err == nil {
 			printFields(t, "ok", example.Mediatype, example.Title)
 			t.Log(example.Body, "---")


### PR DESCRIPTION
Fix #686.

Each content validation function should return both hard error and
warned errors, like:
```go
func validateDescriptor(r io.Reader) ([]error, error)
```

Add a `ValidationAudit` interface on Validate API argument. This
interface allows consumer to implement `Warns` method, to decide how to
handle warned errors. like:
```go
func (v Validator) Validate(src io.Reader, audit ValidationAudit) error
```

Signed-off-by: xiekeyang <xiekeyang@huawei.com>

ping @stevvooe @vbatts If it is on the right way?