### PR TITLE
media-types: Fix broken links

### DIFF
--- a/media-types.md
+++ b/media-types.md
@@ -42,7 +42,7 @@ This section shows where the OCI Image Specification is compatible with formats 
 
 Similar/related schema:
 
-- [application/vnd.docker.distribution.manifest.list.v2+json](https://github.com/distribution/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list)
+- [application/vnd.docker.distribution.manifest.list.v2+json](https://github.com/distribution/distribution/blob/v2.8.3/docs/spec/manifest-v2-2.md#manifest-list)
   - `.annotations`: only present in OCI
   - `.[]manifests.annotations`: only present in OCI
   - `.[]manifests.urls`: only present in OCI
@@ -51,7 +51,7 @@ Similar/related schema:
 
 Similar/related schema:
 
-- [application/vnd.docker.distribution.manifest.v2+json](https://github.com/distribution/distribution/blob/master/docs/spec/manifest-v2-2.md#image-manifest-field-descriptions)
+- [application/vnd.docker.distribution.manifest.v2+json](https://github.com/distribution/distribution/blob/v2.8.3/docs/spec/manifest-v2-2.md#image-manifest)
   - `.annotations`: only present in OCI
   - `.config.annotations`: only present in OCI
   - `.config.urls`: only present in OCI


### PR DESCRIPTION
Related to https://github.com/distribution/distribution/pull/4101, This PR move `spec/manifest-v2-2.md` to `content/spec/manifest-v2-2.md`