### PR TITLE
Fix: Add entry to schema/go.sum

### DIFF
--- a/schema/go.mod
+++ b/schema/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.1
+	github.com/opencontainers/image-spec v1.1.2-0.20250717171153-ab80ff15c2dd
 	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 )

--- a/schema/go.sum
+++ b/schema/go.sum
@@ -2,6 +2,10 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/opencontainers/image-spec v1.1.2-0.20250717171153-ab80ff15c2dd h1:xO7I8yDuhBIf5icA9SwWES/sMW8VzbK+tlc1ffV/YDo=
+github.com/opencontainers/image-spec v1.1.2-0.20250717171153-ab80ff15c2dd/go.mod h1:GRy5q9c6/vsqXmQ1I6TL1PkhA64F6eXG9fUOQ9tFvm8=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=


### PR DESCRIPTION
This is following up on https://github.com/opencontainers/image-spec/pull/1253#pullrequestreview-2988211300

This is the result of running:

```
cd schema && go get github.com/opencontainers/image-spec@main
```

Which allows commands in schema to run without a `go.work` with a fixed version of the image-spec.