### PR TITLE
Add gradle-oci to implementations.md

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -24,6 +24,7 @@ Projects or Companies currently adopting the OCI Image Specification
 - [ORAS](https://oras.land/)
   - [oras-project/oras](https://github.com/oras-project/oras/)
   - [oras-project/oras-go](https://github.com/oras-project/oras-go)
+- [gradle-oci](https://github.com/SgtSilvio/gradle-oci)
 
 ## Former Projects
 


### PR DESCRIPTION
As the author of the [Gradle OCI plugin](https://github.com/SgtSilvio/gradle-oci) I want to ask if it can be included in the list of implementations.

It is a Gradle plugin to ease using and producing (multi-arch) OCI images without requiring external tools.

The plugin allows:
- Building OCI images according to the [OCI Image Format Specification](https://github.com/opencontainers/image-spec)
- Pulling and pushing images from/to OCI registries according to the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec)

Please let me know if any additional information is required.