### PR TITLE
Update GitHub Actions packages to resolve warnings in CI

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -14,11 +14,11 @@ jobs:
     name: Documentation and Linting
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: go/src/github.com/opencontainers/image-spec
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 


### PR DESCRIPTION
### Issue:
N/A

### Description:
This change updates actions/checkout to v4, actions/setup-go to v5, and actions/upload-artifacts to v4 to resolve NodeJS 16 deprecation warnings in CI.

#### Before:
<img width="1322" alt="image" src="https://github.com/opencontainers/image-spec/assets/55906459/b773068b-cb97-44f8-a3a1-630770304b42">

### Additional References:
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
