### PR TITLE
Clarify ignore language, ensure future compat

### DIFF
--- a/config.md
+++ b/config.md
@@ -247,7 +247,7 @@ Note: Any OPTIONAL field MAY also be set to null, which is equivalent to being a
        This field is used to mark if the history item created a filesystem diff.
        It is set to true if this history item doesn't correspond to an actual layer in the rootfs section (for example, Dockerfile's [ENV](https://docs.docker.com/engine/reference/builder/#/env) command results in no change to the filesystem).
 
-Any extra fields in the Image JSON struct are considered implementation specific and MUST be ignored by any implementations which are unable to interpret them.
+Any extra fields in the Image JSON struct are considered implementation specific and MUST NOT generate an error by any implementations which are unable to interpret them.
 
 Whitespace is OPTIONAL and implementations MAY have compact JSON with no whitespace.
 

--- a/considerations.md
+++ b/considerations.md
@@ -1,6 +1,8 @@
 # Extensibility
 
-Implementations that are reading/processing [manifests](manifest.md) or [image indexes](image-index.md) MUST NOT generate an error if they encounter an unknown property.
+Implementations storing or copying content MUST NOT generate error if they encounter an unknown manifest media type (e.g.: [image manifest](manifest.md)) or an unknown property in a manifest.
+
+Implementations processing content MUST NOT generate an error if they encounter an unknown property in a known media type.
 
 # Canonicalization
 

--- a/considerations.md
+++ b/considerations.md
@@ -1,7 +1,6 @@
 # Extensibility
 
 Implementations that are reading/processing [manifests](manifest.md) or [image indexes](image-index.md) MUST NOT generate an error if they encounter an unknown property.
-Instead they MUST ignore unknown properties.
 
 # Canonicalization
 

--- a/descriptor.md
+++ b/descriptor.md
@@ -18,7 +18,8 @@ The following fields contain the primary properties that constitute a Descriptor
 
 - **`mediaType`** *string*
 
-  This REQUIRED property contains the media type of the referenced content.
+  This REQUIRED property MUST either contain the media type of the referenced content, or contain one of the legacy artifact types predating OCI 1.1 described on the config property of [image manifest](manifest.md).
+
   Values MUST comply with [RFC 6838][rfc6838], including the [naming requirements in its section 4.2][rfc6838-s4.2].
 
   The OCI image specification defines [several of its own MIME types](media-types.md) for resources defined in the specification.

--- a/image-index.md
+++ b/image-index.md
@@ -43,7 +43,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
     Image indexes concerned with portability SHOULD use one of the above media types.
     Future versions of the spec MAY use a different mediatype (i.e. a new versioned format).
-    An encountered `mediaType` that is unknown to the implementation MUST be ignored.
+    An encountered `mediaType` that is unknown to the implementation MUST NOT generate an error.
 
   - **`platform`** *object*
 

--- a/image-layout.md
+++ b/image-layout.md
@@ -147,7 +147,7 @@ This index provides an established path (`/index.json`) to have an entry point f
 * No semantic restriction is given for the "org.opencontainers.image.ref.name" annotation of descriptors.
 * In general the `mediaType` of each [descriptor][descriptors] object in the `manifests` field will be either `application/vnd.oci.image.index.v1+json` or `application/vnd.oci.image.manifest.v1+json`.
 * Future versions of the spec MAY use a different mediatype (i.e. a new versioned format).
-* An encountered `mediaType` that is unknown SHOULD be safely ignored.
+* An encountered `mediaType` that is unknown MUST NOT generate an error.
 
 
 **Implementor's Note:**

--- a/manifest.md
+++ b/manifest.md
@@ -39,7 +39,18 @@ Unlike the [image index](image-index.md), which contains information about a set
         - [`application/vnd.oci.image.config.v1+json`](config.md)
 
         Manifests concerned with portability SHOULD use one of the above media types.
-        An encountered `mediaType` that is unknown to the implementation MUST NOT generate an error.
+
+        **Legacy artifact types**
+
+        Artifacts using [image manifest](manifest.md) MAY set the `mediaType` of their `config` property to one of the following:
+
+        - `application/vnd.cncf.helm.config.v1+json`, describing a Helm Chart artifact
+
+        - `application/vnd.sylabs.sif.config.v1+json`, describing a Singularity
+
+        This list may be amended as needed to describe use of image manifest prior to OCI 1.1.
+
+        Implementations SHOULD NOT attempt to parse the referenced content or the layers of unexpected media types, and SHOULD treat unknown data as opaque data (e.g.: `application/octet-stream`).
 
 - **`layers`** *array of objects*
 

--- a/manifest.md
+++ b/manifest.md
@@ -39,6 +39,7 @@ Unlike the [image index](image-index.md), which contains information about a set
         - [`application/vnd.oci.image.config.v1+json`](config.md)
 
         Manifests concerned with portability SHOULD use one of the above media types.
+        An encountered `mediaType` that is unknown to the implementation MUST NOT generate an error.
 
 - **`layers`** *array of objects*
 
@@ -61,7 +62,7 @@ Unlike the [image index](image-index.md), which contains information about a set
         - [`application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`](layer.md#gzip-media-types)
 
         Manifests concerned with portability SHOULD use one of the above media types.
-        An encountered `mediaType` that is unknown to the implementation MUST be ignored.
+        An encountered `mediaType` that is unknown to the implementation MUST NOT generate an error.
 
         Entries in this field will frequently use the `+gzip` types.
 


### PR DESCRIPTION
The usage of "ignore[d]" appears may have resulted in ambiguous parsing of the spec. 

One interpretation is that OCI 1.0 _already_ required registries to accept Artifact and future media types, and implementations - clients and registries - that fail to handle arbitrary media types for blobs, arbitrary media types for image configs.

