### PR TITLE
Updating descriptor_test.go with tiny typo

### DIFF
--- a/schema/descriptor_test.go
+++ b/schema/descriptor_test.go
@@ -97,7 +97,7 @@ func TestDescriptor(t *testing.T) {
 			fail: false,
 		},
 
-		// expected success: mediaType does not match pattern (type too long)
+		// expected failure: mediaType does not match pattern (type too long)
 		{
 			descriptor: `
 {
@@ -109,7 +109,7 @@ func TestDescriptor(t *testing.T) {
 			fail: true,
 		},
 
-		// expected success: mediaType does not match pattern (subtype too long)
+		// expected failure: mediaType does not match pattern (subtype too long)
 		{
 			descriptor: `
 {


### PR DESCRIPTION
The tests for type/subtype too long are failures, and should be commented as such.