### PR TITLE
Replace Brendan Burns with Steve Lasker on maintainers.

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,4 @@
-Brendan Burns <bburns@microsoft.com> (@brendandburns)
+Steve Lasker <Steve.Lasker@microsoft.com> (@stevelasker)
 Jason Bouzane <jbouzane@google.com> (@jbouzane)
 John Starks <jostarks@microsoft.com> (@jstarks)
 Jonathan Boulle <jon@nstack.com> (@jonboulle)


### PR DESCRIPTION
**This PR must get at least 5 LGTMs before merging:**

- [x] Brendan Burns <bburns@microsoft.com> (@brendandburns)
- [ ] Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
- [x] John Starks <jostarks@microsoft.com> (@jstarks)
- [ ] Jonathan Boulle <jon@nstack.com> (@jonboulle)
- [ ] Stephen Day <stevvooe@gmail.com> (@stevvooe)
- [ ] Vincent Batts <vbatts@redhat.com> (@vbatts)
- [ ] Aleksa Sarai <asarai@suse.de> (@cyphar)

Signed-off-by: Brendan Burns <bburns@microsoft.com>