### PR TITLE
Update supported Go range to 1.19 - 1.21

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.18', '1.19', '1.20']
+        go: ['1.19', '1.20', '1.21']
 
     name: Documentation and Linting
     steps:


### PR DESCRIPTION
This updates the supported Go range to 1.19 - 1.21. The previous supported range was 1.18 - 1.20.