### PR TITLE
Embed Platform in Image

### DIFF
--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -86,22 +86,8 @@ type Image struct {
 	// Author defines the name and/or email address of the person or entity which created and is responsible for maintaining the image.
 	Author string `json:"author,omitempty"`
 
-	// Architecture is the CPU architecture which the binaries in this image are built to run on.
-	Architecture string `json:"architecture"`
-
-	// Variant is the variant of the specified CPU architecture which image binaries are intended to run on.
-	Variant string `json:"variant,omitempty"`
-
-	// OS is the name of the operating system which the image is built to run on.
-	OS string `json:"os"`
-
-	// OSVersion is an optional field specifying the operating system
-	// version, for example on Windows `10.0.14393.1066`.
-	OSVersion string `json:"os.version,omitempty"`
-
-	// OSFeatures is an optional field specifying an array of strings,
-	// each listing a required OS feature (for example on Windows `win32k`).
-	OSFeatures []string `json:"os.features,omitempty"`
+	// Platform describes the platform which the image in the manifest runs on.
+	Platform
 
 	// Config defines the execution parameters which should be used as a base when running a container using the image.
 	Config ImageConfig `json:"config,omitempty"`


### PR DESCRIPTION
- relates to the discussion on https://github.com/containerd/containerd/pull/7376#discussion_r966193773

This embeds the Platform struct in the image struct, so that these fields don't have to be defined multiple times, and to allow projects that have tooling for validating/normalizing/handling Platform data can apply these on an image-config, without first constructing a Platform from these fields.
