### PR TITLE
Add ArgsEscaped field to image config

### DIFF
--- a/config.md
+++ b/config.md
@@ -165,6 +165,10 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
 
     The field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`.
 
+  - **ArgsEscaped** *boolean*, OPTIONAL
+
+    This field is used for Windows images to indicate that the `Entrypoint` and `Cmd` fields will have only a single element, which has already been escaped. In this case their values should be used as-is without further escaping.
+
 - **rootfs** *object*, REQUIRED
 
    The rootfs key references the layer content addresses used by the image.

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -83,6 +83,9 @@
         },
         "StopSignal": {
           "type": "string"
+        },
+        "ArgsEscaped": {
+          "type": "boolean"
         }
       }
     },

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -48,6 +48,10 @@ type ImageConfig struct {
 
 	// StopSignal contains the system call signal that will be sent to the container to exit.
 	StopSignal string `json:"StopSignal,omitempty"`
+
+	// ArgsEscaped is used for Windows images to indicate that the Entrypoint and Cmd have already been escaped and should be
+	// used directly as the command line.
+	ArgsEscaped bool `json:"ArgsEscaped,omitempty"`
 }
 
 // RootFS describes a layer content addresses


### PR DESCRIPTION
This PR is an attempt to fix containerd/containerd#5067, which currently prevents certain Docker-built Windows images from working in containerd. See the containerd issue for full details. Brief overview below.

Docker has been relying on the unofficial `ArgsEscaped` field in the image config for several years now. It is added when a Windows image is built using a "shell form" `ENTRYPOINT`/`CMD` in the Dockerfile, and indicates that the first element of the `Entrypoint`/`Cmd` field contains a full command line, rather than just a path to a binary.

This change was made in Docker to improve support for Windows containers, given differences in how Windows and Linux handle command line args and escaping. Given that there are existing images in the world that rely on this field being set, the easiest way to address the problem appears to be simply adding `ArgsEscaped` officially to the image spec.

For context, this is how `ArgsEscaped` is represented in Docker's image config type: https://github.com/moby/moby/blob/46cdcd206c56172b95ba5c77b827a722dab426c5/api/types/container/config.go#L57