### PR TITLE
fix: revert schema identifier for draft-04

### DIFF
--- a/schema/config-schema.json
+++ b/schema/config-schema.json
@@ -1,6 +1,6 @@
 {
   "description": "OpenContainer Config Specification",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://opencontainers.org/schema/image/config",
   "type": "object",
   "properties": {

--- a/schema/content-descriptor.json
+++ b/schema/content-descriptor.json
@@ -1,6 +1,6 @@
 {
   "description": "OpenContainer Content Descriptor Specification",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://opencontainers.org/schema/descriptor",
   "type": "object",
   "properties": {

--- a/schema/image-index-schema.json
+++ b/schema/image-index-schema.json
@@ -1,6 +1,6 @@
 {
   "description": "OpenContainer Image Index Specification",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://opencontainers.org/schema/image/index",
   "type": "object",
   "properties": {

--- a/schema/image-layout-schema.json
+++ b/schema/image-layout-schema.json
@@ -1,6 +1,6 @@
 {
   "description": "OpenContainer Image Layout Schema",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://opencontainers.org/schema/image/layout",
   "type": "object",
   "properties": {

--- a/schema/image-manifest-schema.json
+++ b/schema/image-manifest-schema.json
@@ -1,6 +1,6 @@
 {
   "description": "OpenContainer Image Manifest Specification",
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://opencontainers.org/schema/image/manifest",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Schema for draft 4 should follow
 - https://json-schema.org/understanding-json-schema/reference/schema.html#id4 and the string identifier should be 

`http://json-schema.org/draft-04/schema#` 

Signed-off-by: Sajay Antony <sajaya@microsoft.com>

PR associated with this change -  #915 