### PR TITLE
Chore: fix go.mod - split direct/indirect dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,16 @@ module github.com/opencontainers/image-spec
 go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday v1.6.0
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
 	github.com/xeipuuv/gojsonschema v1.2.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-require github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+)


### PR DESCRIPTION
## What is this PR?

Fix go.mod - split direct/indirect dependencies

## Why do it ?

Clarify direct dependencies.

Signed-off-by: junya koyama <arukiidou@yahoo.co.jp>