### PR TITLE
README: update runtime-spec links to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Additional documentation about how this group operates:
 ## Running an OCI Image
 
 The OCI Image Format partner project is the [OCI Runtime Spec project](https://github.com/opencontainers/runtime-spec).
-The Runtime Specification outlines how to run a "[filesystem bundle](https://github.com/opencontainers/runtime-spec/blob/master/bundle.md)" that is unpacked on disk.
+The Runtime Specification outlines how to run a "[filesystem bundle](https://github.com/opencontainers/runtime-spec/blob/main/bundle.md)" that is unpacked on disk.
 At a high-level an OCI implementation would download an OCI Image then unpack that image into an OCI Runtime filesystem bundle.
 At this point the OCI Runtime Bundle would be run by an OCI Runtime.
 

--- a/conversion.md
+++ b/conversion.md
@@ -19,9 +19,6 @@ Externally provided inputs are considered to be a modification of the `applicati
 For example, externally provided inputs MAY cause an environment variable to be added, removed or changed.
 However an implementation-defined default SHOULD NOT result in an environment variable being removed or changed.
 
-[oci-runtime-bundle]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/bundle.md
-[oci-runtime-config]: https://github.com/opencontainers/runtime-spec/blob/v1.0.0/config.md
-
 ## Verbatim Fields
 
 Certain image configuration fields have an identical counterpart in the runtime configuration.
@@ -128,3 +125,6 @@ If there is a conflict (same key but different value) between an implicit annota
 
 A converter MAY add annotations which have keys not specified in the image.
 A converter MUST NOT modify the values of annotations specified in the image.
+
+[oci-runtime-bundle]: https://github.com/opencontainers/runtime-spec/blob/main/bundle.md
+[oci-runtime-config]: https://github.com/opencontainers/runtime-spec/blob/main/config.md

--- a/image-layout.md
+++ b/image-layout.md
@@ -3,11 +3,11 @@
 - The OCI Image Layout is the directory structure for OCI content-addressable blobs and [location-addressable](https://en.wikipedia.org/wiki/Content-addressable_storage#Content-addressed_vs._location-addressed) references (refs).
 - This layout MAY be used in a variety of different transport mechanisms: archive formats (e.g. tar, zip), shared filesystem environments (e.g. nfs), or networked file fetching (e.g. http, ftp, rsync).
 
-Given an image layout and a ref, a tool can create an [OCI Runtime Specification bundle](https://github.com/opencontainers/runtime-spec/blob/v1.0.0/bundle.md) by:
+Given an image layout and a ref, a tool can create an [OCI Runtime Specification bundle](https://github.com/opencontainers/runtime-spec/blob/main/bundle.md) by:
 
 - Following the ref to find a [manifest](manifest.md#image-manifest), possibly via an [image index](image-index.md)
 - [Applying the filesystem layers](layer.md#applying) in the specified order
-- Converting the [image configuration](config.md) into an [OCI Runtime Specification `config.json`](https://github.com/opencontainers/runtime-spec/blob/v1.0.0/config.md)
+- Converting the [image configuration](config.md) into an [OCI Runtime Specification `config.json`](https://github.com/opencontainers/runtime-spec/blob/main/config.md)
 
 ## Content
 

--- a/spec.md
+++ b/spec.md
@@ -42,7 +42,7 @@ Typically, these manifests may provide different implementations of the image, p
 
 ![build diagram](img/build-diagram.png)
 
-Once built the OCI Image can then be discovered by name, downloaded, verified by hash, trusted through a signature, and unpacked into an [OCI Runtime Bundle](https://github.com/opencontainers/runtime-spec/blob/master/bundle.md).
+Once built the OCI Image can then be discovered by name, downloaded, verified by hash, trusted through a signature, and unpacked into an [OCI Runtime Bundle](https://github.com/opencontainers/runtime-spec/blob/main/bundle.md).
 
 ![runtime diagram](img/run-diagram.png)
 


### PR DESCRIPTION
- Updated several links in README.md, conversion.md, image-layout.md, and spec.md to point to the 'main' branch of the runtime-spec repository.
- Replaced outdated 'master' and 'v1.0.0' references with 'main' for consistency with the latest branch structure.