### PR TITLE
Mediatype of layers should be application/vnd.oci.image.layer.v1.tar+gz

### DIFF
--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -188,17 +188,17 @@ func TestManifest(t *testing.T) {
   },
   "layers": [
     {
-      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
       "size": 1470,
       "digest": "sha256+foo-bar:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
     },
     {
-      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
       "size": 1470,
       "digest": "sha256.foo-bar:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
     },
     {
-      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
       "size": 1470,
 	  "digest": "multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8"
     }
@@ -219,7 +219,7 @@ func TestManifest(t *testing.T) {
   },
   "layers": [
     {
-      "mediaType": "application/vnd.oci.image.config.v1+json",
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
       "size": 1470,
       "digest": "sha256+foo+-b:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
     }


### PR DESCRIPTION
This is another thing I noticed this morning - the mediatype for layers should be in the layers family, but there were two tests (checking for other things) that had config types instead. Should this have been caught, or given that the tests were for failures for other things, it would have been caught had those other things not been wrong?

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>