### PR TITLE
Add mediaType fields into example manifest & image index JSON references

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -109,6 +109,7 @@ When the variant of the CPU is not listed in the table, values are implementatio
 ```json,title=Image%20Index&mediatype=application/vnd.oci.image.index.v1%2Bjson
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",

--- a/manifest.md
+++ b/manifest.md
@@ -78,6 +78,7 @@ Unlike the [image index](image-index.md), which contains information about a set
 ```json,title=Manifest&mediatype=application/vnd.oci.image.manifest.v1%2Bjson
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 7023,


### PR DESCRIPTION
Updating example manifest JSON to include `mediaType` field to match the spec (which says `mediaType` SHOULD be included in the image manifest & image index).