### PR TITLE
Update 2 dependencies

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -19,8 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # current Go releases plus the version in the go.mod are tested
-        go: ['go.mod', 'oldstable', 'stable']
+        # Current Go releases plus the versions in **/go.mod are tested.
+        # See also BUILD_SPEC_MODULE_ONLY below.
+        go: ['go.mod', 'schema/go.mod', 'oldstable', 'stable']
         # https://github.com/actions/setup-go/tree/v5#getting-go-version-from-the-gomod-file
         # https://github.com/actions/setup-go/tree/v5#using-stableoldstable-aliases
 
@@ -31,17 +32,19 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go != 'go.mod' && matrix.go || null }}
-          go-version-file: ${{ matrix.go == 'go.mod' && 'go.mod' || null }}
-          # cache-dependency-path: go.sum
+          go-version: ${{ !endsWith(matrix.go, 'go.mod') && matrix.go || null }}
+          go-version-file: ${{ endsWith(matrix.go, 'go.mod') && matrix.go || null }}
+          cache-dependency-path: ./**/go.sum
 
       - name: Render and Lint
         env:
           # do not automatically upgrade go to a different version: https://go.dev/doc/toolchain
           GOTOOLCHAIN: local
+          BUILD_SPEC_MODULE_ONLY: ${{ matrix.go == 'go.mod' }}
         run: |
           export PATH="$(go env GOPATH)/bin:$PATH"
           make install.tools
+          go work init . schema
           go get -t -d ./...
           ls ../
           make

--- a/HACKING.md
+++ b/HACKING.md
@@ -13,6 +13,12 @@ Prerequisites:
 - Go - latest version is recommended, see the [go.mod](go.mod) file for the minimum requirement
 - make
 
+While developing features spanning `specs-go` and `schema`, to break the dependency cycle on an uncommitted work:
+
+```shell
+go work init . schema
+```
+
 The following make targets are relevant for any work involving the Go packages.
 
 ### Linting

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ header.html: .tool/genheader.go specs-go/version.go
 
 .PHONY: validate-examples
 validate-examples: schema/schema.go ## validate examples in the specification markdown files
-	go test -run TestValidate ./schema
+	cd schema && go test -run TestValidate .
 
 .PHONY: check-license
 check-license: ## check license headers in source files
@@ -91,6 +91,7 @@ lint: lint-go lint-md ## Run all linters
 lint-go: .install.lint ## lint check of Go files using golangci-lint
 	@echo "checking Go lint"
 	@GO111MODULE=on $(GOPATH)/bin/golangci-lint run
+	@[ "$$BUILD_SPEC_MODULE_ONLY" = true ] || { cd schema && GO111MODULE=on $(GOPATH)/bin/golangci-lint run; }
 
 .PHONY: lint-md
 lint-md: ## Run linting for markdown
@@ -99,7 +100,8 @@ lint-md: ## Run linting for markdown
 
 .PHONY: test
 test: ## run the unit tests
-	go test -race -cover $(shell go list ./... | grep -v /vendor/)
+	go test -race -cover ./...
+	[ "$$BUILD_SPEC_MODULE_ONLY" = true ] || { cd schema && go test -race -cover ./...; }
 
 img/%.png: img/%.dot ## generate PNG from dot file
 	dot -Tpng $^ > $@

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,4 @@ module github.com/opencontainers/image-spec
 // For example, updating this version to 1.19 first requires Go 1.21 to be released.
 go 1.18
 
-require (
-	github.com/opencontainers/go-digest v1.0.0
-	github.com/russross/blackfriday v1.6.0
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
-)
+require github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=

--- a/schema/defs-descriptor.json
+++ b/schema/defs-descriptor.json
@@ -1,5 +1,6 @@
 {
   "description": "Definitions particular to OpenContainer Descriptor Specification",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "definitions": {
     "mediaType": {
       "id": "https://opencontainers.org/schema/image/descriptor/mediaType",

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
-	github.com/russross/blackfriday v1.6.0
+	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 )
 

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -1,0 +1,10 @@
+module github.com/opencontainers/image-spec/schema
+
+go 1.21
+
+require (
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
+	github.com/russross/blackfriday v1.6.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+)

--- a/schema/go.mod
+++ b/schema/go.mod
@@ -6,5 +6,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/russross/blackfriday v1.6.0
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 )
+
+require golang.org/x/text v0.14.0 // indirect

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -2,8 +2,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -1,6 +1,10 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -1,0 +1,6 @@
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=


### PR DESCRIPTION
`github.com/santhosh-tekuri/jsonschema/v5` is about 2 years old, `github.com/russross/blackfriday` more than 4 years old. Keeping up will only get harder as the users stay behind.

Note a possible downside: The `v6` of the JSON schema parser imports `golang.org/x/text` to support localized error messages, and that is +17570 of a dependency.

Warning: I am not an expert in either of the packages, I was looking for the most similar new APIs. (I did manually verify that the markdown parsing produces the same code examples.)
