### PR TITLE
Remove filtersApplied from image-spec

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -52,7 +52,6 @@ This specification defines the following annotation keys, intended for but not l
   * This SHOULD be the immediate image sharing zero-indexed layers with the image, such as from a Dockerfile `FROM` statement.
   * This SHOULD NOT reference any other images used to generate the contents of the image (e.g., multi-stage Dockerfile builds).
   * If the `image.base.name` annotation is specified, the `image.base.digest` annotation SHOULD be the digest of the manifest referenced by the `image.ref.name` annotation.
-* **org.opencontainers.referrers.filtersApplied** Comma separated list of filters applied by the registry in the [referrers listing](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) (string)
 
 ## Back-compatibility with Label Schema
 

--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -65,7 +65,4 @@ const (
 
 	// AnnotationArtifactDescription is the annotation key for the human readable description for the artifact.
 	AnnotationArtifactDescription = "org.opencontainers.artifact.description"
-
-	// AnnotationReferrersFiltersApplied is the annotation key for the comma separated list of filters applied by the registry in the referrers listing.
-	AnnotationReferrersFiltersApplied = "org.opencontainers.referrers.filtersApplied"
 )


### PR DESCRIPTION
See https://github.com/opencontainers/distribution-spec/pull/380 which proposes changing how the registry communicates that it applied filters to be "out-of-band" of the image manifest response, so this doesn't need to be documented in image-spec at all.

Signed-off-by: Jason Hall <jason@chainguard.dev>