### PR TITLE
Hacking markdown and Makefile cleanup

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,6 +9,7 @@ This guide contains instructions for building artifacts contained in this reposi
 This spec includes several Go packages, and a command line tool considered to be a reference implementation of the OCI image specification.
 
 Prerequisites:
+
 * Go - current release only, earlier releases are not supported
 * make
 
@@ -16,11 +17,13 @@ The following make targets are relevant for any work involving the Go packages.
 
 ### Linting
 
-The included Go source code is being examined for any linting violations not included in the standard Go compiler. Linting is done using [gometalinter](https://github.com/alecthomas/gometalinter).
+The included Go source code is being examined for any linting violations not included in the standard Go compiler.
+Linting is done using [golangci-lint][golangci-lint].
 
 Invocation:
-```
-$ make lint
+
+```shell
+make lint
 ```
 
 ### Tests
@@ -28,25 +31,10 @@ $ make lint
 This target executes all Go based tests.
 
 Invocation:
-```
-$ make test
-$ make validate-examples
-```
 
-### Virtual schema http/FileSystem
-
-The `schema` validator uses a virtual [http/FileSystem](https://golang.org/pkg/net/http/#FileSystem) to load the JSON schema files for validating OCI images and/or manifests.
-The virtual filesystem is generated using the `esc` tool and compiled into consumers of the `schema` package so the JSON schema files don't have to be distributed along with and consumer binaries.
-
-Whenever changes are being done in any of the `schema/*.json` files, one must refresh the generated virtual filesystem.
-Otherwise schema changes will not be visible inside `schema` consumers.
-
-Prerequisites:
-* [esc](https://github.com/mjibson/esc)
-
-Invocation:
-```
-$ make schema-fs
+```shell
+make test
+make validate-examples
 ```
 
 ### JSON schema formatting
@@ -54,11 +42,13 @@ $ make schema-fs
 This target auto-formats all JSON files in the `schema` directory using the `jq` tool.
 
 Prerequisites:
-* [jq](https://stedolan.github.io/jq/) >=1.5
+
+* [jq][jq] >=1.5
 
 Invocation:
-```
-$ make fmt
+
+```shell
+make fmt
 ```
 
 ### OCI image specification PDF/HTML documentation files
@@ -66,11 +56,13 @@ $ make fmt
 This target generates a PDF/HTML version of the OCI image specification.
 
 Prerequisites:
-* [Docker](https://www.docker.com/)
+
+* [Docker][docker]
 
 Invocation:
-```
-$ make docs
+
+```shell
+make docs
 ```
 
 ### License header check
@@ -78,8 +70,9 @@ $ make docs
 This target checks if the source code includes necessary headers.
 
 Invocation:
-```
-$ make check-license
+
+```shell
+make check-license
 ```
 
 ### Clean build artifacts
@@ -87,8 +80,9 @@ $ make check-license
 This target cleans all generated/compiled artifacts.
 
 Invocation:
-```
-$ make clean
+
+```shell
+make clean
 ```
 
 ### Create PNG images from dot files
@@ -96,9 +90,16 @@ $ make clean
 This target generates PNG image files from DOT source files in the `img` directory.
 
 Prerequisites:
-* [graphviz](https://www.graphviz.org/)
+
+* [graphviz][graphviz]
 
 Invocation:
+
+```shell
+make img/media-types.png
 ```
-$ make img/media-types.png
-```
+
+[docker]: https://www.docker.com/
+[golangci-lint]: https://github.com/golangci/golangci-lint
+[graphviz]: https://www.graphviz.org/
+[jq]: https://stedolan.github.io/jq/


### PR DESCRIPTION
The hacking.md doc had some stale references that needed to the cleaned. That resulted in the following changes:

- Remove/replace stale references from hacking doc.
- Add spacing for markdown.
- Add code block language for syntax highlighting.
- Remove leading "$ " from commands without output.
- Move links to end.
- Switch to automatically generated help in Makefile.