### PR TITLE
Add `org.opencontainers.image.source.subpath`

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -23,6 +23,7 @@ This specification defines the following annotation keys, intended for but not l
 * **org.opencontainers.image.url** URL to find more information on the image (string)
 * **org.opencontainers.image.documentation** URL to get documentation on the image (string)
 * **org.opencontainers.image.source** URL to get source code for building the image (string)
+* **org.opencontainers.image.source.subpath** A tool-specific path within the `source` repository which be used to distinguish different build targets in the same source repository
 * **org.opencontainers.image.version** version of the packaged software
   * The version MAY match a label or tag in the source code repository
   * version MAY be [Semantic versioning-compatible](https://semver.org/)


### PR DESCRIPTION
Fixes #1046

Defines an additional subpath within the source repository.  In combination with the `source` attribute, this functions as a correlation ID for multiple images produces from the same source repository (e.g. the different containers produced by https://github.com/knative/serving, or any other mono-repo type arrangement which builds related artifacts from a common source tree).

`source.subpath` is explicitly tool-specific; I'd expect that most source repositories use a single tool for building images, or at the very least don't use two tools with the same `subpath` value to produce different images.  There's probably at least one awesome counter-example out there... I don't know if I want to see it.

