### PR TITLE
Support the media type `application/vnd.oci.image.layer.v1.raw`

### DIFF
--- a/specs-go/v1/annotations.go
+++ b/specs-go/v1/annotations.go
@@ -59,4 +59,8 @@ const (
 
 	// AnnotationBaseImageName is the annotation key for the image reference of the image's base image.
 	AnnotationBaseImageName = "org.opencontainers.image.base.name"
+
+	// AnnotationImageLayerPath is the annotation key for the layer path.
+	// SHOULD only work for media type `application/vnd.oci.image.layer.v1.raw`
+	AnnotationImageLayerPath = "org.opencontainers.image.layer.path"
 )

--- a/specs-go/v1/mediatype.go
+++ b/specs-go/v1/mediatype.go
@@ -45,6 +45,10 @@ const (
 	// MediaTypeImageLayerZstd is the media type used for zstd compressed
 	// layers referenced by the manifest.
 	MediaTypeImageLayerZstd = "application/vnd.oci.image.layer.v1.tar+zstd"
+
+	// MediaTypeImageLayerRaw is the media type used for layers referenced by the manifest.
+	// the file path is specified by annotation `org.opencontainers.image.layer.path`.
+	MediaTypeImageLayerRaw = "application/vnd.oci.image.layer.v1.raw"
 )
 
 // Non-distributable layer media-types.


### PR DESCRIPTION
This defines a new MediaType that is the original file without any processing, and marks its path in the annotation.
This will be very helpful for the large language model, because the model is just too big (such as 100 GB), and not packaging it would be a huge optimization.

This MediaType is not just for Kubernetes.
It provides a standardized way to handle raw data efficiently for different container environments.

Faster bootstrapping:
On HDDs devices, Unpacking layers can also slow it down.
This step can be removed to speed up bootstrapping after the first image pull.
This is good for places where things need to be up and running fast.

Storage Space Savings:
This MediaType can save almost half of the storage space,
which is crucial for devices with limited storage.


I expected something like this

``` dockerfile
COPY --type=raw ./file /file
```

``` json
...
   "layers": [
      ...
      {
         "mediaType": "application/vnd.oci.image.layer.v1.raw",
         "size": 10000000000,
         "digest": "sha256:"
         "annotations": {
            "org.opencontainers.image.layer.path": "/file"
         }
      }
      ...
   ]
...
```


User Story: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4639-oci-volume-source
