### PR TITLE
Add constants for "index.json" and "blobs" alongside "oci-layout" as parts of the layout specification

### DIFF
--- a/specs-go/v1/layout.go
+++ b/specs-go/v1/layout.go
@@ -15,10 +15,14 @@
 package v1
 
 const (
-	// ImageLayoutFile is the file name of oci image layout file
+	// ImageLayoutFile is the file name containing ImageLayout in an OCI Image Layout
 	ImageLayoutFile = "oci-layout"
 	// ImageLayoutVersion is the version of ImageLayout
 	ImageLayoutVersion = "1.0.0"
+	// ImageIndexFile is the file name of the entry point for references and descriptors in an OCI Image Layout
+	ImageIndexFile = "index.json"
+	// ImageBlobsDir is the directory name containing content addressable blobs in an OCI Image Layout
+	ImageBlobsDir = "blobs"
 )
 
 // ImageLayout is the structure in the "oci-layout" file, found in the root


### PR DESCRIPTION
The [layout spec](https://github.com/opencontainers/image-spec/blob/v1.0/image-layout.md#content) requires three named files/directories. The `oci-layout` file name is already exposed as a constant from this package. This PR adds exported constants for `index.json` and `blobs`.

Closes #1069