### PR TITLE
fix markdown table formatting

### DIFF
--- a/conversion.md
+++ b/conversion.md
@@ -47,8 +47,8 @@ These fields all affect the `annotations` of the runtime configuration, and are 
 | `os`                | `annotations`   | 1,2   |
 | `architecture`      | `annotations`   | 1,3   |
 | `variant`           | `annotations`   | 1,4   |
-| `os.version`         | `annotations`   | 1,5   |
-| `os.features`        | `annotations`   | 1,6   |
+| `os.version`        | `annotations`   | 1,5   |
+| `os.features`       | `annotations`   | 1,6   |
 | `author`            | `annotations`   | 1,7   |
 | `created`           | `annotations`   | 1,8   |
 | `Config.Labels`     | `annotations`   |       |

--- a/descriptor.md
+++ b/descriptor.md
@@ -88,12 +88,12 @@ See also [Registered Algorithms](#registered-algorithms).
 
 Some example digest strings include the following:
 
-digest                                                                    | algorithm           | Registered |
---------------------------------------------------------------------------|---------------------|------------|
-`sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b` | [SHA-256](#sha-256) | Yes        |
-`sha512:401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b372742...`   | [SHA-512](#sha-512) | Yes        |
-`multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8`         | Multihash           | No         |
-`sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564`                 | SHA-256 with urlsafe base64 | No |
+| digest                                                                    | algorithm                   | Registered |
+|---------------------------------------------------------------------------|-----------------------------|------------|
+| `sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b` | [SHA-256](#sha-256)         | Yes        |
+| `sha512:401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b372742...`   | [SHA-512](#sha-512)         | Yes        |
+| `multihash+base58:QmRZxt2b1FVZPNqd8hsiykDL3TdBDeTSPX9Kv46HmX4Gx8`         | Multihash                   | No         |
+| `sha256+b64u:LCa0a2j_xo_5m0U8HTBBNBNCLXBkg7-g-YpeiGJm564`                 | SHA-256 with urlsafe base64 | No         |
 
 Please see [Registered Algorithms](#registered-algorithms) for a list of registered algorithms.
 


### PR DESCRIPTION
- add missing left-border
- align columns

looks like the linter added in a6af2b480dcfc001ba975f44de53001c873cb0ef may not handle tables; rendering still looked good, so Markdown is probably flexible enough to allow omitting the border on one side.