### PR TITLE
travis: use Go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.7
+  - 1.9.x
 
 sudo: required
 


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Locally this fixes lint failure (#735), but not sure why (sorry cargo-cult)
