### PR TITLE
Better describe an Image Manifest as an artifact

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -21,6 +21,8 @@ The following fields contain the primary properties that constitute a Descriptor
   This REQUIRED property contains the media type of the referenced content.
   Values MUST comply with [RFC 6838][rfc6838], including the [naming requirements in its section 4.2][rfc6838-s4.2].
 
+  For the config descriptor of an [image manifest](manifest.md) with a subject field, this is the `artifactType` of that manifest.
+
   The OCI image specification defines [several of its own MIME types](media-types.md) for resources defined in the specification.
 
 - **`digest`** *string*

--- a/manifest.md
+++ b/manifest.md
@@ -117,21 +117,21 @@ Unlike the [image index](image-index.md), which contains information about a set
 }
 ```
 
-*Example showing an artifact referenced by an image manifest:*
+*Example showing an artifact blob referenced by an image manifest:*
 ```json,title=Manifest&mediatype=application/vnd.oci.image.manifest.v1%2Bjson
 {
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.manifest.v1+json",
   "config": {
     "mediaType": "image/gif",
-    "size": 3540101,
-    "digest": "sha256:725c49c527a83669901d00392768df9f653b1964a056c54232bc4c93003ddb48"
-  },
+    "size": 2,
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
   "layers": [
     {
-      "mediaType": "application/octet-stream",
-      "size": 0,
-      "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "mediaType": "image/gif",
+      "size": 3540101,
+      "digest": "sha256:725c49c527a83669901d00392768df9f653b1964a056c54232bc4c93003ddb48"
     }
   ],
   "subject": {

--- a/manifest.md
+++ b/manifest.md
@@ -110,6 +110,30 @@ Unlike the [image index](image-index.md), which contains information about a set
       "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736"
     }
   ],
+  "annotations": {
+    "com.example.key1": "value1",
+    "com.example.key2": "value2"
+  }
+}
+```
+
+*Example showing an artifact referenced by an image manifest:*
+```json,title=Manifest&mediatype=application/vnd.oci.image.manifest.v1%2Bjson
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "image/gif",
+    "size": 3540101,
+    "digest": "sha256:725c49c527a83669901d00392768df9f653b1964a056c54232bc4c93003ddb48"
+  },
+  "layers": [
+    {
+      "mediaType": "application/octet-stream",
+      "size": 0,
+      "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  ],
   "subject": {
     "mediaType": "application/vnd.oci.image.manifest.v1+json",
     "size": 7682,


### PR DESCRIPTION
I think that the only way to know what an artifact stored as an Image Manifest should look like is to read [this](https://github.com/opencontainers/distribution-spec/blame/acfc11dad63159052f98dd9afab04adf59e6ed8f/spec.md#L532) line near the bottom of the "listing referrers" section of the distribution spec. I think it should be possible to understand an artifact from the image spec.