### PR TITLE
Update Go versions in release scripts

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -9,7 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.19', '1.20', '1.21']
+        # current Go releases plus the version in the go.mod are tested
+        go: ['1.18', '1.21', '1.22']
+
+    env:
+      RELEASE_GO_VER: "1.22"
 
     name: Documentation and Linting
     steps:
@@ -41,7 +45,8 @@ jobs:
           make docs
 
       - name: documentation artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        if: matrix.go == env.RELEASE_GO_VER
         with:
           name: oci-docs
           path: go/src/github.com/opencontainers/image-spec/output


### PR DESCRIPTION
This is a follow up to #1166 and fixes a remaining item from #1165. It supports current Go releases and 1.18, upgrades the upload-artifact workflow, but only runs that workflow for the latest Go version.