### PR TITLE
Test older versions of Go with toolchain=local

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Render and Lint
         env:
           GOPATH: /home/runner/work/image-spec/image-spec/go
+          # do not automatically upgrade go to a different version: https://go.dev/doc/toolchain
+          GOTOOLCHAIN: local
         run: |
           export PATH=$GOPATH/bin:$PATH
           cd go/src/github.com/opencontainers/image-spec


### PR DESCRIPTION
This prevents Go from doing an automatic upgrade, giving a better test of backwards compatibility. Related to https://github.com/opencontainers/image-spec/pull/1114#pullrequestreview-1639441396