### PR TITLE
Reduce maintenance burden by letting setup-go track our Go versions

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -10,7 +10,9 @@ jobs:
     strategy:
       matrix:
         # current Go releases plus the version in the go.mod are tested
-        go: ['1.18', '1.22', '1.23']
+        go: ['go.mod', 'oldstable', 'stable']
+        # https://github.com/actions/setup-go/tree/v5#getting-go-version-from-the-gomod-file
+        # https://github.com/actions/setup-go/tree/v5#using-stableoldstable-aliases
 
     env:
       RELEASE_GO_VER: "1.23"
@@ -24,7 +26,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.go != 'go.mod' && matrix.go || null }}
+          go-version-file: ${{ matrix.go == 'go.mod' && 'go/src/github.com/opencontainers/image-spec/go.mod' || null }}
 
       - name: Render and Lint
         env:

--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           go-version: ${{ matrix.go != 'go.mod' && matrix.go || null }}
           go-version-file: ${{ matrix.go == 'go.mod' && 'go/src/github.com/opencontainers/image-spec/go.mod' || null }}
+          cache-dependency-path: go/src/github.com/opencontainers/image-spec/go.sum
 
       - name: Render and Lint
         env:


### PR DESCRIPTION
`actions/setup-go` supports "stable" and "oldstable" as automatic aliases for the latest release and the previous to latest release, which was our intent with two of these three hard-coded versions.  The third is hard-coded to match our `go.mod`, which `actions/setup-go` *also* supports reading from, so we can be completely DRY here.

See https://github.com/opencontainers/image-spec/pull/1225#discussion_r1882995860