### PR TITLE
Fix table header grammar in annotations

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -47,7 +47,7 @@ This specification defines the following annotation keys, intended for but not l
 
 While users are encouraged to use the **org.opencontainers.image** keys, tools MAY choose to support compatible annotations using the **org.label-schema** prefix as follows.
 
-| `org.opencontainers.image` prefix | `org.label-schema prefix` | Compatibility notes |
+| `org.opencontainers.image` prefix | `org.label-schema` prefix | Compatibility notes |
 |---------------------------|-------------------------|---------------------|
 | `created` | `build-date` | Compatible |
 | `url` | `url` | Compatible |


### PR DESCRIPTION
Move "prefix" to out of the code backtick.