### PR TITLE
manifest: clarify failure modes for unknown layer types

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -60,7 +60,13 @@ Unlike the [image index](image-index.md), which contains information about a set
         - [`application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`](layer.md#gzip-media-types)
 
         Manifests concerned with portability SHOULD use one of the above media types.
-        An encountered `mediaType` that is unknown to the implementation MUST be ignored.
+        An encountered `mediaType` that is unknown to the implementation and cannot be processed MUST be ignored.
+
+        For example, an image transport tool which does not unpack layers can
+        process layers with mime types it does not understand, since it does
+        not need to inspect the content of the layers. However, a runtime which
+        cannot unpack a layer MUST fail, since it cannot render the final
+        filesystem layout as described above.
 
 
         Entries in this field will frequently use the `+gzip` types.


### PR DESCRIPTION
Per #803, there seems to be some confusion about how tools should fail when
they encounter unknown layer types. Container runtimes cannot satisfy the
bit about:

   The final filesystem layout MUST match the result of
   [applying](layer.md#applying-changesets) the layers to an empty
   directory.

by ignoring layer types, so the spec is slightly in conflict with itself
here, by requiring runtimes both MUST apply all the layers and MUST ignore
layers that they cannot understand. Given that the behavior of runtimes
(and image tools like umoci) today is simply to fail if it gets a layer
type it doesn't understand here, let's clarify the behavior to that.

However, image transfer tools can safely ignore mime types they don't
understand (indeed, skopeo does this today); let's add the wiggle wording
about "cannot be processed" for all similar classes of tools which don't
actually need to inspect layer content.

Suggested-by: Sebastiaan van Stijn <github@gone.nl>
Signed-off-by: Tycho Andersen <tycho@tycho.pizza>