### PR TITLE
image-layout: Replace "slash separated layout" with "directory structure"

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -1,6 +1,6 @@
 ## OCI Image Layout Specification
 
-* The OCI Image Layout is a slash separated layout of OCI content-addressable blobs and [location-addressable](https://en.wikipedia.org/wiki/Content-addressable_storage#Content-addressed_vs._location-addressed) references (refs).
+* The OCI Image Layout is directory structure for OCI content-addressable blobs and [location-addressable](https://en.wikipedia.org/wiki/Content-addressable_storage#Content-addressed_vs._location-addressed) references (refs).
 * This layout MAY be used in a variety of different transport mechanisms: archive formats (e.g. tar, zip), shared filesystem environments (e.g. nfs), or networked file fetching (e.g. http, ftp, rsync).
 
 Given an image layout and a ref, a tool can create an [OCI Runtime Specification bundle](https://github.com/opencontainers/runtime-spec/blob/v1.0.0/bundle.md) by:


### PR DESCRIPTION
Adjusting wording we've been carrying since #605.

On Windows, an unpacked layout will use backslashes.  Layouts really don't care what the directory separator is, and each access method (filesytem access, tar unpacker, etc.) already has an unambiguous separator character.

This is a very minor nit, but seems easy enough to clean up.