### PR TITLE
Add ArgsEscaped field to image config

### DIFF
--- a/config.md
+++ b/config.md
@@ -183,6 +183,13 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
 
     The field contains the system call signal that will be sent to the container to exit. The signal can be a signal name in the format `SIGNAME`, for instance `SIGKILL` or `SIGRTMIN+3`.
 
+  - **ArgsEscaped** *boolean*, OPTIONAL
+
+    `[Deprecated]` - This field is present only for legacy compatibility with Docker and should not be used by new image builders.
+    It is used by Docker for Windows images to indicate that the `Entrypoint` or `Cmd` or both, contains only a single element array, that is a pre-escaped, and combined into a single string `CommandLine`.
+    If `true` the value in `Entrypoint` or `Cmd` should be used as-is to avoid double escaping.
+    Note, the exact behavior of `ArgsEscaped` is complex and subject to implementation details in Moby project.
+
   - **Memory** *integer*, OPTIONAL
 
     This property is *reserved* for use, to [maintain compatibility](media-types.md#compatibility-matrix).

--- a/media-types.md
+++ b/media-types.md
@@ -69,6 +69,8 @@ This section shows where the OCI Image Specification is compatible with formats 
   - `.config.MemorySwap`: only present in Docker, and reserved in OCI
   - `.config.CpuShares`: only present in Docker, and reserved in OCI
   - `.config.Healthcheck`: only present in Docker, and reserved in OCI
+- [Moby/Docker](https://github.com/moby/moby)
+  - `.config.ArgsEscaped`: Windows-specific Moby/Docker extension, deprecated in OCI, available for compatibility with older images.
 
 `.config.StopSignal` and `.config.Labels` are accidentally undocumented in Docker Image Spec v1.2, but these fields are not OCI-specific concepts.
 

--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -95,6 +95,9 @@
         },
         "StopSignal": {
           "type": "string"
+        },
+        "ArgsEscaped": {
+          "type": "boolean"
         }
       }
     },

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -48,6 +48,15 @@ type ImageConfig struct {
 
 	// StopSignal contains the system call signal that will be sent to the container to exit.
 	StopSignal string `json:"StopSignal,omitempty"`
+
+	// ArgsEscaped `[Deprecated]` - This field is present only for legacy
+	// compatibility with Docker and should not be used by new image builders.
+	// It is used by Docker for Windows images to indicate that the `Entrypoint`
+	// or `Cmd` or both, contains only a single element array, that is a
+	// pre-escaped, and combined into a single string `CommandLine`. If `true`
+	// the value in `Entrypoint` or `Cmd` should be used as-is to avoid double
+	// escaping.
+	ArgsEscaped bool `json:"ArgsEscaped,omitempty"`
 }
 
 // RootFS describes a layer content addresses


### PR DESCRIPTION
This change officially adds ArgsEscaped to the image config. This field has already been used by Docker for several years, so adding it here allows images that depend on its behavior to work with other runtimes.

For certain Windows images created via Docker they may contain `ArgsEscaped==true` if the ENTRYPOINT or CMD is in the `shell` form and contains spaces, path characters, etc.

An example is the following:
```
FROM mcr.microsoft.com/windows/servercore:ltsc2019

SHELL ["powershell", "-Command"]
ENTRYPOINT "C:\Path To\MyExe.exe" -arg1 "-arg2 value2"
```

Will be encoded by Docker as:
```
"Config": {
  ...
  "ArgsEscaped": true,
  ...
  "Entrypoint": [
    "powershell.exe -Command \"C:\\My Data\\MyExe.exe\" -arg1 \"-arg2 value2\""
  ],
  ...
}
```

You can see that `Entrypoint` becomes a single element array with the entire argument list already escaped. To avoid a double escape problem Windows supports passing via OCI as a complete `CommandLine`.

@kevpar - Please let me know if you do not want me to carry this as your change or don't wan't your signature on the commit. I wanted to give you credit since you originally opened #829.