### PR TITLE
Add deprecation notices to nondistributable layers

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -9,12 +9,12 @@ This section defines the `application/vnd.oci.image.layer.v1.tar`, `application/
 ## `+gzip` Media Types
 
 - The media type `application/vnd.oci.image.layer.v1.tar+gzip` represents an `application/vnd.oci.image.layer.v1.tar` payload which has been compressed with [gzip][rfc1952_2].
-- The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload which has been compressed with [gzip][rfc1952_2].
+- The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload ([deprecation notice](#non-distributable-layers)) which has been compressed with [gzip][rfc1952_2].
 
 ## `+zstd` Media Types
 
 - The media type `application/vnd.oci.image.layer.v1.tar+zstd` represents an `application/vnd.oci.image.layer.v1.tar` payload which has been compressed with [zstd][rfc8478].
-- The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload which has been compressed with [zstd][rfc8478].
+- The media type `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd` represents an `application/vnd.oci.image.layer.nondistributable.v1.tar` payload ([deprecation notice](#non-distributable-layers)) which has been compressed with [zstd][rfc8478].
 
 ## Distributable Format
 
@@ -328,11 +328,12 @@ Any given image is likely to be composed of several of these Image Filesystem Ch
 
 > **NOTE**: Non-distributable layers are deprecated, and not recommended for future use.
 > Implementations SHOULD NOT produce new non-distributable layers.
+> Implementations are expected to support preexisting images with non-distributable layers.
 
 Due to legal requirements, certain layers may not be regularly distributable.
 Such "non-distributable" layers are typically downloaded directly from a distributor but never uploaded.
 
-Non-distributable layers SHOULD be tagged with an alternative mediatype of `application/vnd.oci.image.layer.nondistributable.v1.tar`.
+Non-distributable layers SHOULD be tagged with an alternative mediatype of `application/vnd.oci.image.layer.nondistributable.v1.tar`, `application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`, or `application/vnd.oci.image.layer.nondistributable.v1.tar+zstd`.
 Implementations SHOULD NOT upload layers tagged with this media type; however, such a media type SHOULD NOT affect whether an implementation downloads the layer.
 
 [Descriptors](descriptor.md) referencing non-distributable layers MAY include `urls` for downloading these layers directly; however, the presence of the `urls` field SHOULD NOT be used to determine whether or not a layer is non-distributable.

--- a/manifest.md
+++ b/manifest.md
@@ -81,8 +81,8 @@ Unlike the [image index](image-index.md), which contains information about a set
 
     - [`application/vnd.oci.image.layer.v1.tar`](layer.md)
     - [`application/vnd.oci.image.layer.v1.tar+gzip`](layer.md#gzip-media-types)
-    - [`application/vnd.oci.image.layer.nondistributable.v1.tar`](layer.md#non-distributable-layers)
-    - [`application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`](layer.md#gzip-media-types)
+    - [`application/vnd.oci.image.layer.nondistributable.v1.tar`](layer.md#non-distributable-layers) ([deprecation notice](./layer.md#non-distributable-layers))
+    - [`application/vnd.oci.image.layer.nondistributable.v1.tar+gzip`](layer.md#gzip-media-types) ([deprecation notice](./layer.md#non-distributable-layers))
 
     Manifests concerned with portability SHOULD use one of the above media types.
     Implementations storing or copying image manifests MUST NOT error on encountering a `mediaType` that is unknown to the implementation.


### PR DESCRIPTION
This highlights that nondistributable layers have been deprecated in other parts in the spec.