### PR TITLE
Update image spec and conversion to clarify groups

### DIFF
--- a/config.md
+++ b/config.md
@@ -138,7 +138,8 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
     The username or UID which is a platform-specific structure that allows specific control over which user the process run as.
     This acts as a default value to use when the value is not specified when creating a container.
     For Linux based systems, all of the following are valid: `user`, `uid`, `user:group`, `uid:gid`, `uid:group`, `user:gid`.
-    If `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` from the container are applied.
+    If `group`/`gid` is not specified, the default group and supplementary groups of the given `user`/`uid` in `/etc/passwd` and `/etc/group` from the container are applied.
+    If `group`/`gid` is specified, supplementary groups from the container are ignored.
 
   - **ExposedPorts** *object*, OPTIONAL
 

--- a/conversion.md
+++ b/conversion.md
@@ -83,7 +83,7 @@ For Unix-like systems, this MAY involve resolution through NSS or parsing `/etc/
 
 In addition, a converter SHOULD set the value of `process.user.additionalGids` to a value corresponding to the user in the container's context described by `Config.User`.
 For Unix-like systems, this MAY involve resolution through NSS or parsing `/etc/group` and determining the group memberships of the user specified in `process.user.uid`.
-If the value of [`user`](config.md#properties) in `Config.User` is numeric, the converter SHOULD NOT modify `process.user.additionalGids`.
+The converter SHOULD NOT modify `process.user.additionalGids` if the value of [`user`](config.md#properties) in `Config.User` is numeric or if `Config.User` specifies a group.
 
 If `Config.User` is not defined, the converted `process.user` value is implementation-defined.
 If `Config.User` does not correspond to a user in the container's context, the converter MUST return an error.


### PR DESCRIPTION
This clarifies the behavior of supplemental groups when a primary group is specified.

The config part is implied by the text, and the conversion part seems to miss this corner case.