### PR TITLE
Remove special guidance around wasm

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -58,7 +58,6 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
         This REQUIRED property specifies the operating system.
         Image indexes SHOULD use, and implementations SHOULD understand, values listed in the Go Language document for [`GOOS`][go-environment2].
-        An exception to this guidance is provided for Wasm applications that rely on the WASI system interface, where the `os` SHOULD be `wasi`.
 
     - **`os.version`** *string*
 


### PR DESCRIPTION
Go is going to support a platform like `wasip1/wasm`, `wasip2/wasm`, and eventually `wasi/wasm`. We should remove the guidance that Wasm is a special case, and fallback to following Go's guidance when describing a platform.

Fixes https://github.com/opencontainers/image-spec/issues/1053

This exception was added in https://github.com/opencontainers/image-spec/pull/964 -- see there for original (outdated!) discussion.