### PR TITLE
Remove misleading "must" in `ref.name` requirements

### DIFF
--- a/annotations.md
+++ b/annotations.md
@@ -33,7 +33,7 @@ This specification defines the following annotation keys, intended for but not l
 - **org.opencontainers.image.ref.name** Name of the reference for a target (string).
   - SHOULD only be considered valid when on descriptors on `index.json` within [image layout](image-layout.md).
   - Character set of the value SHOULD conform to alphanum of `A-Za-z0-9` and separator set of `-._:@/+`
-  - The reference must match the following [grammar](considerations.md#ebnf):
+  - A valid reference matches the following [grammar](considerations.md#ebnf):
 
     ```ebnf
     ref       ::= component ("/" component)*


### PR DESCRIPTION
~~See b692deece6f3e93d43de1615fa592b86f0f27c34 (https://github.com/opencontainers/image-spec/pull/695) for where this was originally added (making clear this was the original intent).~~

~~IMO it _slightly_ conflicts with the bullet point above it being simply SHOULD, but it has been part of the spec since v1.0 (and in a disagreement between MUST and SHOULD, the stronger constraint wins and that's MUST).~~

Updated: https://github.com/opencontainers/image-spec/pull/1196#pullrequestreview-2243187911