### PR TITLE
tag v1.1.0-rc.3

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-dev"
+	VersionDev = "-rc.3"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3"
+	VersionDev = "-rc.3-dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
## to tag

this is would mean tagging 085b884 as v1.1.0-rc.3 (now with more SemVer)

## changes
fd45b6b Add scratch descriptor and scope layer limits
63b8bd0 Remove artifact manifest
23c4647 Define image manifest artifactType and guidance
5751791 Add Tianon as maintainer
f4fc83a Fix unused variable linting error
d09d13d Update Jon Johnson's email
4136bec descriptor schema: add missing data and artifactType definitions
729a03e manifest, specs-go/: provide guidance on SCRATCH config descriptor
31de013 manifest schema: add tests for the subject field
7a9efbd manifest schema: add the missing `subject` field
f2f1956 descriptor: clarify artifactType field must have compliant values
98f35df Update image spec and conversion to clarify groups
336b02c Require IANA mediaType for image config.mediaType and layers.mediaType
1f60184 Add Go 1.20 support
f99b121 Remove filtersApplied from image-spec
b5998ba specs-go/v1/*.go: align the deprecation style
6687119 Chore: fix go.mod - split direct/indirect dependencies
867ce74 ArtifactType is optional, omit when empty
ccb86b9 mention deprecation in media-types.md
9b4e6c0 even fewer words
2cdbef2 Deprecate non-distributable layers
265874e Note an exception to the platform.os recommendation for wasi
59780aa Add ArgsEscaped field to image config
3625ee3 doc: fix example in artifact.md
94f2431 version: bump main back to -dev
0a97fe7 docs: Added artifact.md to docs and spec.md
ca2e500 Embed Platform in Image
293f064 Reverting json schema to well known value
