### PR TITLE
Makefile: remove stray trailing space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ FIGURE_FILES := \
 
 MARKDOWN_LINT_VER?=v0.8.1
 
-TOOLS := gitvalidation 
+TOOLS := gitvalidation
 
 default: check-license lint test
 


### PR DESCRIPTION
"call me Mr. Nit-Pick"


Sorry for the very minor PR, but this one was driving me nuts as my IDE kept stripping it when working on the Makefile, so let's stop this fight between my IDE and the repository, and settle this once and for all 😂 

Thank you `git`, you were a worthy contender.