### PR TITLE
Add platform.Feature

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -87,7 +87,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     - **`features`** *array of strings*
 
-        This OPTIONAL property specifies an array of strings, each specifying a mandatory hardware/host feature. Examples are:
+        This OPTIONAL property specifies an array of strings, each specifying an optional hardware/host feature. Examples are:
          - CPU type (*haswell*, *broadwell*, *skylake*, *ryzen*)
          - GPU [NVIDIA Compute Capability](https://developer.nvidia.com/cuda-gpus) (3.7, 6.1)
          - Host name, to separate different types in a data center without flushing out all the specifics (*compute-20190213*, *storage-2019*)

--- a/image-index.md
+++ b/image-index.md
@@ -90,7 +90,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
         This OPTIONAL property specifies an array of strings, each specifying a mandatory hardware/host feature. Examples are:
          - CPU type (*haswell*, *broadwell*, *skylake*, *ryzen*)
          - GPU [NVIDIA Compute Capability](https://developer.nvidia.com/cuda-gpus) (3.7, 6.1)
-         - Host name, to separate different types in a data center without flushing out all the specifics (*ComputeNode-20190213*, *storage-2019*)
+         - Host name, to separate different types in a data center without flushing out all the specifics (*compute-20190213*, *storage-2019*)
         By using this feature flag, an image index is able to provide specific images for certain hosts.
 
 - **`annotations`** *string-string map*

--- a/image-index.md
+++ b/image-index.md
@@ -87,7 +87,11 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     - **`features`** *array of strings*
 
-        This property is RESERVED for future versions of the specification.
+        This OPTIONAL property specifies an array of strings, each specifying a mandatory hardware/host feature. Examples are:
+         - CPU type (*haswell*, *broadwell*, *skylake*, *ryzen*)
+         - GPU [NVIDIA Compute Capability](https://developer.nvidia.com/cuda-gpus) (3.7, 6.1)
+         - Host name, to separate different types in a data center without flushing out all the specifics (*ComputeNode-20190213*, *storage-2019*)
+        By using this feature flag, a manifest list is able to provide specific images for certain hosts.
 
 - **`annotations`** *string-string map*
 

--- a/image-index.md
+++ b/image-index.md
@@ -91,7 +91,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
          - CPU type (*haswell*, *broadwell*, *skylake*, *ryzen*)
          - GPU [NVIDIA Compute Capability](https://developer.nvidia.com/cuda-gpus) (3.7, 6.1)
          - Host name, to separate different types in a data center without flushing out all the specifics (*ComputeNode-20190213*, *storage-2019*)
-        By using this feature flag, a manifest list is able to provide specific images for certain hosts.
+        By using this feature flag, an image index is able to provide specific images for certain hosts.
 
 - **`annotations`** *string-string map*
 

--- a/schema/image-index-schema.json
+++ b/schema/image-index-schema.json
@@ -67,6 +67,12 @@
               },
               "variant": {
                 "type": "string"
+              },
+              "features": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             }
           },

--- a/specs-go/v1/descriptor.go
+++ b/specs-go/v1/descriptor.go
@@ -61,4 +61,8 @@ type Platform struct {
 	// Variant is an optional field specifying a variant of the CPU, for
 	// example `v7` to specify ARMv7 when architecture is `arm`.
 	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings,
+	// each listing a required general feature (CPU feature like `avx512` or CUDA driver version).
+	Features []string `json:"features,omitempty"`
 }

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -20,9 +20,9 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 1
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 0
+	VersionMinor = 1
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = "-dev"


### PR DESCRIPTION
As discussed on the [mailing list](https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/PCvWK6rEcqE) a PR to bring platform.features back into the image spec.
Motivation stated in https://github.com/moby/moby/issues/38715
Blog post providing context:
- [Optimized Container Images for AI/ML and HPC]()http://qnib.org/2019/02/12/optimized-images-for-aiml-hpc/
- [Match Node-Specific Needs Using Manifest Lists](http://qnib.org/2019/02/14/manifest-list-to-pick-optimized-images/)

Not sure about the version bump tho - please advise how to handle that one.