### PR TITLE
Update schema and tests for mediaType validation

### DIFF
--- a/image-layout.md
+++ b/image-layout.md
@@ -162,6 +162,7 @@ Those tags will often be represented in an image-layout repository with matching
 ```json,title=Image%20Index&mediatype=application/vnd.oci.image.index.v1%2Bjson
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.index.v1+json",

--- a/schema/image-index-schema.json
+++ b/schema/image-index-schema.json
@@ -11,6 +11,10 @@
       "minimum": 2,
       "maximum": 2
     },
+    "mediaType": {
+      "description": "the mediatype of the referenced object",
+      "$ref": "defs-descriptor.json#/definitions/mediaType"
+    },
     "manifests": {
       "type": "array",
       "items": {

--- a/schema/image-manifest-schema.json
+++ b/schema/image-manifest-schema.json
@@ -11,6 +11,10 @@
       "minimum": 2,
       "maximum": 2
     },
+    "mediaType": {
+      "description": "the mediatype of the referenced object",
+      "$ref": "defs-descriptor.json#/definitions/mediaType"
+    },
     "config": {
       "$ref": "content-descriptor.json"
     },

--- a/schema/imageindex_test.go
+++ b/schema/imageindex_test.go
@@ -31,6 +31,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "invalid",
@@ -52,6 +53,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -73,6 +75,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -93,6 +96,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -113,6 +117,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "invalid",
@@ -134,6 +139,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "",
@@ -155,6 +161,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -189,6 +196,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -206,6 +214,7 @@ func TestImageIndex(t *testing.T) {
 			imageIndex: `
 {
   "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
     {
       "mediaType": "application/customized.manifest+json",

--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -31,6 +31,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "invalid",
     "size": 1470,
@@ -53,6 +54,8 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
+  "config": {
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": "1470",
@@ -75,6 +78,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -97,6 +101,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -133,6 +138,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -165,6 +171,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -181,6 +188,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -212,6 +220,7 @@ func TestManifest(t *testing.T) {
 			manifest: `
 {
   "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,


### PR DESCRIPTION
Ideally it would be better to make the `mediaType` a required property. But given that we want to be backward compatible, the check is left to the client to ensure that layers/config doesn't appear with the manifests then mediaType is not present. 

This PR doesn't attempt to fix that requirement in the schema  and fixes only tests to have a valid mediaType. 

-- Signed-off-by: Sajay Antony <sajaya@microsoft.com>