### PR TITLE
Add Go 1.20 support

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.18', '1.19', '1.20']
 
     name: Documentation and Linting
     steps:

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ install.tools: $(TOOLS:%=.install.%)
 
 .install.lint:
 	case "$$(go env GOVERSION)" in \
-	go1.17.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3;; \
 	go1.18.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3;; \
 	*) go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;; \
 	esac

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opencontainers/image-spec
 
-go 1.17
+go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
Added Go 1.20 to GitHub actions matrix and dropped Go 1.17

Signed-off-by: Austin Vazquez <macedonv@amazon.com>