### PR TITLE
Replace Jason Bouzane with Jon Johnson in image-spec maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,5 @@
 Brendan Burns <bburns@microsoft.com> (@brendandburns)
-Jason Bouzane <jbouzane@google.com> (@jbouzane)
+Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
 John Starks <jostarks@microsoft.com> (@jstarks)
 Jonathan Boulle <jon@nstack.com> (@jonboulle)
 Stephen Day <stevvooe@gmail.com> (@stevvooe)


### PR DESCRIPTION
Switch approved by Jason Bouzane via email to OCI TOB mailing list: https://groups.google.com/a/opencontainers.org/g/tob/c/Q08hiintwY4/m/tMreB9LgCwAJ

Text:
```
From: Jason Bouzane <jbouzane@google.com>
Date: Thu, 25 Mar 2021 11:34:51 -0600
Message-ID: <CAFi6z1Hb+dC-=0g3rceGSyZ+dYHR=F8XNQvd4=0E=y9RaQ-pwA@mail.gmail.com>
Subject: Re: [oci-tob] image-spec maintainer gap
To: Vincent Batts <vbatts@hashbangbash.com>
Cc: Phil Estes <estesp@gmail.com>, Technical Oversight Board <tob@opencontainers.org>

I'm on PTO for a few days, so I'm not in a position to make the swap
myself. But I'm fine with this if someone else wants to do it.
```

**This PR must get at least 6 LGTMs before merging:**

- [x] Brendan Burns <bburns@microsoft.com> (@brendandburns)
- [x] Jason Bouzane <jbouzane@google.com> (@jbouzane) (via email)
- [x] John Starks <jostarks@microsoft.com> (@jstarks)
- [ ] Jonathan Boulle <jon@nstack.com> (@jonboulle)
- [x] Stephen Day <stevvooe@gmail.com> (@stevvooe)
- [x] Vincent Batts <vbatts@redhat.com> (@vbatts)
- [x] Aleksa Sarai <asarai@suse.de> (@cyphar)
- [ ] Keyang Xie <keyang.xie@gmail.com> (@xiekeyang)


Signed-off-by: Phil Estes <estesp@gmail.com>