### PR TITLE
Fix lint failing under Go 1.27

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,32 +1,47 @@
-run:
-  timeout: 10m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errorlint
-    - gofmt
-    - goimports
-    - gomodguard
-    - gosimple
+    - gomodguard_v2
     - govet
     - ineffassign
     - misspell
     - nakedret
     - revive
-    - unused
     - staticcheck
-
-linters-settings:
-  gofmt:
-    simplify: true
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/pkg/errors:
-            recommendations:
-              - errors
-              - fmt
-  dupl:
-    threshold: 400
+    - unused
+  settings:
+    dupl:
+      threshold: 400
+    gomodguard_v2:
+      blocked:
+        - module: github.com/pkg/errors
+          recommendations:
+            - errors
+            - fmt
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ FIGURE_FILES := \
 	img/media-types.png
 
 MARKDOWN_LINT_VER?=v0.8.1
+GOLANGCI_LINT_VER?=v2.13.0
 
 TOOLS := gitvalidation
 
@@ -118,13 +119,7 @@ install.tools: $(TOOLS:%=.install.%)
 
 .PHONY: .install.lint
 .install.lint:
-	case "$$(go env GOVERSION)" in \
-	go1.18.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3;; \
-	go1.19.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1;; \
-	go1.20.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2;; \
-	go1.21.*)	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1;; \
-	*) go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest;; \
-	esac
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VER)
 
 .PHONY: .install.gitvalidation
 .install.gitvalidation:

--- a/schema/backwards_compatibility_test.go
+++ b/schema/backwards_compatibility_test.go
@@ -37,7 +37,7 @@ var compatMap = map[string]string{
 func convertFormats(input string) string {
 	out := input
 	for k, v := range compatMap {
-		out = strings.Replace(out, k, v, -1)
+		out = strings.ReplaceAll(out, k, v)
 	}
 	return out
 }


### PR DESCRIPTION
The golangci-lint v1 that is installed today fails under Go 1.27. This updates it to v2 and converts the configuration with `golangci-lint migrate`.

It also moves gomodguard to `gomodguard_v2` and fixes the staticcheck issue that the newer version reports.
