### PR TITLE
Fixing charter link

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -67,4 +67,4 @@ For example:
 
 > [runtime-spec adopted]: Tag 0647920 as 1.0.0-rc (+6 -0 #3)
 
-[charter]: https://www.opencontainers.org/about/governance
+[charter]: https://github.com/opencontainers/tob/blob/main/CHARTER.md

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -48,4 +48,4 @@ Specifications have a variety of different timelines in their lifecycle.
   For example if a breaking change is introduced in v1.0.0-rc2 then the series would end with v1.0.0-rc4 and v1.0.0.
 - Minor and patch releases SHOULD be made on an as-needed basis.
 
-[charter]: https://www.opencontainers.org/about/governance
+[charter]: https://github.com/opencontainers/tob/blob/main/CHARTER.md


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

The current charter link is 404'ing: <https://www.opencontainers.org/about/governance>

This points to the git repo, which is the same location the website redirects to: <https://github.com/opencontainers/tob/blob/main/CHARTER.md>