### PR TITLE
tag 1.1.0-rc4

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.4"
+	VersionDev = "-rc.4+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.3+dev"
+	VersionDev = "-rc.4"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
## tag


This would mean tagging 82e8329 as v1.1.0-rc4


## changes

988df0a  specs-go: remove artifact prefixed annotations
25fc553 Switch from scratch to empty
a68ca3e Remove artifact media type reference
a845c7a  image-index: add artifactType to specs and schema
749ea9a Add artifactType to image index
32036d8 Apply version change from #1050
f3f0906 Specify the content of the scratch blob
e13840d Add language from artifacttype field to forbid allowlists of media types
77efc6e spec: clarify descriptor, align with de facto artifact usage
29a1380 Remove special guidance around wasm
2720969 Update descriptor.go
428b1e5 releases: use +dev as in-development suffix
2f691e8 version: bump HEAD back to -dev
c6854a6 image-index: add the `subject` field

## diff
[v1.1.0-rc3..82e8329](https://github.com/opencontainers/image-spec/compare/v1.1.0-rc3...sajayantony:image-spec:82e8329)

[Mailing List Vote](https://groups.google.com/a/opencontainers.org/g/dev/c/gPgzESGb7xs)

- [ ] @cyphar 
- [ ] @jonboulle 
- [x] @jonjohnsonjr
- [x] @sajayantony 
- [x] @stevvooe 
- [x] @sudo-bmitch
- [x] @tianon
- [x] @vbatts 