### PR TITLE
Remove artifact media type reference

### DIFF
--- a/media-types.md
+++ b/media-types.md
@@ -11,7 +11,6 @@ The following media types identify the formats described here and their referenc
 - `application/vnd.oci.image.layer.v1.tar+gzip`: ["Layer", as a tar archive](layer.md#gzip-media-types) compressed with [gzip][rfc1952]
 - `application/vnd.oci.image.layer.v1.tar+zstd`: ["Layer", as a tar archive](layer.md#zstd-media-types) compressed with [zstd][rfc8478]
 - `application/vnd.oci.scratch.v1+json`: [Scratch blob](manifest.md#example-of-a-scratch-config-or-layer-descriptor)
-- `application/vnd.oci.artifact.manifest.v1+json`: [Artifact manifest](artifact.md)
 
 The following media types identify a ["Layer" with distribution restrictions](layer.md#non-distributable-layers), but are **deprecated** and not recommended for future use:
 


### PR DESCRIPTION
The artifact manifest media type (and the `artifact.md`) was removed in https://github.com/opencontainers/image-spec/pull/999. This PR removes expired reference to them.