### PR TITLE
layer: clarify attributes for implied directories

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -61,6 +61,20 @@ Where supported, MUST include file attributes for Additions and Modifications in
 
 [Sparse files](https://en.wikipedia.org/wiki/Sparse_file) SHOULD NOT be used because they lack consistent support across tar implementations.
 
+#### Implied Directories
+
+As the tar format describes directory hierarchies using a flat datastructure, it is possible to have so-called "implied directories" where not all parent directories implied by an entries' path in the archive have their own entry.
+
+When applying a layer, implementations MUST create any parent directories implied by an entries' path, even if it is otherwise absent from the archive. Attributes of the created parent directories MUST be set as follows:
+
+* `mtime` is set to the Unix epoch (`0`)
+* `uid` is set to the `0`
+* `gid` is set to the `0`
+* `mode` is set to `0755`
+* `xattrs` are empty
+
+Layer authors SHOULD ensure directory entries are fully present for all directory hierarchies in their layers, as previous versions of this specification did not specify this behavior and results may be implementation defined.
+
 #### Hardlinks
 
 * Hardlinks are a [POSIX concept](https://pubs.opengroup.org/onlinepubs/9699919799/functions/link.html) for having one or more directory entries for the same file on the same device.


### PR DESCRIPTION
The image specification currently does not describe how conformant implementations should handle the case of a layer that contains "implied directories" -- entries that imply parent directories exist through their path, without those parent directories having their own entires in the archive.

As such, this behavior is currently implementation-defined and may not be consistent, even in the same implementation (e.g. moby/moby#44106).

To resolve this, we explicitly define what behavior is expected in this situation, selecting 'neutral' attributes (e.g. using the container `USER`'s UID/GID, and using `0755` for mode, as derived from the default `umask(2)` of 0022).

It has been observed that it may be desirable to allow (`MAY`) conformant implementations to instead elect to not handle this case, and to fail with a useful error message instead. I lack the insight into the wider ecosystem to consider if this is a useful behavior, but it provides another aspect to consider when discussing this change.

Fixes #737 
