### PR TITLE
releases: use +dev as in-development suffix

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -64,7 +64,7 @@ Releases usually follow a few steps:
     * [ ] merge multi-commit PRs (so each line has a `(#num)` suffix)
     * [ ] drop hash and indent, `:'<,'> s/^\w*  /^I* /`
   * [ ] a commit bumping `./specs-go/version.go` to next version and empty the `VersionDev` variable
-  * [ ] a commit adding back the "-dev" to `VersionDev`
+  * [ ] a commit adding back the "+dev" to `VersionDev`
 * [ ] send email to dev@opencontainers.org
   * [ ] copy the exact commit hash for bumping the version from the pull-request (since master always stays as "-dev")
   * [ ] count the PRs since last release (that this version is tracking, in the cases of multiple branching), like `git log --pretty=oneline --no-merges --decorate $priorTag..$versionBumpCommit  | grep \(pr\/ | wc -l`


### PR DESCRIPTION
Under SemVer, the suffix "-dev" actually indicates a pre-release, meaning the way we've been using the suffix indicates that "1.0.0-dev" is *older* than "1.0.0" when we've used the suffix to indicate the opposite.

With most package managers, the "+dev" suffix correctly indicates that the version is newer (i.e. 1.0.1 > 1.0.0+dev > 1.0.0), though under SemVer "+dev" build tags must be ignored when doing version comparisons (meaning 1.0.0+dev == 1.0.0 under SemVer). However,  from a SemVer perspective the unreleased version is inarguably closer to being equal to the last release than being older than it. As a specification we also allow extensibility of various parts, meaning that if someone uses an as-yet-unreleased version it seems reasonable to me for it to be treated as the same (from a SemVer perspective) as the last released version it's based on.

The other option would be to continue to use "-dev" as a suffix but bump the rest of the version number to the next version we plan to release, but this could also cause issues (we could have a "pre-release" for a release that never happened). Using "+dev" seems more sensible.

Switching to "+dev" also matches the way runc and umoci are versioned, and allows downstreams that use as-yet-unreleased versions of our specs to have their spec versions be treated as the same as the released version by other consumers.

Signed-off-by: Aleksa Sarai <asarai@suse.de>