### PR TITLE
Deprecate non-distributable layers

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -325,7 +325,7 @@ Any given image is likely to be composed of several of these Image Filesystem Ch
 # Non-Distributable Layers
 
 > **NOTE**: Non-distributable layers are deprecated, and not recommended for future use.
-> Clients SHOULD consider the advice below for existing images, but in general SHOULD NOT produce new non-distributable layers.
+> Implementations SHOULD NOT produce new non-distributable layers.
 
 Due to legal requirements, certain layers may not be regularly distributable.
 Such "non-distributable" layers are typically downloaded directly from a distributor but never uploaded.

--- a/layer.md
+++ b/layer.md
@@ -324,6 +324,9 @@ Any given image is likely to be composed of several of these Image Filesystem Ch
 
 # Non-Distributable Layers
 
+> **NOTE**: Non-distributable layers are deprecated, and not recommended for future use.
+> Clients SHOULD consider the advice below for existing images, but in general SHOULD NOT produce new non-distributable layers.
+
 Due to legal requirements, certain layers may not be regularly distributable.
 Such "non-distributable" layers are typically downloaded directly from a distributor but never uploaded.
 

--- a/media-types.md
+++ b/media-types.md
@@ -10,10 +10,13 @@ The following media types identify the formats described here and their referenc
 - `application/vnd.oci.image.layer.v1.tar`: ["Layer", as a tar archive](layer.md)
 - `application/vnd.oci.image.layer.v1.tar+gzip`: ["Layer", as a tar archive](layer.md#gzip-media-types) compressed with [gzip][rfc1952]
 - `application/vnd.oci.image.layer.v1.tar+zstd`: ["Layer", as a tar archive](layer.md#zstd-media-types) compressed with [zstd][rfc8478]
-- `application/vnd.oci.image.layer.nondistributable.v1.tar`: ["Layer", as a tar archive with distribution restrictions](layer.md#non-distributable-layers)
+- `application/vnd.oci.artifact.manifest.v1+json`: [Artifact manifest](artifact.md)
+
+The following media types identify a ["Layer" with distribution restrictions](layer.md#non-distributable-layers), but are **deprecated** and not recommended for future use:
+
+- `application/vnd.oci.image.layer.nondistributable.v1.tar`: "Layer", as a tar archive
 - `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`: ["Layer", as a tar archive with distribution restrictions](layer.md#gzip-media-types) compressed with [gzip][rfc1952]
 - `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd`: ["Layer", as a tar archive with distribution restrictions](layer.md#zstd-media-types) compressed with [zstd][rfc8478]
-- `application/vnd.oci.artifact.manifest.v1+json`: [Artifact manifest](artifact.md)
 
 ## Media Type Conflicts
 


### PR DESCRIPTION
Microsoft has announced their intention to change their image redistribution policy so that Windows images no longer make use of non-distributable layers: https://techcommunity.microsoft.com/t5/containers/announcing-windows-container-base-image-redistribution-rights/ba-p/3645201

@justincormack says:
> Foreign layers in OCI images can now be deprecated
- https://twitter.com/justincormack/status/1580536342114492417

This PR updates the spec to note that clients SHOULD NOT create new images with non-distributable layers. They may still need to handle them for old images created pre-this-deprecation however.

Please feel free to suggest better wording. 🚲🏠  