### PR TITLE
manifest: clarify that `layers` is technically OPTIONAL

### DIFF
--- a/manifest.md
+++ b/manifest.md
@@ -44,6 +44,8 @@ Unlike the [image index](image-index.md), which contains information about a set
 
 - **`layers`** *array of objects*
 
+    This OPTIONAL property specifies an array of [descriptor](descriptor.md).
+    
     Each item in the array MUST be a [descriptor](descriptor.md).
     The array MUST have the base layer at index 0.
     Subsequent layers MUST then follow in stack order (i.e. from `layers[0]` to `layers[len(layers)-1]`).

--- a/schema/image-manifest-schema.json
+++ b/schema/image-manifest-schema.json
@@ -20,7 +20,7 @@
     },
     "layers": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "$ref": "content-descriptor.json"
       }
@@ -32,7 +32,6 @@
   },
   "required": [
     "schemaVersion",
-    "config",
-    "layers"
+    "config"
   ]
 }

--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -166,7 +166,7 @@ func TestManifest(t *testing.T) {
 			fail: false,
 		},
 
-		// expected failure: empty layer, expected at least one
+		// expected success: layers may be empty
 		{
 			manifest: `
 {
@@ -180,7 +180,23 @@ func TestManifest(t *testing.T) {
   "layers": []
 }
 `,
-			fail: true,
+			fail: false,
+		},
+
+		// expected success: layers is OPTIONAL
+		{
+			manifest: `
+{
+  "schemaVersion": 2,
+  "mediaType" : "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "size": 1470,
+    "digest": "sha256:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
+  }
+}
+`,
+			fail: false,
 		},
 
 		// expected pass: test bounds of algorithm field in digest.

--- a/specs-go/v1/manifest.go
+++ b/specs-go/v1/manifest.go
@@ -28,7 +28,7 @@ type Manifest struct {
 	Config Descriptor `json:"config"`
 
 	// Layers is an indexed list of layers referenced by the manifest.
-	Layers []Descriptor `json:"layers"`
+	Layers []Descriptor `json:"layers,omitempty"`
 
 	// Subject is an optional link from the image manifest to another manifest forming an association between the image manifest and the other manifest.
 	Subject *Descriptor `json:"subject,omitempty"`


### PR DESCRIPTION
Surprisingly, this field was not clearly marked as REQUIRED or OPTIONAL, and is generally allowed as an OPTIONAL field.

Per the conversation in slack with @tianon and @thaJeztah: https://explore.ggcr.dev/?image=tianon/scratch:nolayers

```
Docker-Content-Digest: sha256:aad957e043852ec4cd630cabb56da94c024a0bb3a72bd4d530a13b8f6b752ca7
Content-Length: 271
Content-Type: application/vnd.oci.image.manifest.v1+json

$ crane manifest tianon/scratch:nolayers | jq .
{
	"schemaVersion": 2,
	"mediaType": "application/vnd.oci.image.manifest.v1+json",
	"config": {
		"mediaType": "application/vnd.oci.image.config.v1+json",
		"size": 290,
		"digest": "sha256:132144ab4e026a9b1ca95b5dfeb9892d12f0c2c1368ae0b4bdca408e62768396"
	}
}
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>