### PR TITLE
Pin golangci-lint for Go v1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ install.tools: $(TOOLS:%=.install.%)
 	case "$$(go env GOVERSION)" in \
 	go1.18.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3;; \
 	go1.19.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1;; \
+	go1.20.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2;; \
 	*) go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;; \
 	esac
 


### PR DESCRIPTION
### Issue:
Fixes CI issue blocking #1165

### Description:
This changes pins golangci-lint to v1.55.2 for Go v1.20 to resolve CI issues where golangci-lint v1.56.1 requires Go v1.21 or higher.