### PR TITLE
Add Brandon as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brendandburns @jonjohnsonjr @jstarks @jonboulle @stevvooe @vbatts @cyphar
+* @brendandburns @jonjohnsonjr @jstarks @jonboulle @stevvooe @sudo-bmitch @vbatts @cyphar

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brendandburns @jonjohnsonjr @jstarks @jonboulle @stevvooe @sudo-bmitch @vbatts @cyphar
+* @jonjohnsonjr @jonboulle @stevvooe @sudo-bmitch @vbatts @cyphar

--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,7 +1,9 @@
 We would like to acknowledge previous OCI image spec maintainers and their huge contributions to our collective success:
 
 * Brandon Philips (@philips)
+* Brendan Burns (@brendandburns)
 * Jason Bouzane (@jbouzane)
+* John Starks (@jstarks)
 * Keyang Xie (@xiekeyang)
 
 We thank these members for their service to the OCI community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,4 @@
+Brandon Mitchell <git@bmitch.net> (@sudo-bmitch)
 Brendan Burns <bburns@microsoft.com> (@brendandburns)
 Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
 John Starks <jostarks@microsoft.com> (@jstarks)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,5 @@
 Brandon Mitchell <git@bmitch.net> (@sudo-bmitch)
-Brendan Burns <bburns@microsoft.com> (@brendandburns)
 Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
-John Starks <jostarks@microsoft.com> (@jstarks)
 Jonathan Boulle <jonathanboulle@gmail.com> (@jonboulle)
 Stephen Day <stevvooe@gmail.com> (@stevvooe)
 Vincent Batts <vbatts@hashbangbash.com> (@vbatts)


### PR DESCRIPTION
# Nomination for a New Maintainer

## Nominating Maintainer

jdolitsky

## New Maintainer

sudo-bmitch

## Justification

- Attendance in OCI weekly meetings
- Activity in image-spec/distribution-spec issues relating to extending specs
- Contributing to the OCI Reference Types working group
- Overall solid person

Need 3 approvals from the current 5 maintainers:

- [x] Jon Johnson (@jonjohnsonjr)
- [ ] Jonathan Boulle (@jonboulle)
- [x] Stephen Day (@stevvooe)
- [x] Vincent Batts  (@vbatts)
- [ ] Aleksa Sarai (@cyphar)