### PR TITLE
Proposal to add Encrypted Layer Mediatype

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -49,6 +49,10 @@ This specification defines the following annotation keys, intended for but not l
   * This SHOULD be the immediate image sharing zero-indexed layers with the image, such as from a Dockerfile `FROM` statement.
   * This SHOULD NOT reference any other images used to generate the contents of the image (e.g., multi-stage Dockerfile builds).
   * If the `image.base.name` annotation is specified, the `image.base.digest` annotation SHOULD be the digest of the manifest referenced by the `image.ref.name` annotation.
+* **org.opencontainers.image.org.opencontainers.image.enc.keys.pkcs7** Base64 comma separated [PKCS7(RFC2315)](https://tools.ietf.org/html/rfc2315) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
+* **org.opencontainers.image.org.opencontainers.image.enc.keys.jwe** Base64 comma separated [JWE(RFC7516)](https://tools.ietf.org/html/rfc7516) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
+* **org.opencontainers.image.org.opencontainers.image.enc.keys.openpgp** Base64 comma separated [OpenPGP(RFC4880)](https://tools.ietf.org/html/rfc4880) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
+* **org.opencontainers.image.org.opencontainers.image.enc.pubopts** Base64 encoded PublicLayerBlockCipherOptions JSON object for [encryption](layer.md#layer-encryption)
 
 ## Back-compatibility with Label Schema
 

--- a/annotations.md
+++ b/annotations.md
@@ -50,9 +50,9 @@ This specification defines the following annotation keys, intended for but not l
   * This SHOULD NOT reference any other images used to generate the contents of the image (e.g., multi-stage Dockerfile builds).
   * If the `image.base.name` annotation is specified, the `image.base.digest` annotation SHOULD be the digest of the manifest referenced by the `image.ref.name` annotation.
 * **org.opencontainers.image.org.opencontainers.image.enc.keys.pkcs7** Base64 comma separated [PKCS7(RFC2315)](https://tools.ietf.org/html/rfc2315) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
-* **org.opencontainers.image.org.opencontainers.image.enc.keys.jwe** Base64 comma separated [JWE(RFC7516)](https://tools.ietf.org/html/rfc7516) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
-* **org.opencontainers.image.org.opencontainers.image.enc.keys.openpgp** Base64 comma separated [OpenPGP(RFC4880)](https://tools.ietf.org/html/rfc4880) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
-* **org.opencontainers.image.org.opencontainers.image.enc.pubopts** Base64 encoded PublicLayerBlockCipherOptions JSON object for [encryption](layer.md#layer-encryption)
+* **org.opencontainers.image.enc.keys.jwe** Base64 comma separated [JWE(RFC7516)](https://tools.ietf.org/html/rfc7516) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
+* **org.opencontainers.image.enc.keys.openpgp** Base64 comma separated [OpenPGP(RFC4880)](https://tools.ietf.org/html/rfc4880) encrypted messages that contain wrapped PrivateLayerBlockCipherOptions JSON objects for [encryption](layer.md#layer-encryption)
+* **org.opencontainers.image.enc.pubopts** Base64 encoded PublicLayerBlockCipherOptions JSON object for [encryption](layer.md#layer-encryption)
 
 ## Back-compatibility with Label Schema
 

--- a/layer.md
+++ b/layer.md
@@ -4,7 +4,7 @@ This document describes how to serialize a filesystem and filesystem changes lik
 One or more layers are applied on top of each other to create a complete filesystem.
 This document will use a concrete example to illustrate how to create and consume these filesystem layers.
 
-This section defines the `application/vnd.oci.image.layer.v1.tar`, `application/vnd.oci.image.layer.v1.tar+gzip`, `application/vnd.oci.image.layer.v1.tar+zstd`, `application/vnd.oci.image.layer.nondistributable.v1.tar`, `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`, and `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd` [media types](media-types.md).
+This section defines the `application/vnd.oci.image.layer.v1.tar`, `application/vnd.oci.image.layer.v1.tar+gzip`, `application/vnd.oci.image.layer.v1.tar+zstd`, `application/vnd.oci.image.layer.nondistributable.v1.tar`, `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`, `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd`, `application/vnd.oci.image.layer.v1.tar+encrypted`, `application/vnd.oci.image.layer.v1.tar+gzip+encrypted`, `application/vnd.oci.image.layer.nondistributable.v1.tar+encrypted` and `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+encrypted` [media types](media-types.md).
 
 ## `+gzip` Media Types
 
@@ -15,6 +15,13 @@ This section defines the `application/vnd.oci.image.layer.v1.tar`, `application/
 
 * The media type `application/vnd.oci.image.layer.v1.tar+zstd` represents an `application/vnd.oci.image.layer.v1.tar` payload which has been compressed with [zstd][rfc8478].
 * The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload which has been compressed with [zstd][rfc8478].
+
+## `+encrypted` Media Types
+
+* The media type `application/vnd.oci.image.layer.v1.tar+encrypted` represents an `application/vnd.oci.image.layer.v1.tar` payload which has been [encrypted](#layer-encryption).
+* The media type `application/vnd.oci.image.layer.v1.tar+gzip+encrypted` represents an `application/vnd.oci.image.layer.v1.tar+gzip` payload which has been [encrypted](#layer-encryption).
+* The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+encrypted` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload which has been [encrypted](#layer-encryption).
+* The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+encrypted` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip` payload which has been [encrypted](#layer-encryption).
 
 ## Distributable Format
 
@@ -331,6 +338,96 @@ Non-distributable layers SHOULD be tagged with an alternative mediatype of `appl
 Implementations SHOULD NOT upload layers tagged with this media type; however, such a media type SHOULD NOT affect whether an implementation downloads the layer.
 
 [Descriptors](descriptor.md) referencing non-distributable layers MAY include `urls` for downloading these layers directly; however, the presence of the `urls` field SHOULD NOT be used to determine whether or not a layer is non-distributable.
+
+
+# Layer Encryption
+
+To be able to protect the confidentiality of the data in layers, encryption of the layer data blobs can be done to prevent unauthorized access to layer data. Encryption is performed on the data blob of a layer by specifying a mediatype with the `+encrypted` suffix. For example, `application/vnd.oci.image.layer.v1.tar+encrypted` is an layer representation of an encrypted `application/vnd.oci.image.layer.v1.tar` layer. 
+
+When using the `+encrypted` mediatype, the layer data blobs are encrypted. In order to decrypt an image, the encryption metadata is required. 
+
+## Encryption Metadata
+
+The encryption metadata consists of 2 parts: PublicLayerBlockCipherOptions and PrivateLayerBlockCipherOptions. The PublicLayerBlockCipherOptions contain encryption metadata that is public, i.e. cipher type, HMAC, etc. and PrivateLayerBlockCipherOptions contains the encryption metadata which should be confidential, i.e. symmetric key, nonce (optional), etc. These are stored in the respective [**org.opencontainers.image.enc** prefixed annotations](annotations.md).
+
+Below are golang definitions of these JSON objects:
+
+```
+// LayerCipherType is the ciphertype as specified in the layer metadata
+type LayerCipherType string
+
+// PublicLayerBlockCipherOptions includes the information required to encrypt/decrypt
+// an image which are public and can be deduplicated in plaintext across multiple
+// recipients
+type PublicLayerBlockCipherOptions struct {
+    // CipherType denotes the cipher type according to the list of OCI suppported
+    // cipher types.
+    CipherType LayerCipherType `json:"cipher"`
+
+    // Hmac contains the hmac string to help verify encryption
+    Hmac []byte `json:"hmac"`
+
+    // CipherOptions contains the cipher metadata used for encryption/decryption
+    // This field should be populated by Encrypt/Decrypt calls
+    CipherOptions map[string][]byte `json:"cipheroptions"`
+}
+
+// PrivateLayerBlockCipherOptions includes the information required to encrypt/decrypt
+// an image which are sensitive and should not be in plaintext
+type PrivateLayerBlockCipherOptions struct {
+	// SymmetricKey represents the symmetric key used for encryption/decryption
+	// This field should be populated by Encrypt/Decrypt calls
+	SymmetricKey []byte `json:"symkey"`
+
+	// Digest is the digest of the original data for verification.
+	// This is NOT populated by Encrypt/Decrypt calls
+	Digest digest.Digest `json:"digest"`
+
+	// CipherOptions contains the cipher metadata used for encryption/decryption
+	// This field should be populated by Encrypt/Decrypt calls
+	CipherOptions map[string][]byte `json:"cipheroptions"`
+}
+```
+
+Details of the algorithms and protocols used in the encryption of the data blob are defined in these JSON objects. Here are some examples of the Public/Private LayerBlockCipherOptions.
+- The `cipher` field specifies the encryption algorithm to use according to the [list of cipher types supported](#cipher-types).
+- The `symkey` field specifies the base64 encoded bytes of the symmetric key used in decryption.
+- The `cipherOptions` field specifies additional parameters used in the decryption process of the specified algorithm. This should be in accordance with the RFC standard of the algorithm used.
+```
+PublicLayerBlockCipherOption
+{
+    "cipher": "AES_256_CTR_HMAC_SHA256",
+    "hmac": "M0M5OTA5QUZFQzI1MzU0RDU1MURBRTIxNTkwQkIyNkUzOEQ1M0YyMTczQjhEM0RDM0VFRTRDMDQ3RTdBQjFDMQ=="
+    "cipheroptions": {}
+}
+
+PrivateLayerBlockCipherOption
+{
+    "symkey": "54kiln1USEaKnlYhKdz+aA==",
+    "cipheroptions": {
+        "nonce": "AdcRPTAEhXx6uwuYcOquNA==",
+        ...
+    }
+}
+
+```
+
+The PublicLayerBlockCipherOptions JSON object is stored base64 encoded in the layer annotation **org.opencontainers.image.enc.pubopts**. 
+
+The PrivateLayerBlockCipherOptions JSON object is not stored in plaintext due to the sensitive nature of the contents. Instead, the object goes through a cryptographic wrapping process. This ensures that only authorized parties are able to decrypt the layers, the decryption metadata objects are wrapped as encrypted messages to the authorized recipients in accordance with encrypted message standards such as [OpenPGP(RFC4880)](https://tools.ietf.org/html/rfc4880), [PKCS7(RFC2315)](https://tools.ietf.org/html/rfc2315), [JWE(RFC7516)](https://tools.ietf.org/html/rfc7516). 
+
+The following annotations are used to communicate these encrypted messages:
+- `org.opencontainers.image.enc.keys.pkcs7` - An array of base64 comma separated encrypted messages that contain PrivateLayerBlockCipherOptions to perform decryption of the layer data in accordance with [PKCS7(RFC2315)](https://tools.ietf.org/html/rfc2315)
+- `org.opencontainers.image.enc.keys.jwe` - An array of base64 comma separated encrypted messages that contain PrivateLayerBlockCipherOptions to perform decryption of the layer data in accordance with [JWE(RFC7516)](https://tools.ietf.org/html/rfc7516)
+- `org.opencontainers.image.enc.keys.openpgp` - An array of base64 comma separated encrypted messages that contain PrivateLayerBlockCipherOptions to perform decryption of the layer data in accordance with [OpenPGP(RFC4880)](https://tools.ietf.org/html/rfc4880)
+- `org.opencontainers.image.enc.keys.*` - An array of base64 comma separated encrypted messages that contain PrivateLayerBlockCipherOptions to perform decryption of the layer data in accordance with an appropriate standard of specified protocol.
+
+The decryption of the image can be performed by unwrapping the PrivateLayerBlockCipherOptions using the `org.opencontainers.image.enc.keys.*` annotations and using the appropriate cipher with the unwrapped PrivateLayerBlockCipherOptions to decrypt the layer data blob.
+
+### Cipher Types
+
+The current list of cipher types supported are:
+- `AES_256_CTR_HMAC_SHA256` - Encryption with `AES_256_CTR` algorithm [FIPS-197](https://csrc.nist.gov/csrc/media/publications/fips/197/final/documents/fips-197.pdf)  with Encrypt-then-mac [RFC7366](https://tools.ietf.org/html/rfc7366). The protocols used in this cipher type is in accordance to FIPS 140-2 compliant standards. 
 
 [libarchive-tar]: https://github.com/libarchive/libarchive/wiki/ManPageTar5#POSIX_ustar_Archives
 [gnu-tar-standard]: http://www.gnu.org/software/tar/manual/html_node/Standard.html

--- a/layer.md
+++ b/layer.md
@@ -352,7 +352,7 @@ The encryption metadata consists of 2 parts: PublicLayerBlockCipherOptions and P
 
 Below are golang definitions of these JSON objects:
 
-```
+```go
 // LayerCipherType is the ciphertype as specified in the layer metadata
 type LayerCipherType string
 

--- a/media-types.md
+++ b/media-types.md
@@ -13,6 +13,10 @@ The following media types identify the formats described here and their referenc
 - `application/vnd.oci.image.layer.nondistributable.v1.tar`: ["Layer", as a tar archive with distribution restrictions](layer.md#non-distributable-layers)
 - `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`: ["Layer", as a tar archive with distribution restrictions](layer.md#gzip-media-types) compressed with [gzip][rfc1952]
 - `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd`: ["Layer", as a tar archive with distribution restrictions](layer.md#zstd-media-types) compressed with [zstd][rfc8478]
+- `application/vnd.oci.image.layer.v1.tar+encrypted` : ["Layer", as an encrypted tar archive](layer.md#enc-media-types)
+- `application/vnd.oci.image.layer.v1.tar+gzip+encrypted` : ["Layer", as an encrypted gzipped tar archive](layer.md#enc-media-types)
+- `application/vnd.oci.image.layer.nondistributable.v1.tar+encrypted` : ["Layer", as an encrypted tar archive with distribution restrictions](layer.md#enc-media-types)
+- `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+encrypted` : ["Layer", as an encrypted gzipped tar archive with distribution restrictions](layer.md#enc-media-types)
 
 ## Media Type Conflicts
 

--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -59,4 +59,16 @@ const (
 
 	// AnnotationBaseImageName is the annotation key for the image reference of the image's base image.
 	AnnotationBaseImageName = "org.opencontainers.image.base.name"
+
+	// AnnotationEncryptionKeysPkcs7 is the annotation key for the base64 encoded encrypted
+	// messages containing metadata for decrypting encrypted data blobs.
+	AnnotationEncryptionKeysPkcs7 = "org.opencontainers.image.enc.keys.pkcs7"
+
+	// AnnotationEncryptionKeysJwe is the annotation key for the base64 encoded encrypted
+	// messages containing metadata for decrypting encrypted data blobs.
+	AnnotationEncryptionKeysJwe = "org.opencontainers.image.enc.keys.jwe"
+
+	// AnnotationEncryptionKeysOpenPgp is the annotation key for the base64 encoded encrypted
+	// messages containing metadata for decrypting encrypted data blobs.
+	AnnotationEncryptionKeysOpenPgp = "org.opencontainers.image.enc.keys.openpgp"
 )

--- a/specs-go/v1/encryption.go
+++ b/specs-go/v1/encryption.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+// LayerBlockCipherOptions includes the information required to encrypt/decrypt
+// layer blob data.
+type LayerBlockCipherOptions struct {
+	CipherType    string            `json:'cipher'`
+	SymmetricKey  []byte            `json:'symkey'`
+	CipherOptions map[string][]byte `json:'cipheroptions'`
+}

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -30,6 +30,10 @@ const (
 	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
 	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar"
 
+	// MediaTypeImageLayerEnc is the media type used for encrypted layers
+	// referenced by the manifest.
+	MediaTypeImageLayerEnc = "application/vnd.oci.image.layer.v1.tar+encrypted"
+
 	// MediaTypeImageLayerGzip is the media type used for gzipped layers
 	// referenced by the manifest.
 	MediaTypeImageLayerGzip = "application/vnd.oci.image.layer.v1.tar+gzip"
@@ -37,6 +41,10 @@ const (
 	// MediaTypeImageLayerZstd is the media type used for zstd compressed
 	// layers referenced by the manifest.
 	MediaTypeImageLayerZstd = "application/vnd.oci.image.layer.v1.tar+zstd"
+
+	// MediaTypeImageLayerGzipEnc is the media type used for encrypted
+	// gzipped layers referenced by the manifest.
+	MediaTypeImageLayerGzipEnc = "application/vnd.oci.image.layer.v1.tar+gzip+encrypted"
 
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
@@ -51,6 +59,15 @@ const (
 	// compressed layers referenced by the manifest but with distribution
 	// restrictions.
 	MediaTypeImageLayerNonDistributableZstd = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
+
+	// MediaTypeImageLayerNonDistributableEnc is the media type for encrypted
+	// layers referenced by the manifest but with distribution restrictions.
+	MediaTypeImageLayerNonDistributableEnc = "application/vnd.oci.image.layer.nondistributable.v1.tar+encrypted"
+
+	// MediaTypeImageLayerNonDistributableGzipEnc is the media type for
+	// gzipped and encrypted layers referenced by the manifest but with
+	// distribution restrictions.
+	MediaTypeImageLayerNonDistributableGzipEnc = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip+encrypted"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"


### PR DESCRIPTION
This is a first draft of modifications to the OCI spec on Encrypted Container Images. Work around this has been on-going for quite a while (since the start of [the issue](https://github.com/opencontainers/image-spec/issues/747)). The current design is based on the discussions we've had in [the issue](https://github.com/opencontainers/image-spec/issues/747) and with the [runtime implementation in containerd](https://github.com/containerd/containerd/pull/3134).

## Abstract

We would like to propose a new media type for encrypted layers of a container image. This addition would facilitate the ecosystem for encrypted container images. This allows users with stricter trust requirements to be able ensure end-to-end encryption from build to runtime. In addition, it allows users to use a centralized managed repository (i.e. Docker Hub) without any risk of their images being compromised. 

## Issue Details
Based on the discussion of https://github.com/opencontainers/image-spec/issues/747


## Implementations


## The specification and libraries to perform encryption/decryption

The implementation to perform encryption and decryption of this spec is in:
- https://github.com/containers/ocicrypt
  - `func EncryptLayer(ec *config.EncryptConfig, encOrPlainLayerReader io.Reader, desc ocispec.Descriptor) (io.Reader, EncryptLayerFinalizer, error)`
  - `func DecryptLayer(dc *config.DecryptConfig, encLayerReader io.Reader, desc ocispec.Descriptor, unwrapOnly bool) (io.Reader, digest.Digest, error)`

### Container Runtimes

Implemented and upstreamed for containerd stack
- [containerd (1.3+)](https://github.com/containerd/containerd/blob/master/docs/cri/decryption.md)
- https://github.com/containerd/imgcrypt

Implemented and upstreamed for RedHat stack
- [cri-o 1.17+](https://github.com/cri-o/cri-o/blob/master/tutorials/decryption.md)
- [buildah 1.5+](https://github.com/containers/buildah)
- [skopeo](https://github.com/containers/skopeo)

### Registry

Current docker distribution supports: https://github.com/docker/distribution. Tested with v2.7.1.

### Build toolchain

The plan for this is to have docker CLI, skopeo and buildah. In the meantime, we also support encryption of images in containerd via `imgcrypt` ctr client.

Current implementations for RedHat stack
- [buildah 1.5+](https://github.com/containers/buildah)
- [skopeo](https://github.com/containers/skopeo)

Current implementations for containerd stack
- [ctr-enc](https://github.com/containerd/imgcrypt)
- To integrate into docker CLI, we are currently waiting on https://github.com/moby/moby/issues/38043. Tracking with https://github.com/moby/buildkit/issues/714

### Kubernetes Integration

It is important to note that kubernetes integration is not required to use encrypted container images. i.e. in cri-o you are able to specify a directory containing keys.

A way to do this is via an operator [k8s-enc-image-operator](https://github.com/IBM/k8s-enc-image-operator)


Signed-off-by: Brandon Lum <lumjjb@gmail.com>