### PR TITLE
index: add media type

### DIFF
--- a/specs-go/v1/index.go
+++ b/specs-go/v1/index.go
@@ -21,6 +21,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Index struct {
 	specs.Versioned
 
+	// MediaType is the media type of the index.
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Manifests references platform specific manifests.
 	Manifests []Descriptor `json:"manifests"`
 


### PR DESCRIPTION
Add a media type to the image index.  The spec mentions that an index
media type is reserved for use, to maintain compatibility.  Although
not being strictly required, some tools might want to set the media type
to be more explicit.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>