### PR TITLE
Quote lint-md wildcard expression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lint-go: .install.lint ## lint check of Go files using golangci-lint
 .PHONY: lint-md
 lint-md: ## Run linting for markdown
 	docker run --rm -v "$(PWD):/workdir:ro" docker.io/davidanson/markdownlint-cli2:$(MARKDOWN_LINT_VER) \
-	  **/*.md "#vendor"
+	  "**/*.md" "#vendor"
 
 .PHONY: test
 test: ## run the unit tests


### PR DESCRIPTION
This avoids a potential foot gun, where a future md file in a sub directory would match the wildcard in the shell, and not pass the expression to the linter. I ran into this when setting up the linter on the wg-auth repo.