### PR TITLE
Handle multiple matching index entries

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -83,6 +83,8 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
         This property is RESERVED for future versions of the specification.
 
+  If multiple manifests match a client or runtime's requirements, the first matching entry SHOULD be used.
+
 - **`annotations`** *string-string map*
 
     This OPTIONAL property contains arbitrary metadata for the image index.


### PR DESCRIPTION
The goal is to handle an index where there are multiple entries that look the same to older clients, but a newer client may see a feature it supports in the annotations. This would allow an SBoM to be packaged as an OCI-artifact and pushed in an index along side the image. It would also give a way to support [different layer encodings](https://github.com/opencontainers/image-spec/issues/803#issuecomment-742157836) for the same image without breaking older clients.

I say "SHOULD", but if there are no use cases where this change would break, then I'd be tempted to say "MUST".

Fixes #862, fixes #776

Signed-off-by: Brandon Mitchell <git@bmitch.net>