### PR TITLE
Remove @jonboulle as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,6 @@
 Brendan Burns <bburns@microsoft.com> (@brendandburns)
 Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
 John Starks <jostarks@microsoft.com> (@jstarks)
-Jonathan Boulle <jon@nstack.com> (@jonboulle)
 Stephen Day <stevvooe@gmail.com> (@stevvooe)
 Vincent Batts <vbatts@hashbangbash.com> (@vbatts)
 Aleksa Sarai <asarai@suse.de> (@cyphar)


### PR DESCRIPTION
Jon has been unresponsive and last made project activity was nearly 2 years ago.

We thank Jon for his contributions and he was instrumental in helping getting OCI off the ground.

See https://github.com/opencontainers/image-spec/issues/834

**This PR must get at least 5 LGTMs before merging:**

- [ ] Brendan Burns <bburns@microsoft.com> (@brendandburns)
- [x] Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
- [ ] John Starks <jostarks@microsoft.com> (@jstarks)
- [ ] Jonathan Boulle <jon@nstack.com> (@jonboulle)
- [ ] Stephen Day <stevvooe@gmail.com> (@stevvooe)
- [x] Vincent Batts <vbatts@redhat.com> (@vbatts)
- [x] Aleksa Sarai <asarai@suse.de> (@cyphar)

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>