### PR TITLE
Bump from Go 1.16 to 1.17

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -9,17 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18', '1.19']
 
     name: Documentation and Linting
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: go/src/github.com/opencontainers/image-spec
 
-                               # commit for v1 release
-      - uses: actions/setup-go@0caeaed6fd66a828038c2da3c0f662a42862658f
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
@@ -40,7 +39,7 @@ jobs:
           make docs
 
       - name: documentation artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: oci-docs
           path: go/src/github.com/opencontainers/image-spec/output

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/image-spec
 
-go 1.16
+go 1.17
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -12,3 +12,5 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+require github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect


### PR DESCRIPTION
With Go releasing 1.19, the current supported versions are 1.18 and 1.19. I think we are staying 1 version behind supported, so this bumps to 1.17 with tests on 1.18 and 1.19. It also bumps up the GHA steps to the current versions.

Signed-off-by: Brandon Mitchell <git@bmitch.net>