### PR TITLE
Note an exception to the platform.os recommendation for wasi

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -59,6 +59,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
         This REQUIRED property specifies the operating system.
         Image indexes SHOULD use, and implementations SHOULD understand, values listed in the Go Language document for [`GOOS`][go-environment2].
+        An exception to this guidance is provided for Wasm applications that rely on the WASI system interface, where the `os` SHOULD be `wasi`.
 
     - **`os.version`** *string*
 


### PR DESCRIPTION
As discussed in today's call.

Wasm (WebAssembly) is an exciting new space, and the Wasm community has smartly chosen to adopt OCI as a packaging and distribution format for Wasm applications.

Unfortunately, today, they mainly build applications using `docker build` and Dockerfiles where `.wasm` files are `COPY`ed onto `scratch` base images, resulting in images whose configs report them as `linux/amd64` images by default.

If Wasm applications want to be distributed alongside images for other platforms, especially alongside _actual_ `linux/amd64` images, this may be problematic.

Unfortunately, OCI's guidance around selecting a platform to report is lacking for this use case. Repurposing Go's set of supported `GOOS` and `GOARCH` values is insufficient here, since Go currently doesn't have good support for Wasm outside of JS-adjacent use cases. In the years since Go added support for JS/Wasm, Wasm has "escaped" the browser, and is now used directly on some platforms, aided by [WASI, the WebAssembly System Interface](https://wasi.dev/). Regular Go tooling has no support for Wasi today -- see discussion here: https://github.com/golang/go/issues/31105 -- though a separate project, TinyGo, does support Wasm and WASI in constrained scenarios.

This PR proposes defining an exception to the recommendation to use an appropriate `GOOS` value, when the Wasm application relies on WASI.

Diverging from Go here provides some small opportunity for trouble for us down the road:
1. Go could add official support for WASI, but choose to do so using a `GOOS` value that isn't `wasi` -- this would confuse our guidance more, since there'd be a valid `GOOS` for WASI that isn't our recommended `.platform.os` value.
2. Go could add support for something that isn't WASI, but choose to do so using the `GOOS` value `wasi` -- this would confuse our guidance since `wasi` in OCI-land would mean one thing, and `wasi` in Go-land would mean something else.

Either of these scenarios seem unlikely, and we'd have some options in either case to avoid confusion. Trying to plan for infinite scary futures is hard.

Having this expected behavior defined would help Wasm image builders and platforms agree on shared values to interoperate better.

Alternatively, we could just do nothing for now, and recommend the Wasm community build using `os=wasi` "off the record", gathering feedback and watching the community until their behavior settles. Maybe Go will have WASI support by then, alleviating some potential risks above.

cc @squillace @devigned