### PR TITLE
descriptor: clarify `artifactType` field must have compliant values

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -57,6 +57,7 @@ The following fields contain the primary properties that constitute a Descriptor
   This OPTIONAL property contains the type of an artifact when the descriptor points to an artifact.
   This is the value of `artifactType` when the descriptor references an [artifact manifest](artifact.md).
   This is the value of the config descriptor `mediaType` when the descriptor references an [image manifest](manifest.md).
+  If defined, the value MUST comply with [RFC 6838][rfc6838], including the [naming requirements in its section 4.2][rfc6838-s4.2], and MAY be registered with [IANA][iana].
 
 Descriptors pointing to [`application/vnd.oci.image.manifest.v1+json`](manifest.md) SHOULD include the extended field `platform`, see [Image Index Property Descriptions](image-index.md#image-index-property-descriptions) for details.
 


### PR DESCRIPTION
In likeness to #1010

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>