### PR TITLE
Reference "org" repo for meeting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ When in doubt, start on the [mailing-list](#mailing-list).
 
 ## Meetings
 
-Please see the [OCI org repository README](https://github.com/opencontainers/org#meetings) for the most up-to-date
-information on OCI contributor and maintainer meeting schedules. You can also find links to meeting agendas and
-minutes for all prior meetings.
+Please see the [OCI org repository README](https://github.com/opencontainers/org#meetings) for the most up-to-date information on OCI contributor and maintainer meeting schedules. 
+You can also find links to meeting agendas and minutes for all prior meetings.
 
 ## Mailing List
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,11 @@ It also guarantees that the design is sound before code is written; a GitHub pul
 Typos and grammatical errors can go straight to a pull-request.
 When in doubt, start on the [mailing-list](#mailing-list).
 
-## Weekly Call
+## Meetings
 
-The contributors and maintainers of all OCI projects have a weekly meeting Wednesdays at 2:00 PM (USA Pacific).
-Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1-415-968-0849 (no PIN needed).
-An initial agenda will be posted to the [mailing list](#mailing-list) earlier in the week, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
-Minutes are posted to the [mailing list](#mailing-list) and minutes from past calls are archived [here][minutes].
+Please see the [OCI org repository README](https://github.com/opencontainers/org#meetings) for the most up-to-date
+information on OCI contributor and maintainer meeting schedules. You can also find links to meeting agendas and
+minutes for all prior meetings.
 
 ## Mailing List
 
@@ -163,6 +162,4 @@ Read more on [How to Write a Git Commit Message](http://chris.beams.io/posts/git
 
 
 [code-of-conduct]: https://github.com/opencontainers/org/blob/master/CODE_OF_CONDUCT.md
-[UberConference]: https://www.uberconference.com/opencontainers
 [irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
-[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/


### PR DESCRIPTION
Point to one canonical location for meeting details, frequency, minutes,
agenda, etc.

Closes: #779 
Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>