### PR TITLE
ci(lint): enable gci linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   enable:
     - dupl
     - errorlint
+    - gci
     - gofmt
     - goimports
     - gomodguard
@@ -19,6 +20,13 @@ linters:
     - staticcheck
 
 linters-settings:
+  dupl:
+    threshold: 400
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/opencontainers)
   gofmt:
     simplify: true
   gomodguard:
@@ -28,5 +36,3 @@ linters-settings:
             recommendations:
               - errors
               - fmt
-  dupl:
-    threshold: 400

--- a/identity/helpers.go
+++ b/identity/helpers.go
@@ -17,7 +17,6 @@ package identity
 import (
 	_ "crypto/sha256" // side-effect to install impls, sha256
 	_ "crypto/sha512" // side-effect to install impls, sha384/sh512
-
 	"io"
 
 	digest "github.com/opencontainers/go-digest"

--- a/schema/spec_test.go
+++ b/schema/spec_test.go
@@ -26,8 +26,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/opencontainers/image-spec/schema"
 	"github.com/russross/blackfriday"
+
+	"github.com/opencontainers/image-spec/schema"
 )
 
 var (

--- a/schema/validator.go
+++ b/schema/validator.go
@@ -22,9 +22,10 @@ import (
 	"io"
 	"regexp"
 
+	"github.com/xeipuuv/gojsonschema"
+
 	digest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/xeipuuv/gojsonschema"
 )
 
 // Validator wraps a media type string identifier


### PR DESCRIPTION
Order imports and places github.com/opencontainers modules at last.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>