### PR TITLE
Apply version change from #1050

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3-dev"
+	VersionDev = "-rc.3+dev"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
#1050 updates the release instructions. This applies the change to the version.go.