### PR TITLE
specs-go/v1/*.go: align the deprecation style

### DIFF
--- a/schema/validator.go
+++ b/schema/validator.go
@@ -117,9 +117,9 @@ func validateManifest(r io.Reader) error {
 		if layer.MediaType != string(v1.MediaTypeImageLayer) &&
 			layer.MediaType != string(v1.MediaTypeImageLayerGzip) &&
 			layer.MediaType != string(v1.MediaTypeImageLayerZstd) &&
-			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) &&
-			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableGzip) &&
-			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableZstd) {
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributable) && //nolint:staticcheck
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableGzip) && //nolint:staticcheck
+			layer.MediaType != string(v1.MediaTypeImageLayerNonDistributableZstd) { //nolint:staticcheck
 			fmt.Printf("warning: layer %s has an unknown media type: %s\n", layer.Digest, layer.MediaType)
 		}
 	}

--- a/specs-go/v1/config.go
+++ b/specs-go/v1/config.go
@@ -49,13 +49,15 @@ type ImageConfig struct {
 	// StopSignal contains the system call signal that will be sent to the container to exit.
 	StopSignal string `json:"StopSignal,omitempty"`
 
-	// ArgsEscaped `[Deprecated]` - This field is present only for legacy
-	// compatibility with Docker and should not be used by new image builders.
-	// It is used by Docker for Windows images to indicate that the `Entrypoint`
-	// or `Cmd` or both, contains only a single element array, that is a
-	// pre-escaped, and combined into a single string `CommandLine`. If `true`
-	// the value in `Entrypoint` or `Cmd` should be used as-is to avoid double
-	// escaping.
+	// ArgsEscaped
+	//
+	// Deprecated: This field is present only for legacy compatibility with
+	// Docker and should not be used by new image builders.  It is used by Docker
+	// for Windows images to indicate that the `Entrypoint` or `Cmd` or both,
+	// contains only a single element array, that is a pre-escaped, and combined
+	// into a single string `CommandLine`. If `true` the value in `Entrypoint` or
+	// `Cmd` should be used as-is to avoid double escaping.
+	// https://github.com/opencontainers/image-spec/pull/892
 	ArgsEscaped bool `json:"ArgsEscaped,omitempty"`
 }
 

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -40,16 +40,31 @@ const (
 
 	// MediaTypeImageLayerNonDistributable is the media type for layers referenced by
 	// the manifest but with distribution restrictions.
+	//
+	// Deprecated: Non-distributable layers are deprecated, and not recommended
+	// for future use. Implementations SHOULD NOT produce new non-distributable
+	// layers.
+	// https://github.com/opencontainers/image-spec/pull/965
 	MediaTypeImageLayerNonDistributable = "application/vnd.oci.image.layer.nondistributable.v1.tar"
 
 	// MediaTypeImageLayerNonDistributableGzip is the media type for
 	// gzipped layers referenced by the manifest but with distribution
 	// restrictions.
+	//
+	// Deprecated: Non-distributable layers are deprecated, and not recommended
+	// for future use. Implementations SHOULD NOT produce new non-distributable
+	// layers.
+	// https://github.com/opencontainers/image-spec/pull/965
 	MediaTypeImageLayerNonDistributableGzip = "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
 
 	// MediaTypeImageLayerNonDistributableZstd is the media type for zstd
 	// compressed layers referenced by the manifest but with distribution
 	// restrictions.
+	//
+	// Deprecated: Non-distributable layers are deprecated, and not recommended
+	// for future use. Implementations SHOULD NOT produce new non-distributable
+	// layers.
+	// https://github.com/opencontainers/image-spec/pull/965
 	MediaTypeImageLayerNonDistributableZstd = "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
 
 	// MediaTypeImageConfig specifies the media type for the image configuration.


### PR DESCRIPTION
Use the golang styling for deprecation notices. This way importing from this source as a library may give notice.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

this is a continuation/cleanup of #892 and #965