### PR TITLE
Describe integer fields with JSON types and bound the descriptor size

### DIFF
--- a/descriptor.md
+++ b/descriptor.md
@@ -29,12 +29,13 @@ The following fields contain the primary properties that constitute a Descriptor
   This REQUIRED property is the _digest_ of the targeted content, conforming to the requirements outlined in [Digests](#digests).
   Retrieved content SHOULD be verified against this digest when consumed via untrusted sources.
 
-- **`size`** *int64*
+- **`size`** *integer*
 
   This REQUIRED property specifies the size, in bytes, of the raw content.
   This property exists so that a client will have an expected size for the content before processing.
   If the length of the retrieved content does not match the specified length, the content SHOULD NOT be trusted.
   The size MUST NOT be negative.
+  The size MUST NOT be greater than 9007199254740991 (2^53-1).
 
 - **`urls`** *array of strings*
 

--- a/image-index.md
+++ b/image-index.md
@@ -9,7 +9,7 @@ For the media type(s) that this document is compatible with, see the [matrix][ma
 
 ## _Image Index_ Property Descriptions
 
-- **`schemaVersion`** *int*
+- **`schemaVersion`** *integer*
 
   This REQUIRED property specifies the image manifest schema version.
   For this version of the specification, this MUST be `2` to ensure backward compatibility with older versions of Docker.

--- a/manifest.md
+++ b/manifest.md
@@ -15,7 +15,7 @@ Unlike the [image index](image-index.md), which contains information about a set
 
 ## _Image Manifest_ Property Descriptions
 
-- **`schemaVersion`** *int*
+- **`schemaVersion`** *integer*
 
   This REQUIRED property specifies the image manifest schema version.
   For this version of the specification, this MUST be `2` to ensure backward compatibility with older versions of Docker. The value of this field will not change. This field MAY be removed in a future version of the specification.

--- a/schema/defs-descriptor.json
+++ b/schema/defs-descriptor.json
@@ -10,7 +10,7 @@
     "size": {
       "type": "integer",
       "minimum": 0,
-      "maximum": 9223372036854776000
+      "maximum": 9007199254740991
     },
     "digest": {
       "description": "the cryptographic checksum digest of the object, in the pattern '<algorithm>:<encoded>'",

--- a/schema/descriptor_test.go
+++ b/schema/descriptor_test.go
@@ -393,6 +393,17 @@ func TestDescriptor(t *testing.T) {
 }`,
 			fail: true,
 		},
+
+		// expected failure: size is outside the safe integer range of a double
+		{
+			descriptor: `
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "size": 9007199254740992,
+  "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270"
+}`,
+			fail: true,
+		},
 	} {
 		r := strings.NewReader(tt.descriptor)
 		err := schema.ValidatorMediaTypeDescriptor.Validate(r)

--- a/schema/image-index-schema.json
+++ b/schema/image-index-schema.json
@@ -39,7 +39,7 @@
           },
           "size": {
             "description": "the size in bytes of the referenced object",
-            "$ref": "defs.json#/definitions/int64"
+            "$ref": "defs-descriptor.json#/definitions/size"
           },
           "digest": {
             "description": "the cryptographic checksum digest of the object, in the pattern '<algorithm>:<encoded>'",

--- a/schema/imageindex_test.go
+++ b/schema/imageindex_test.go
@@ -305,6 +305,50 @@ func TestImageIndex(t *testing.T) {
 `,
 			fail: true,
 		},
+
+		// expected failure: negative manifest size
+		{
+			imageIndex: `
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": -7682,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}
+`,
+			fail: true,
+		},
+
+		// expected failure: manifest size is outside the safe integer range of a double
+		{
+			imageIndex: `
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 9007199254740992,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}
+`,
+			fail: true,
+		},
 	} {
 		r := strings.NewReader(tt.imageIndex)
 		err := schema.ValidatorMediaTypeImageIndex.Validate(r)


### PR DESCRIPTION
#1249 made the I-JSON limitations of RFC 7493 a MUST for all JSON content in this specification, and RFC 7493 section 2.2 states that a sender cannot expect a receiver to treat an integer outside [-(2^53)+1, (2^53)-1] as an exact value. For the specification to be self-consistent the range permitted for `size` therefore has to be a subset of that interval, and today it is not: `defs-descriptor.json` allows values up to 9223372036854776000.

RFC 7493 attaches no requirement keyword to that interval; it only says that values outside it cannot be expected to be exact. Specifications built on I-JSON generally tighten it into a requirement so that values stay exact across implementations. RFC 8620 section 1.3 defines UnsignedInt as an integer where "the value MUST be in the range 0 <= value <= 2^53-1", and section 6.1 applies it to a directly comparable field: the size in octets of an immutable blob addressed by an id. RFC 9535 section 2.1 requires integers relevant to processing to be "within the range of exact integer values defined in Internet JSON (I-JSON) ..., namely within the interval [-(2^53)+1, (2^53)-1]".

This narrows the upper bound in theory, but it puts no valid existing data at risk: with the hardware available today an image cannot approach petabyte scale, and if that ever changes it will be a v2 concern.

Separately, this specification should be language neutral, and `int64` is a Go type name. The specification only needs to state that the value is an integer and give its bounds; which data type an implementation uses is the implementation's choice and outside the scope of the specification. `int` is not a JSON type either, so `schemaVersion` in manifest.md and image-index.md is changed to `integer` for consistency.

Changing the prose does not imply changing the Go types, which would be a breaking change. It only clarifies the specification document so that it is self-consistent and leaves no room for ambiguity, and it describes the current situation more closely, since oci-spec-rs defines the field as `u64`.

Related: #153, #350, https://github.com/youki-dev/oci-spec-rs/blob/42a237132bcaf7c6a753be0e1d7e309b7298fb5a/src/image/descriptor.rs#L40
