### PR TITLE
image-layout: make index.json OPTIONAL

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -139,7 +139,7 @@ This section defines the `application/vnd.oci.layout.header.v1+json` [media type
 
 ## index.json file
 
-This REQUIRED file is the entry point for references and descriptors of the image-layout.
+This OPTIONAL file is the entry point for references and descriptors of the image-layout.
 The [image index](image-index.md) is a multi-descriptor entry point.
 
 This index provides an established path (`/index.json`) to have an entry point for an image-layout and to discover auxiliary descriptors.


### PR DESCRIPTION
The index.json is OPTIONAL, according to the description in
image-index.md and media-types.dot.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>


discussed in https://github.com/opencontainers/image-spec/pull/716
