### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/docs-and-linting.yml
+++ b/.github/workflows/docs-and-linting.yml
@@ -1,8 +1,18 @@
 name: Render and Lint Documentation
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    branches_ignore: []
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # OCI Image Format Specification
 
-![GitHub Actions for Docs and Linting](https://img.shields.io/github/actions/workflow/status/opencontainers/image-spec/docs-and-linting.yml?branch=main&label=GHA%20docs%20and%20linting)
 ![License](https://img.shields.io/github/license/opencontainers/image-spec)
 [![Go Reference](https://pkg.go.dev/badge/github.com/opencontainers/image-spec.svg)](https://pkg.go.dev/github.com/opencontainers/image-spec)
 


### PR DESCRIPTION
- remove meaningless badge
- also lint/test pushes (not just PRs)
- allow running the job explicitly on-demand ("workflow dispatch")
- cancel in-progress runs on PR update / push to the same branch
- explicitly limit GitHub token permissions

See also https://github.com/opencontainers/image-spec/pull/1251