### PR TITLE
Rename refers field to subject

### DIFF
--- a/artifact.md
+++ b/artifact.md
@@ -28,7 +28,7 @@ For the media type(s) that this is compatible with see the [matrix](media-types.
   Each descriptor represents an artifact of any IANA mediaType.
   The list MAY be ordered for certain artifact types like scan results.
 
-- **`refers`** *[descriptor](descriptor.md)*
+- **`subject`** *[descriptor](descriptor.md)*
 
   This OPTIONAL property specifies a [descriptor](descriptor.md) of another manifest.
   This value, used by the [`referrers` API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers), indicates a relationship to the specified manifest.
@@ -57,7 +57,7 @@ For the media type(s) that this is compatible with see the [matrix](media-types.
       "digest": "sha256:87923725d74f4bfb94c9e86d64170f7521aad8221a5de834851470ca142da630"
     }
   ],
-  "refers": {
+  "subject": {
     "mediaType": "application/vnd.oci.image.manifest.v1+json",
     "size": 1234,
     "digest": "sha256:cc06a2839488b8bd2a2b99dcdc03d5cfd818eed72ad08ef3cc197aac64c0d0a0"

--- a/manifest.md
+++ b/manifest.md
@@ -65,7 +65,7 @@ Unlike the [image index](image-index.md), which contains information about a set
 
         Entries in this field will frequently use the `+gzip` types.
 
-- **`refers`** *[descriptor](descriptor.md)*
+- **`subject`** *[descriptor](descriptor.md)*
 
     This OPTIONAL property specifies a [descriptor](descriptor.md) of another manifest.
     This value, used by the [`referrers` API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers), indicates a relationship to the specified manifest.
@@ -106,7 +106,7 @@ Unlike the [image index](image-index.md), which contains information about a set
       "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736"
     }
   ],
-  "refers": {
+  "subject": {
     "mediaType": "application/vnd.oci.image.manifest.v1+json",
     "size": 7682,
     "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270"

--- a/specs-go/v1/artifact.go
+++ b/specs-go/v1/artifact.go
@@ -26,8 +26,8 @@ type Artifact struct {
 	// Blobs is a collection of blobs referenced by this manifest.
 	Blobs []Descriptor `json:"blobs,omitempty"`
 
-	// Refers is an optional link to any existing manifest within the repository.
-	Refers *Descriptor `json:"refers,omitempty"`
+	// Subject (reference) is an optional link from the artifact to another manifest forming an association between the artifact and the other manifest.
+	Subject *Descriptor `json:"subject,omitempty"`
 
 	// Annotations contains arbitrary metadata for the artifact manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/specs-go/v1/manifest.go
+++ b/specs-go/v1/manifest.go
@@ -30,8 +30,8 @@ type Manifest struct {
 	// Layers is an indexed list of layers referenced by the manifest.
 	Layers []Descriptor `json:"layers"`
 
-	// Refers is an optional link to any existing manifest within the repository.
-	Refers *Descriptor `json:"refers,omitempty"`
+	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
+	Subject *Descriptor `json:"subject,omitempty"`
 
 	// Annotations contains arbitrary metadata for the image manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`


### PR DESCRIPTION
Addresses the renaming of `refers` --> `subject`  for #940 

Signed-off-by: Sajay Antony <sajaya@microsoft.com>