### PR TITLE
Update linter and Go releases

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         # current Go releases plus the version in the go.mod are tested
-        go: ['1.18', '1.21', '1.22']
+        go: ['1.18', '1.22', '1.23']
 
     env:
-      RELEASE_GO_VER: "1.22"
+      RELEASE_GO_VER: "1.23"
 
     name: Documentation and Linting
     steps:

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ install.tools: $(TOOLS:%=.install.%)
 	go1.18.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3;; \
 	go1.19.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1;; \
 	go1.20.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2;; \
+	go1.21.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1;; \
 	*) go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;; \
 	esac
 


### PR DESCRIPTION
This fixes the broken linter. As the comment says on the matrix, I'm testing the currently supported Go releases plus the one in our go.mod: https://github.com/opencontainers/image-spec/blob/main/go.mod#L3