### PR TITLE
Create artifacts guidance

### DIFF
--- a/artifacts-guidance.md
+++ b/artifacts-guidance.md
@@ -1,0 +1,5 @@
+# Guidance for Artifacts Authors
+
+Content other than OCI container images MAY be packaged using the image manifest.
+When this is done, the `config.mediaType` value MUST be set to a value specific to the artifact type or the [empty value](manifest.md#guidance-for-an-empty-descriptor).
+Additional details and examples are provided in the [image manifest specification](manifest.md#guidelines-for-artifact-usage).

--- a/spec.md
+++ b/spec.md
@@ -57,6 +57,7 @@ The high-level components of the spec include:
 * [Filesystem Layer](layer.md) - a changeset that describes a container's filesystem
 * [Image Configuration](config.md) - a document determining layer ordering and configuration of the image suitable for translation into a [runtime bundle][runtime-spec]
 * [Conversion](conversion.md) - a document describing how this translation should occur
+* [Artifacts Guidance](artifacts-guidance.md) - a document describing how to use the spec for packaging content other than OCI images
 * [Descriptor](descriptor.md) - a reference that describes the type, metadata and content address of referenced content
 
 Future versions of this specification may include the following OPTIONAL features:


### PR DESCRIPTION
This adds a destination for the link in https://github.com/opencontainers/artifacts/pull/68. This will be easier to update later, e.g. moving the guidance out of manifest.md, or adding guidance for using an index when we have examples of that, without needing to modify a link in an archived project.