### PR TITLE
Add GCR to implementations

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -17,5 +17,6 @@ Projects or Companies currently adopting the OCI Image Specification
 * [coreos/rkt](https://github.com/coreos/rkt)
 * [box-builder/box](https://github.com/box-builder/box)
 * [coolljt0725/docker2oci](https://github.com/coolljt0725/docker2oci)
+* [Google Container Registry(GCR)](https://cloud.google.com/container-registry/docs/image-formats)
 
 _(to add your project please open a [pull-request](https://github.com/opencontainers/image-spec/pulls))_

--- a/implementations.md
+++ b/implementations.md
@@ -17,6 +17,6 @@ Projects or Companies currently adopting the OCI Image Specification
 * [coreos/rkt](https://github.com/coreos/rkt)
 * [box-builder/box](https://github.com/box-builder/box)
 * [coolljt0725/docker2oci](https://github.com/coolljt0725/docker2oci)
-* [Google Container Registry(GCR)](https://cloud.google.com/container-registry/docs/image-formats)
+* [Google Container Registry (GCR)](https://cloud.google.com/container-registry/docs/image-formats)
 
 _(to add your project please open a [pull-request](https://github.com/opencontainers/image-spec/pulls))_


### PR DESCRIPTION
## What

As title. Add Google Cloud Registry(GCR) to `implementations.md`.
If I am misunderstanding, please close this PR 🙇 

## Why

Because it was missing. 

Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com>