### PR TITLE
Fix golangci-lint install on older versions of Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ install.tools: $(TOOLS:%=.install.%)
 .install.lint:
 	case "$$(go env GOVERSION)" in \
 	go1.18.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3;; \
+	go1.19.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1;; \
 	*) go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;; \
 	esac
 


### PR DESCRIPTION
This fixes a CI failure that started with the latest golangci-lint release.