### PR TITLE
Add artifactType to image index

### DIFF
--- a/image-index.md
+++ b/image-index.md
@@ -22,6 +22,11 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
   When used, this field MUST contain the media type `application/vnd.oci.image.index.v1+json`.
   This field usage differs from the [descriptor](descriptor.md#properties) use of `mediaType`.
 
+- **`artifactType`** *string*
+
+  This OPTIONAL property contains the type of an artifact when the manifest is used for an artifact.
+  If defined, the value MUST comply with [RFC 6838][rfc6838], including the [naming requirements in its section 4.2][rfc6838-s4.2], and MAY be registered with [IANA][iana].
+
 - **`manifests`** *array of objects*
 
   This REQUIRED property contains a list of [manifests](manifest.md) for specific platforms.


### PR DESCRIPTION
It would be useful for implementations which generate multiple artifacts, each with their own platform or other metadata and perhaps, associated signatures, attestations, to be able to index them all in a single image index.

As an implementer, I'm considering having a top level "package" stored as an image index, which then references all the artifacts in the package as artifacts (image manifests). The artifactType of the image index would be "application/...package", and the artifactType of the image manifests could be:

* "application/...plugin" with annotations and/or platform fields set to indicate that it is the plugin for, e.g., macOS with Apple Silicon (darwin-arm64)
* "application/...schema" with annotations indicating this is a separate artifact
* ... other artifact types as needed

Using an image index in this use case is helpful as we would want to associate SBOMs, signatures to the individual artifacts references, so that a client only needs to download and verify the artifacts it consumes selects from the index.