### PR TITLE
Unspecified descriptor mediatypes MUST be ignored

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -4,6 +4,7 @@ The image index is a higher-level manifest which points to specific [image manif
 While the use of an image index is OPTIONAL for image providers, image consumers SHOULD be prepared to process them.
 
 This section defines the `application/vnd.oci.image.index.v1+json` [media type](media-types.md).
+
 For the media type(s) that this document is compatible with, see the [matrix][matrix].
 
 ## *Image Index* Property Descriptions
@@ -40,7 +41,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     Image indexes concerned with portability SHOULD use one of the above media types.
     Future versions of the spec MAY use a different mediatype (i.e. a new versioned format).
-    An encountered `mediaType` that is unknown SHOULD be safely ignored.
+    An encountered `mediaType` that is unknown to the implementation MUST be ignored.
 
   - **`platform`** *object*
 

--- a/manifest.md
+++ b/manifest.md
@@ -60,6 +60,8 @@ Unlike the [image index](image-index.md), which contains information about a set
         - [`application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`](layer.md#gzip-media-types)
 
         Manifests concerned with portability SHOULD use one of the above media types.
+        An encountered `mediaType` that is unknown to the implementation MUST be ignored.
+
 
         Entries in this field will frequently use the `+gzip` types.
 


### PR DESCRIPTION
As per out discussions on the dev mailing list, this is the first step towards ensuring that storage and distribution of non-specified content can be experimented with while maintaining a standards-compliant registry.

cc @stevvooe 