### PR TITLE
zstd: add constants to specs-go/v1

### DIFF
--- a/schema/validator.go
+++ b/schema/validator.go
@@ -117,8 +117,10 @@ func validateManifest(r io.Reader) error {
 	for _, layer := range header.Layers {
 		if layer.MediaType != string(v1.MediaTypeImageLayer) &&
 			layer.MediaType != string(v1.MediaTypeImageLayerGzip) &&
+			layer.MediaType != string(v1.MediaTypeImageLayerZstd) &&
 			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) &&
-			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableGzip) {
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableGzip) &&
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableZstd) {
 			fmt.Printf("warning: layer %s has an unknown media type: %s\n", layer.Digest, layer.MediaType)
 		}
 	}

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -34,6 +34,10 @@ const (
 	// referenced by the manifest.
 	MediaTypeImageLayerGzip = "application/vnd.oci.image.layer.v1.tar+gzip"
 
+	// MediaTypeImageLayerZstd is the media type used for zstd compressed
+	// layers referenced by the manifest.
+	MediaTypeImageLayerZstd = "application/vnd.oci.image.layer.v1.tar+zstd"
+
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
 	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar"
@@ -42,6 +46,11 @@ const (
 	// gzipped layers referenced by the manifest but with distribution
 	// restrictions.
 	MediaTypeImageLayerNonDistributableGzip = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
+
+	// MediaTypeImageLayerNonDistributableZstd is the media type for zstd
+	// compressed layers referenced by the manifest but with distribution
+	// restrictions.
+	MediaTypeImageLayerNonDistributableZstd = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.
 	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"


### PR DESCRIPTION
Add go constants for the zstd MIME types to make them usable by
consumers of the go package.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

Cc: @giuseppe, @vbatts, @cyphar, @rhatdan, @AkihiroSuda, @jonboulle 