### PR TITLE
Ignore uname/gname where uid/gid are supported

### DIFF
--- a/layer.md
+++ b/layer.md
@@ -51,9 +51,9 @@ Where supported, MUST include file attributes for Additions and Modifications in
 
 - Modification Time (`mtime`)
 - User ID (`uid`)
-  - User Name (`uname`) *secondary to `uid`*
+  - User Name (`uname`) should be ignored on platforms that support User ID (`uid`)
 - Group ID (`gid`)
-  - Group Name (`gname`) *secondary to `gid`*
+  - Group Name (`gname`) should be ignored on platforms that support Group ID (`gid`)
 - Mode (`mode`)
 - Extended Attributes (`xattrs`)
 - Symlink reference (`linkname` + symbolic link type)


### PR DESCRIPTION
Fixes #1210.

"Secondary" wasn't defined. This clarifies that the fields should be ignored on platforms where uid/gid are supported. The behavior for Windows filesystems where uid/gid are not supported is not defined and deferred to a separate PR.