### PR TITLE
Add clarifaction for WASM OCI artifact use case

### DIFF
--- a/artifacts-guidance.md
+++ b/artifacts-guidance.md
@@ -1,6 +1,6 @@
 # Guidance for Artifacts Authors
 
 Content other than OCI container images MAY be packaged using the image manifest.
-When this is done, the `config.mediaType` value should not be a known OCI image config [media type](media-types.md).
-Historically, due to registry limitations, some tools have created non-OCI conformant artifacts using the `application/vnd.oci.image.config.v1+json` value for `config.mediaType` and values specific to the artifact in `layer[*].mediaType`.
+When this is done, the `config.mediaType` value MAY not be a known OCI image config [media type](media-types.md).
+Historically, due to registry limitations, some tools have created non-OCI conformant artifacts using the `application/vnd.oci.image.config.v1+json` value for `config.mediaType` and values specific to the artifact in `layer[*].mediaType`.  In some cases, the `application/vnd.oci.image.config.v1+json` may still be appropriate if the artifact is to be run via a runtime.
 Implementation details and examples are provided in the [image manifest specification](manifest.md#guidelines-for-artifact-usage).

--- a/manifest.md
+++ b/manifest.md
@@ -255,6 +255,8 @@ The decision tree below and the associated examples MAY be used to design new ar
    }
    ```
 
+   In the case where the artifact may be run by a runtime the `config.mediaType` MAY be `application/vnd.oci.image.config.v1+json`.
+
 _Implementers note:_ artifacts have historically been created without an `artifactType` field, and tooling to work with artifacts should fallback to the `config.mediaType` value.
 
 [iana]:         https://www.iana.org/assignments/media-types/media-types.xhtml


### PR DESCRIPTION
I would like to propose a small change to the wording of for OCI artifacts.  This comes up from the use case from WASM where we run the wasm components in a runtime like containerd and using the `application/vnd.oci.image.config.v1+json` is required.  We are using the `artifactType` to distinguish between a standard image and wasm OCI artifact.

Some details are on how this works in containerd is in https://docs.google.com/document/d/11shgC3l6gplBjWF1VJCWvN_9do51otscAm0hBDGSSAc and a sample using https://github.com/containerd/runwasi/pull/147