### PR TITLE
Move inactive maintainers to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @brendandburns @jonjohnsonjr @jstarks @jonboulle @stevvooe @vbatts @cyphar
+* @jonjohnsonjr @jonboulle @stevvooe @vbatts @cyphar

--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,7 +1,9 @@
 We would like to acknowledge previous OCI image spec maintainers and their huge contributions to our collective success:
 
 * Brandon Philips (@philips)
+* Brendan Burns (@brendandburns)
 * Jason Bouzane (@jbouzane)
+* John Starks (@jstarks)
 * Keyang Xie (@xiekeyang)
 
 We thank these members for their service to the OCI community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,4 @@
-Brendan Burns <bburns@microsoft.com> (@brendandburns)
 Jon Johnson <jonjohnson@google.com> (@jonjohnsonjr)
-John Starks <jostarks@microsoft.com> (@jstarks)
 Jonathan Boulle <jonathanboulle@gmail.com> (@jonboulle)
 Stephen Day <stevvooe@gmail.com> (@stevvooe)
 Vincent Batts <vbatts@hashbangbash.com> (@vbatts)


### PR DESCRIPTION
As stated in [`EMRITUS.md`](https://github.com/opencontainers/image-spec/blob/main/EMERITUS.md):

> We would like to acknowledge previous OCI image spec maintainers and their huge contributions to our collective success ... We thank these members for their service to the OCI community.

The last activity from these maintainers appears to be Jun 30, 2017, which predates my involvement in this community. As we make progress in areas such as the [OCI Reference Types WG](https://github.com/opencontainers/wg-reference-types), it becomes critical to have active maintainers on this repository.

In my opinion, If you do not support this motion, it says a lot about your motivations and political agendas. Please consider this and do the right thing.