### PR TITLE
Test subject field in index

### DIFF
--- a/schema/imageindex_test.go
+++ b/schema/imageindex_test.go
@@ -255,6 +255,56 @@ func TestImageIndex(t *testing.T) {
 `,
 			fail: false,
 		},
+
+		// valid image index with a subject field
+		{
+			imageIndex: `
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 7682,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ],
+  "subject" : {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "size": 1234,
+    "digest": "sha256:220a60ecd4a3c32c282622a625a54db9ba0ff55b5ba9c29c7064a2bc358b6a3e"
+  }
+}
+`,
+			fail: false,
+		},
+
+		// expected failure, invalid subject field
+		{
+			imageIndex: `
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 7682,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ],
+  "subject" : "nope"
+}
+`,
+			fail: true,
+		},
 	} {
 		r := strings.NewReader(tt.imageIndex)
 		err := schema.ValidatorMediaTypeImageIndex.Validate(r)

--- a/schema/manifest_test.go
+++ b/schema/manifest_test.go
@@ -221,11 +221,6 @@ func TestManifest(t *testing.T) {
 {
   "schemaVersion": 2,
   "mediaType" : "application/vnd.oci.image.manifest.v1+json",
-  "subject" : {
-    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-    "size": 1234,
-    "digest": "sha256:220a60ecd4a3c32c282622a625a54db9ba0ff55b5ba9c29c7064a2bc358b6a3e"
-  },
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -237,7 +232,12 @@ func TestManifest(t *testing.T) {
       "size": 1470,
       "digest": "sha256:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
     }
-  ]
+  ],
+  "subject" : {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "size": 1234,
+    "digest": "sha256:220a60ecd4a3c32c282622a625a54db9ba0ff55b5ba9c29c7064a2bc358b6a3e"
+  }
 }
 `,
 			fail: false,
@@ -249,7 +249,6 @@ func TestManifest(t *testing.T) {
 {
   "schemaVersion": 2,
   "mediaType" : "application/vnd.oci.image.manifest.v1+json",
-  "subject" : ".nope",
   "config": {
     "mediaType": "application/vnd.oci.image.config.v1+json",
     "size": 1470,
@@ -261,7 +260,8 @@ func TestManifest(t *testing.T) {
       "size": 1470,
       "digest": "sha256:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
     }
-  ]
+  ],
+  "subject" : ".nope"
 }
 `,
 			fail: true,


### PR DESCRIPTION
This adds missing tests for the subject field on the image index. It also moved the field before annotations for consistency in the image manifest tests.