### PR TITLE
Release v1.1.0-rc6

### DIFF
--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.6"
+	VersionDev = "-rc.6+dev"
 )
 
 // Version is the specification version that the package types support.

--- a/specs-go/version.go
+++ b/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc.5+dev"
+	VersionDev = "-rc.6"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
# Tag

6c2b5fa as v1.1.0-rc6

# Changes

53d9855 new section for projects no longer maintained (#1148)
b391bc0 fix: SPDX licenses URL (#1146)
dd66b54 Test older versions of Go with toolchain=local (#1133)
93f6e65 Makefile: remove stray trailing space (#1126)
d881fa8 deps: remove deprecated github.com/pkg/errors (#1125)
072574d add ORAS to implementations.md (#1122)
9954739 specs-go: group MediaTypes (#1118)
344b098 fix markdown table formatting (#1117)
c7a064f Update supported Go range to 1.19 - 1.21 (#1114)
f0ef80e version: bump back to +dev (#1109)
a2a5750 Add step to update website after a release (#1107)

Diff: https://github.com/opencontainers/image-spec/compare/v1.1.0-rc5...6c2b5fa

Mailing list: https://groups.google.com/a/opencontainers.org/g/dev/c/HOxZlfhr9-o

Votes:

- [x] @jonjohnsonjr
- [ ] @jonboulle
- [x] @stevvooe
- [X] @sudo-bmitch 
- [x] @sajayantony
- [x] @tianon
- [x] @vbatts
- [ ] @cyphar
